### PR TITLE
Fix pip installation to work without pre-installed numpy/cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,6 @@ The library has been tested on Linux, MacOSX and Windows. It requires a C++ comp
 
 #### Pip installation
 
-Note that due to a limitation of pip, `cython` and `numpy` need to be installed
-prior to installing POT. This can be done easily with
-
-```console
-pip install numpy cython
-```
-
 You can install the toolbox through PyPI with:
 
 ```console

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 
+from distutils.sysconfig import get_python_inc
 from setuptools import find_packages, setup, Extension
 
 # dirty but working
@@ -48,6 +49,9 @@ setup(
             sources=["ot/lp/emd_wrap.pyx",
                      "ot/lp/EMD_wrapper.cpp"],  # cython/c++ src files
             language="c++",
+            include_dirs=[
+                os.path.join(get_python_inc(plat_specific=1), "numpy")
+            ],
             extra_compile_args=compile_args,
         )
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,7 @@ import re
 import subprocess
 import sys
 
-from setuptools import find_packages, setup
-from setuptools.extension import Extension
-
-import numpy
-from Cython.Build import cythonize
-
+from setuptools import find_packages, setup, Extension
 
 # dirty but working
 __version__ = re.search(
@@ -34,7 +29,8 @@ compile_args = ["-O3"]
 if sys.platform.startswith('darwin'):
     compile_args.append("-stdlib=libc++")
     sdk_path = subprocess.check_output(['xcrun', '--show-sdk-path'])
-    os.environ['CFLAGS'] = '-isysroot "{}"'.format(sdk_path.rstrip().decode("utf-8"))
+    os.environ['CFLAGS'] = '-isysroot "{}"'.format(
+        sdk_path.rstrip().decode("utf-8"))
 
 setup(
     name='POT',
@@ -46,15 +42,18 @@ setup(
     author_email='remi.flamary@gmail.com, ncourty@gmail.com',
     url='https://github.com/PythonOT/POT',
     packages=find_packages(),
-    ext_modules=cythonize(Extension(
-        name="ot.lp.emd_wrap",
-        sources=["ot/lp/emd_wrap.pyx", "ot/lp/EMD_wrapper.cpp"],  # cython/c++ src files
-        language="c++",
-        include_dirs=[numpy.get_include(), os.path.join(ROOT, 'ot/lp')],
-        extra_compile_args=compile_args,
-    )),
+    ext_modules=[
+        Extension(
+            name="ot.lp.emd_wrap",
+            sources=["ot/lp/emd_wrap.pyx",
+                     "ot/lp/EMD_wrapper.cpp"],  # cython/c++ src files
+            language="c++",
+            extra_compile_args=compile_args,
+        )
+    ],
     platforms=['linux', 'macosx', 'windows'],
-    download_url='https://github.com/PythonOT/POT/archive/{}.tar.gz'.format(__version__),
+    download_url='https://github.com/PythonOT/POT/archive/{}.tar.gz'.format(
+        __version__),
     license='MIT',
     scripts=[],
     data_files=[],
@@ -85,5 +84,4 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-    ]
-)
+    ])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import sys
 
-from distutils.sysconfig import get_python_inc
+from distutils.sysconfig import get_python_lib
 from setuptools import find_packages, setup, Extension
 
 # dirty but working
@@ -33,6 +33,9 @@ if sys.platform.startswith('darwin'):
     os.environ['CFLAGS'] = '-isysroot "{}"'.format(
         sdk_path.rstrip().decode("utf-8"))
 
+numpy_include_dir = os.path.join(get_python_lib(plat_specific=True), "numpy",
+                                 "core", "include")
+
 setup(
     name='POT',
     version=__version__,
@@ -49,9 +52,7 @@ setup(
             sources=["ot/lp/emd_wrap.pyx",
                      "ot/lp/EMD_wrapper.cpp"],  # cython/c++ src files
             language="c++",
-            include_dirs=[
-                os.path.join(get_python_inc(plat_specific=1), "numpy")
-            ],
+            include_dirs=[numpy_include_dir],
             extra_compile_args=compile_args,
         )
     ],


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

This will fix the installation process through `pip`. No need for pre-installed `numpy` and `cython`, as mentioned here: https://pypi.org/project/POT/

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

Installation (and compillation) from the github repository through `pip` finished successfully.

## Checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
