### PR TITLE
[WIP] Add Wasserstein GAN and debug memory leak

### DIFF
--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -55,7 +55,8 @@ import matplotlib.pyplot as pl
 import ot
 import torch
 
-# %% Data generation
+# %%
+# Data generation
 # ---------------
 
 torch.manual_seed(1)
@@ -72,9 +73,10 @@ def get_data(n):
     return x
 
 
-##############################################################################
+# %%
 # Plot data
 # ---------
+
 # %% plot the distributions
 x = get_data(500)
 pl.figure(1)
@@ -83,12 +85,11 @@ pl.title('Data distribution')
 pl.legend()
 
 
-##############################################################################
+# %%
 # Generator Model
 # ---------------
-# %% define the MLP model
 
-
+# define the MLP model
 class Generator(torch.nn.Module):
     def __init__(self):
         super(Generator, self).__init__()
@@ -105,10 +106,9 @@ class Generator(torch.nn.Module):
         output = self.fc3(output)
         return output
 
-##############################################################################
+# %%
 # Training the model
 # ------------------
-# %%
 
 
 G = Generator()
@@ -160,8 +160,9 @@ pl.title('Wasserstein distance')
 pl.xlabel("Iterations")
 
 
-# %% Plot trajectories of generated samples along iterations
-# ----------------------------------------------------------
+# %%
+# Plot trajectories of generated samples along iterations
+# -------------------------------------------------------
 
 
 pl.figure(3, (10, 10))
@@ -178,10 +179,10 @@ for i in range(9):
     if i == 0:
         pl.legend()
 
-##############################################################################
+# %%
 # Generate and visualize data
 # ---------------------------
-# %%
+
 size_batch = 500
 xd = get_data(size_batch)
 xn = torch.randn(size_batch, 2)

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -51,16 +51,15 @@ and Statistics (Vol. 108).
 
 from torch import nn
 import numpy as np
-import matplotlib.pylab as pl
+import matplotlib.pyplot as plt
 import ot
 import torch
 
 
 ##############################################################################
 # Data generation
-# -------------
+# ---------------
 
-#%% Data generation
 torch.manual_seed(1)
 ncirc = 6
 sig = 0.1

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -77,7 +77,7 @@ def get_data(n):
 # Plot data
 # ---------
 
-# %% plot the distributions
+# plot the distributions
 x = get_data(500)
 pl.figure(1)
 pl.scatter(x[:, 0], x[:, 1], label='Data samples from $\mu_d$', alpha=0.5)
@@ -115,19 +115,19 @@ G = Generator()
 optimizer = torch.optim.RMSprop(G.parameters(), lr=0.001)
 
 # number of iteration and size of the batches
-niter = 500
+n_iter = 500
 size_batch = 500
 
 # generate statis samples to see their trajectory along training
-nvisu = 100
-xnvisu = torch.randn(nvisu, n_features)
-xvisu = torch.zeros(niter, nvisu, n_dims)
+n_visu = 100
+xnvisu = torch.randn(n_visu, n_features)
+xvisu = torch.zeros(n_iter, n_visu, n_dims)
 
 ab = torch.ones(size_batch) / size_batch
 losses = []
 
 
-for i in range(niter):
+for i in range(n_iter):
 
     # generate noise samples
     xn = torch.randn(size_batch, n_features)

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -48,12 +48,12 @@ and Statistics (Vol. 108).
 
 # sphinx_gallery_thumbnail_number = 3
 
-
-from torch import nn
 import numpy as np
 import matplotlib.pyplot as pl
-import ot
 import torch
+from torch import nn
+import ot
+
 
 # %%
 # Data generation
@@ -65,11 +65,11 @@ n_dims = 2
 n_features = 2
 
 
-def get_data(n):
-    c = torch.rand(size=(n, 1))
+def get_data(n_samples):
+    c = torch.rand(size=(n_samples, 1))
     angle = c * 2 * np.pi
     x = torch.cat((torch.cos(angle), torch.sin(angle)), 1)
-    x += torch.randn(n, 2) * sigma
+    x += torch.randn(n_samples, 2) * sigma
     return x
 
 

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -10,19 +10,26 @@ as a distribution fitting term.
 We want to train a generator :math:`G_\theta` that generates realistic
 data from random noise drawn form a Gaussian :math:`\mu_n` distribution so
 that the data is indistinguishable from true data in the data distribution
