### PR TITLE
Check if alpha is not None when restricting it to be at most 1

### DIFF
--- a/ot/optim.py
+++ b/ot/optim.py
@@ -69,7 +69,7 @@ def line_search_armijo(f, xk, pk, gfk, old_fval,
     alpha, phi1 = scalar_search_armijo(
         phi, phi0, derphi0, c1=c1, alpha0=alpha0)
 
-    return min(1, alpha), fc[0], phi1
+    return min(1, alpha) if alpha is not None else 1, fc[0], phi1
 
 
 def solve_linesearch(cost, G, deltaG, Mi, f_val,

--- a/ot/optim.py
+++ b/ot/optim.py
@@ -69,7 +69,10 @@ def line_search_armijo(f, xk, pk, gfk, old_fval,
     alpha, phi1 = scalar_search_armijo(
         phi, phi0, derphi0, c1=c1, alpha0=alpha0)
 
-    return min(1, alpha) if alpha is not None else 1, fc[0], phi1
+    # scalar_search_armijo can return alpha > 1
+    if alpha is not None:
+        alpha = min(1, alpha)
+    return alpha, fc[0], phi1
 
 
 def solve_linesearch(cost, G, deltaG, Mi, f_val,

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -104,3 +104,13 @@ def test_solve_1d_linesearch_quad_funct():
     np.testing.assert_allclose(ot.optim.solve_1d_linesearch_quad(1, -1, 0), 0.5)
     np.testing.assert_allclose(ot.optim.solve_1d_linesearch_quad(-1, 5, 0), 0)
     np.testing.assert_allclose(ot.optim.solve_1d_linesearch_quad(-1, 0.5, 0), 1)
+
+
+def test_line_search_armijo():
+    xk = np.array([[0.25, 0.25], [0.25, 0.25]])
+    pk = np.array([[-0.25, 0.25], [0.25, -0.25]])
+    gfk = np.array([[23.04273441, 23.0449082], [23.04273441, 23.0449082]])
+    old_fval = -123
+    # Should not throw an exception and return None for alpha
+    alpha, _, _ = ot.optim.line_search_armijo(lambda x: 1, xk, pk, gfk, old_fval)
+    assert alpha is None


### PR DESCRIPTION
## Types of changes
scipy.optimize.linesearch.scalar_search_armijo can return alpha=None ([function definition](https://github.com/scipy/scipy/blob/master/scipy/optimize/linesearch.py#L689)). In optim.py:line_search_armijo as part of a previous issue #184, we restrict the value of alpha to be at most 1 with min(1, alpha) but this throws an Exception when alpha is None. In this PR, we just check the value of `alpha` is not `None` when making the comparison with `1`.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Issue: [https://github.com/PythonOT/POT/issues/198](https://github.com/PythonOT/POT/issues/198)

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->


## Checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
