### PR TITLE
[MRG] Add new python versions for tests (also macos and windows)

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [ 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1
@@ -97,7 +97,32 @@ jobs:
      strategy:
        max-parallel: 4
        matrix:
-         python-version: [3.7]
+         python-version: [3.8, 3.9]
+
+     steps:
+     - uses: actions/checkout@v1
+     - name: Set up Python ${{ matrix.python-version }}
+       uses: actions/setup-python@v1
+       with:
+         python-version: ${{ matrix.python-version }}
+     - name: Install dependencies
+       run: |
+         python -m pip install --upgrade pip
+         pip install -r requirements.txt
+         pip install pytest "pytest-cov<2.6"
+     - name: Install POT
+       run: |
+         pip install -e .
+     - name: Run tests
+       run: |
+         python -m pytest -v test/ ot/ --doctest-modules --ignore ot/gpu/ --cov=ot
+
+  macos-11:
+     runs-on: macos-11
+     strategy:
+       max-parallel: 4
+       matrix:
+         python-version: [3.8, 3.9]
 
      steps:
      - uses: actions/checkout@v1
@@ -123,7 +148,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -93,32 +93,7 @@ jobs:
 
 
   macos:
-     runs-on: macOS-latest
-     strategy:
-       max-parallel: 4
-       matrix:
-         python-version: [3.8, 3.9]
-
-     steps:
-     - uses: actions/checkout@v1
-     - name: Set up Python ${{ matrix.python-version }}
-       uses: actions/setup-python@v1
-       with:
-         python-version: ${{ matrix.python-version }}
-     - name: Install dependencies
-       run: |
-         python -m pip install --upgrade pip
-         pip install -r requirements.txt
-         pip install pytest "pytest-cov<2.6"
-     - name: Install POT
-       run: |
-         pip install -e .
-     - name: Run tests
-       run: |
-         python -m pytest -v test/ ot/ --doctest-modules --ignore ot/gpu/ --cov=ot
-
-  macos-11:
-     runs-on: macos-11
+     runs-on: macos-latest
      strategy:
        max-parallel: 4
        matrix:
@@ -141,6 +116,7 @@ jobs:
      - name: Run tests
        run: |
          python -m pytest -v test/ ot/ --doctest-modules --ignore ot/gpu/ --cov=ot
+
 
 
   windows:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -3,8 +3,6 @@ name: build
 on:
   push:
 
-  pull_request:
-
   create:
     branches:
       - 'master'

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -122,7 +122,7 @@ jobs:
      strategy:
        max-parallel: 4
        matrix:
-         python-version: [3.8, 3.9]
+         python-version: [3.7, 3.8, 3.9]
 
      steps:
      - uses: actions/checkout@v1
@@ -148,7 +148,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -237,7 +237,7 @@ def fun(f, q_in, q_out):
 def parmap(f, X, nprocs=multiprocessing.cpu_count()):
     """ paralell map for multiprocessing (only map on windows)"""
 
-    if not sys.platform.endswith('win32'):
+    if not sys.platform.endswith('win32') and not sys.platform.endswith('darwin'):
 
         q_in = multiprocessing.Queue(1)
         q_out = multiprocessing.Queue()


### PR DESCRIPTION
* Add new python versions 3.9 in test (and remove 3.5 that is end of life)
* Add more versions in macosx and windows 
* Correct pickling problem for paralell implementation of emd (now deactivated on macos and windows)
