### PR TITLE
Restrict Armijo linesearch function step to be at most 1

### DIFF
--- a/ot/optim.py
+++ b/ot/optim.py
@@ -69,7 +69,7 @@ def line_search_armijo(f, xk, pk, gfk, old_fval,
     alpha, phi1 = scalar_search_armijo(
         phi, phi0, derphi0, c1=c1, alpha0=alpha0)
 
-    return alpha, fc[0], phi1
+    return min(1, alpha), fc[0], phi1
 
 
 def solve_linesearch(cost, G, deltaG, Mi, f_val,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Issue: [line_search_armijo returns alpha > 1](https://github.com/PythonOT/POT/issues/184)

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->


## Checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->