-:math:`\mu_d`. To this end we want to optimize the parameters :math:`\theta`
-of the generator with the following optimization problem:
+:math:`\mu_d`. To this end Wasserstein GAN [Arjovsky2017] aim at optimizing
+the parameters :math:`\theta` of the generator with the following
+optimization problem:
 
 .. math::
      \min_{\theta} W(\mu_d,G_\theta#\mu_n)
 
 
 In practice we do not have access to the full distribution :math:`\mu_d` but
-samples and we cannot compute the Wasserstein disqtance for lare dataset. So
+samples and we cannot compute the Wasserstein disqtance for lare dataset.
+[Arjovsky2017] proposed to approximate the dual potential of Wassrestein 1
+with a neural network recovering an optimization problem similar to GAN.
+In this example
 we will optimize the expectation of the Wasserstein distance over minibatches
 at each iterations as proposed in [Genevay2018]. Optimizing the Minibatches
-of the Wassretsein disatnce has been studied in
+of the Wassretsein distance  has been studied in[Fatras2019].
 
+[Arjovsky2017] Arjovsky, M., Chintala, S., & Bottou, L. (2017, July).
+Wasserstein generative adversarial networks. In International conference
+on machine learning (pp. 214-223). PMLR.
 
 [Genevay2018] Genevay, Aude, Gabriel Peyré, and Marco Cuturi. "Learning generative models
 with sinkhorn divergences." International Conference on Artificial Intelligence
@@ -145,7 +152,8 @@ for i in range(niter):
     loss = ot.emd2(ab, ab, M)
     losses.append(float(loss.detach()))
 
-    #print(losses[-1])
+    if i % 10 == 0:
+        print("Iter: {:3d}, loss={}".format(i, losses[-1]))
 
     loss.backward()
     optimizer.step()

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -4,7 +4,7 @@ r"""
 Wasserstein 2 Minibatch GAN with PyTorch
 ========================================
 
-In this example we train a Wassertsein GAN using Wasserstein 2 on minibatches
+In this example we train a Wasserstein GAN using Wasserstein 2 on minibatches
 as a distribution fitting term.
 
 We want to train a generator :math:`G_\theta` that generates realistic
@@ -19,13 +19,13 @@ optimization problem:
 
 
 In practice we do not have access to the full distribution :math:`\mu_d` but
-samples and we cannot compute the Wasserstein disqtance for lare dataset.
-[Arjovsky2017] proposed to approximate the dual potential of Wassrestein 1
+samples and we cannot compute the Wasserstein distance for lare dataset.
+[Arjovsky2017] proposed to approximate the dual potential of Wasserstein 1
 with a neural network recovering an optimization problem similar to GAN.
 In this example
 we will optimize the expectation of the Wasserstein distance over minibatches
 at each iterations as proposed in [Genevay2018]. Optimizing the Minibatches
-of the Wassretsein distance  has been studied in[Fatras2019].
+of the Wasserstein distance  has been studied in[Fatras2019].
 
 [Arjovsky2017] Arjovsky, M., Chintala, S., & Bottou, L. (2017, July).
 Wasserstein generative adversarial networks. In International conference
@@ -51,36 +51,31 @@ and Statistics (Vol. 108).
 
 from torch import nn
 import numpy as np
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as pl
 import ot
 import torch
 
-
-##############################################################################
-# Data generation
+# %% Data generation
 # ---------------
 
 torch.manual_seed(1)
-ncirc = 6
-sig = 0.1
-n = 100
-d = 2
-p = 2
+sigma = 0.1
+n_dims = 2
+n_features = 2
 
 
 def get_data(n):
     c = torch.rand(size=(n, 1))
     angle = c * 2 * np.pi
     x = torch.cat((torch.cos(angle), torch.sin(angle)), 1)
-    x += torch.randn(n, 2) * sig
+    x += torch.randn(n, 2) * sigma
     return x
 
 
 ##############################################################################
 # Plot data
 # ---------
-
-#%% plot the distributions
+# %% plot the distributions
 x = get_data(500)
 pl.figure(1)
 pl.scatter(x[:, 0], x[:, 1], label='Data samples from $\mu_d$', alpha=0.5)
@@ -91,16 +86,15 @@ pl.legend()
 ##############################################################################
 # Generator Model
 # ---------------
-
-#%% define the MLP model
+# %% define the MLP model
 
 
 class Generator(torch.nn.Module):
     def __init__(self):
         super(Generator, self).__init__()
-        self.fc1 = nn.Linear(p, 200)
+        self.fc1 = nn.Linear(n_features, 200)
         self.fc2 = nn.Linear(200, 500)
-        self.fc3 = nn.Linear(500, d)
+        self.fc3 = nn.Linear(500, n_dims)
         self.relu = torch.nn.ReLU()  # instead of Heaviside step fn
 
     def forward(self, x):
@@ -114,9 +108,9 @@ class Generator(torch.nn.Module):
 ##############################################################################
 # Training the model
 # ------------------
+# %%
 
 
-#%%
 G = Generator()
 optimizer = torch.optim.RMSprop(G.parameters(), lr=0.001)
 
@@ -126,8 +120,8 @@ size_batch = 500
 
 # generate statis samples to see their trajectory along training
 nvisu = 100
-xnvisu = torch.randn(nvisu, 2)
-xvisu = torch.zeros(niter, nvisu, 2)
+xnvisu = torch.randn(nvisu, n_features)
+xvisu = torch.zeros(niter, nvisu, n_dims)
 
 ab = torch.ones(size_batch) / size_batch
 losses = []
@@ -136,7 +130,7 @@ losses = []
 for i in range(niter):
 
     # generate noise samples
-    xn = torch.randn(size_batch, 2)
+    xn = torch.randn(size_batch, n_features)
 
     # generate data samples
     xd = get_data(size_batch)
@@ -166,12 +160,9 @@ pl.title('Wasserstein distance')
 pl.xlabel("Iterations")
 
 
-##############################################################################
-# Plot trajectories of generated samples along iterations
-# -------------------------------------------------------
+# %% Plot trajectories of generated samples along iterations
+# ----------------------------------------------------------
 
-
-#%%
 
 pl.figure(3, (10, 10))
 
@@ -188,11 +179,9 @@ for i in range(9):
         pl.legend()
 
 ##############################################################################
-# Generate and vizualize data
+# Generate and visualize data
 # ---------------------------
-
-
-#%%
+# %%
 size_batch = 500
 xd = get_data(size_batch)
 xn = torch.randn(size_batch, 2)

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -15,7 +15,7 @@ the parameters :math:`\theta` of the generator with the following
 optimization problem:
 
 .. math::
-     \min_{\theta} W(\mu_d,G_\theta#\mu_n)
+     \min_{\theta} W(\mu_d,G_\theta\#\mu_n)
 
 
 In practice we do not have access to the full distribution :math:`\mu_d` but
@@ -46,7 +46,7 @@ and Statistics (Vol. 108).
 #
 # License: MIT License
 
-# sphinx_gallery_thumbnail_number = 2
+# sphinx_gallery_thumbnail_number = 3
 
 
 from torch import nn

--- a/examples/domain-adaptation/plot_otda_color_images.py
+++ b/examples/domain-adaptation/plot_otda_color_images.py
@@ -53,7 +53,7 @@ X1 = im2mat(I1)
 X2 = im2mat(I2)
 
 # training samples
-nb = 1000
+nb = 500
 idx1 = r.randint(X1.shape[0], size=(nb,))
 idx2 = r.randint(X2.shape[0], size=(nb,))
 

--- a/examples/domain-adaptation/plot_otda_mapping_colors_images.py
+++ b/examples/domain-adaptation/plot_otda_mapping_colors_images.py
@@ -56,7 +56,7 @@ X1 = im2mat(I1)
 X2 = im2mat(I2)
 
 # training samples
-nb = 1000
+nb = 500
 idx1 = r.randint(X1.shape[0], size=(nb,))
 idx2 = r.randint(X2.shape[0], size=(nb,))
 

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -403,16 +403,22 @@ class TorchBackend(Backend):
 
         # define a function that takes inputs and return val
         class ValFunction(Function):
+
             @staticmethod
-            def forward(ctx, *inputs):
+            def forward(ctx, val, grads, *inputs):
+                ctx.grads = grads
                 return val
 
             @staticmethod
             def backward(ctx, grad_output):
                 # the gradients are grad
-                return grads
+                return (None, None) + ctx.grads
 
-        return ValFunction.apply(*inputs)
+        Func = ValFunction()
+
+        res = Func.apply(val, grads, *inputs)
+
+        return res
 
     def zeros(self, shape, type_as=None):
         if type_as is None:


### PR DESCRIPTION
This PR introduce the following changes

- [x] New example for Wasserstein GAN
- [x] Correct memory leak in ot.emd2 for torch backend
- [x] Speedup color Domain Adaptation examples for a quicker compilation of the doc

 The memory leak was due to the creation of a new class for each call to ot.emd2 that used torch tensors in their scope which meant that tose tensors could not be de-allocated by the garbage collector. It has been solved by using a torch function that takes both inputs output value and gradients as input bu provides gardients only for the inputs (see set_gradients(self, val, inputs, grads) function on torch backend)


