### PR TITLE
[MRG] Cleanup minimal build and add separate build for pep8

### DIFF
--- a/.github/requirements_strict.txt
+++ b/.github/requirements_strict.txt
@@ -1,4 +1,4 @@
 numpy
 scipy>=1.3
-cython>=0.29
+cython
 pytest

--- a/.github/requirements_strict.txt
+++ b/.github/requirements_strict.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.*
-scipy>=1.0.*
-cython>=0.23.*
+numpy
+scipy>=1.3
+cython>=0.29
 pytest

--- a/.github/requirements_strict.txt
+++ b/.github/requirements_strict.txt
@@ -1,7 +1,4 @@
-numpy==1.16.*
-scipy==1.0.*
-cython==0.23.*
-matplotlib
-cvxopt
-scikit-learn
+numpy>=1.16.*
+scipy>=1.0.*
+cython>=0.23.*
 pytest

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -30,13 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 pytest "pytest-cov<2.6" codecov
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 examples/ ot/ test/ --count --max-line-length=127 --statistics
+        pip install pytest "pytest-cov<2.6" codecov
     - name: Install POT
       run: |
         pip install -e .
@@ -47,6 +41,28 @@ jobs:
       run: |
         codecov
 
+  pep8:
+    runs-on: ubuntu-latest
+     strategy:
+       max-parallel: 4
+       matrix:
+         python-version: [3.8]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 examples/ ot/ test/ --count --max-line-length=127 --statistics
 
   linux-minimal-deps:
 
@@ -93,7 +109,6 @@ jobs:
          python -m pip install --upgrade pip
          pip install -r requirements.txt
          pip install pytest "pytest-cov<2.6"
-         pip install -U "sklearn"
      - name: Install POT
        run: |
          pip install -e .

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -31,7 +31,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install flake8 pytest "pytest-cov<2.6" codecov
-        pip install -U "sklearn"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -68,7 +67,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r .github/requirements_strict.txt
         pip install pytest
-        pip install -U "sklearn"
     - name: Install POT
       run: |
         pip install -e .

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -47,6 +47,7 @@ jobs:
        max-parallel: 4
        matrix:
          python-version: [3.8]
+
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -135,7 +136,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest "pytest-cov<2.6"
-        pip install -U "sklearn"
     - name: Install POT
       run: |
         pip install -e .

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -43,7 +43,7 @@ jobs:
 
   pep8:
     runs-on: ubuntu-latest
-     strategy:
+    strategy:
        max-parallel: 4
        matrix:
          python-version: [3.8]

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ var/
 *.manifest
 *.spec
 
+# env
+pythonenv3.8/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ pep8 :
 	flake8 examples/ ot/ test/
 
 test : FORCE pep8
-	$(PYTHON) -m pytest -v test/ --doctest-modules --ignore ot/gpu/  --cov=ot --cov-report html:cov_html
+	$(PYTHON) -m pytest -v test/ --doctest-modules --ignore ot/gpu/  
 	
 pytest : FORCE 
-	$(PYTHON) -m pytest -v test/ --doctest-modules --ignore ot/gpu/  --cov=ot
+	$(PYTHON) -m pytest -v test/ --doctest-modules --ignore ot/gpu/  
 
 release :
 	twine upload dist/*

--- a/ot/lp/__init__.py
+++ b/ot/lp/__init__.py
@@ -426,7 +426,7 @@ def emd2(a, b, M, processes=multiprocessing.cpu_count(),
     nb = b.shape[1]
 
     if processes > 1:
-        res = parmap(f, [b[:, i] for i in range(nb)], processes)
+        res = parmap(f, [b[:, i].copy() for i in range(nb)], processes)
     else:
         res = list(map(f, [b[:, i].copy() for i in range(nb)]))
 

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -697,6 +697,7 @@ def test_jcpot_barycenter():
 
     np.testing.assert_allclose(prop, [1 - pt, pt], rtol=1e-3, atol=1e-3)
 
+
 @pytest.mark.skipif(nosklearn, reason="No sklearn available")
 def test_emd_laplace_class():
     """test_emd_laplace_transport

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -6,10 +6,17 @@
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+import pytest
 
 import ot
 from ot.datasets import make_data_classif
 from ot.utils import unif
+
+try:  # test if cudamat installed
+    import sklearn
+    nosklearn = False
+except ImportError:
+    nosklearn = True
 
 
 def test_sinkhorn_lpl1_transport_class():
@@ -690,7 +697,7 @@ def test_jcpot_barycenter():
 
     np.testing.assert_allclose(prop, [1 - pt, pt], rtol=1e-3, atol=1e-3)
 
-
+@pytest.mark.skipif(nosklearn, reason="No sklearn available")
 def test_emd_laplace_class():
     """test_emd_laplace_transport
     """

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -13,7 +13,7 @@ from ot.datasets import make_data_classif
 from ot.utils import unif
 
 try:  # test if cudamat installed
-    import sklearn
+    import sklearn  # noqa: F401
     nosklearn = False
 except ImportError:
     nosklearn = True


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+ cleanupothe build_minimal that had numpy, scipy cython version forced and was failing
+ add a separate pep8 build so taht all teh otehr test can still run in pep8 fails


- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The build was failing in all the PR becausqe of that.

The pep8 was a pain when a new commit was necessary in order to get tye output of the tests when pep8 failure

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->


## Checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
