### PR TITLE
[MRG] Tensorflow backend & Benchmarker & Myst_parser

### DIFF
--- a/.github/requirements_test_windows.txt
+++ b/.github/requirements_test_windows.txt
@@ -7,7 +7,4 @@ pymanopt==0.2.4; python_version <'3'
 pymanopt==0.2.6rc1; python_version >= '3'
 cvxopt
 scikit-learn
-jax
-jaxlib
-tensorflow
 pytest

--- a/.github/requirements_test_windows.txt
+++ b/.github/requirements_test_windows.txt
@@ -4,7 +4,7 @@ cython
 matplotlib
 autograd
 pymanopt==0.2.4; python_version <'3'
-pymanopt; python_version >= '3'
+pymanopt==0.2.6rc1; python_version >= '3'
 cvxopt
 scikit-learn
 pytest

--- a/.github/requirements_test_windows.txt
+++ b/.github/requirements_test_windows.txt
@@ -7,4 +7,7 @@ pymanopt==0.2.4; python_version <'3'
 pymanopt==0.2.6rc1; python_version >= '3'
 cvxopt
 scikit-learn
+jax
+jaxlib
+tensorflow
 pytest

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ POT provides the following generic OT solvers (links to examples):
 * [Partial Wasserstein and Gromov-Wasserstein](https://pythonot.github.io/auto_examples/unbalanced-partial/plot_partial_wass_and_gromov.html) (exact [29] and entropic [3]
   formulations).
 * [Sliced Wasserstein](https://pythonot.github.io/auto_examples/sliced-wasserstein/plot_variance.html) [31, 32] and Max-sliced Wasserstein [35] that can be used for gradient flows [36].
-* [Several backends](https://pythonot.github.io/quickstart.html#solving-ot-with-multiple-backends) for easy use of POT with  [Pytorch](https://pytorch.org/)/[jax](https://github.com/google/jax)/[Numpy](https://numpy.org/) arrays.
+* [Several backends](https://pythonot.github.io/quickstart.html#solving-ot-with-multiple-backends) for easy use of POT with  [Pytorch](https://pytorch.org/)/[jax](https://github.com/google/jax)/[Numpy](https://numpy.org/)/[Cupy](https://cupy.dev/)/[Tensorflow](https://www.tensorflow.org/) arrays.
 
 POT provides the following Machine Learning related solvers:
 

--- a/README.md
+++ b/README.md
@@ -202,12 +202,12 @@ This toolbox benefit a lot from open source research and we would like to thank 
 
 * [Gabriel Peyré](http://gpeyre.github.io/) (Wasserstein Barycenters in Matlab)
 * [Mathieu Blondel](https://mblondel.org/) (original implementation smooth OT)
-* [Nicolas Bonneel](http://liris.cnrs.fr/~nbonneel/) ( C++ code for EMD)
+* [Nicolas Bonneel](http://liris.cnrs.fr/~nbonneel/) (C++ code for EMD)
 * [Marco Cuturi](http://marcocuturi.net/) (Sinkhorn Knopp in Matlab/Cuda)
 
 ## Contributions and code of conduct
 
-Every contribution is welcome and should respect the [contribution guidelines](https://pythonot.github.io/contributing.html). Each member of the project is expected to follow the [code of conduct](https://pythonot.github.io/code_of_conduct.html).
+Every contribution is welcome and should respect the [contribution guidelines](.github/CONTRIBUTING.md). Each member of the project is expected to follow the [code of conduct](.github/CODE_OF_CONDUCT.md).
 
 ## Support
 
@@ -217,7 +217,7 @@ You can ask questions and join the development discussion:
 * On the POT [gitter channel](https://gitter.im/PythonOT/community)
 * On the POT [mailing list](https://mail.python.org/mm3/mailman3/lists/pot.python.org/)
 
-You can also post bug reports and feature requests in Github issues. Make sure to read our [guidelines](https://pythonot.github.io/contributing.html) first.
+You can also post bug reports and feature requests in Github issues. Make sure to read our [guidelines](.github/CONTRIBUTING.md) first.
 
 ## References
 

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,4 +1,5 @@
 from . import benchmark
 from . import sinkhorn_knopp
+from . import emd
 
-__all__= ["benchmark", "sinkhorn_knopp"]
+__all__= ["benchmark", "sinkhorn_knopp", "emd"]

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,4 @@
+from . import benchmark
+from . import sinkhorn_knopp
+
+__all__= ["benchmark", "sinkhorn_knopp"]

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -84,8 +84,8 @@ def convert_to_html_table(results, param_name, main_title=None, comments=None):
 
         # make device header
         string += f'<tr><th align="center">Device</th>'
-        string += f'<th align="center" colspan="{cpus_cols}"">CPU</th>'
-        string += f'<th align="center" colspan="{gpus_cols}">GPU</tr>\n'
+        string += f'<th align="center" colspan="{cpus_cols}">CPU</th>'
+        string += f'<th align="center" colspan="{gpus_cols}">GPU</th></tr>\n'
 
         # make param_name / backend header
         string += f'<tr><th align="center">{param_name}</th>'

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -37,7 +37,7 @@ def get_keys(d):
     return sorted(list(d.keys()))
 
 
-def convert_to_html_table(results, param_name, comments=None):
+def convert_to_html_table(results, param_name, main_title=None, comments=None):
     string = "<table>\n"
     keys = get_keys(results)
     subkeys = get_keys(results[keys[0]])
@@ -50,7 +50,13 @@ def convert_to_html_table(results, param_name, comments=None):
     gpus_cols = list(devices).count("GPU") / n_bitsizes
     assert cpus_cols + gpus_cols == len(devices_names)
 
+    if main_title is not None:
+        string += f'<tr><th align="center" colspan="{length}">{str(main_title)}</th></tr>\n'
+
     for i, bitsize in enumerate(sorted(list(set(bitsizes)))):
+
+        if i != 0:
+            string += f'<tr><td colspan="{length}">&nbsp;</td></tr>\n'
 
         # make bitsize header
         text = f"{bitsize} bits"
@@ -60,7 +66,8 @@ def convert_to_html_table(results, param_name, comments=None):
                 text += str(comments[i])
             else:
                 text += str(comments)
-        string += f'<tr><th align="center" colspan="{length}">{text}</th></tr>\n'
+        string += f'<tr><th align="center">Bitsize</th>'
+        string += f'<th align="center" colspan="{length - 1}">{text}</th></tr>\n'
 
         # make device header
         string += f'<tr><th align="center">Devices</th>'

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -71,7 +71,7 @@ def convert_to_html_table(results, param_name, main_title=None, comments=None):
         string += f'<th align="center" colspan="{length - 1}">{text}</th></tr>\n'
 
         # make device header
-        string += f'<tr><th align="center">Devices</th>'
+        string += f'<tr><th align="center">Device</th>'
         string += f'<th align="center" colspan="{cpus_cols}"">CPU</th>'
         string += f'<th align="center" colspan="{gpus_cols}">GPU</tr>\n'
 

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -83,12 +83,10 @@ def convert_to_html_table(results, param_name, main_title=None, comments=None):
         # make results rows
         for key in keys:
             subdict = results[key]
-            subkeys = get_keys(subdict)
             string += f'<tr><td align="center">{key}</td>'
-            for subkey in subkeys:
-                name, device, size = subkey
-                if size == bitsize:
-                    string += f'<td align="center">{subdict[subkey]:.4f}</td>'
+            for device, name in devices_names:
+                subkey = (name, device, bitsize)
+                string += f'<td align="center">{subdict[subkey]:.4f}</td>'
             string += "</tr>\n"
 
     string += "</table>"

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,0 +1,67 @@
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from ot.backend import get_backend_list, jax, tf
+
+
+def setup_backends():
+    if jax:
+        from jax.config import config
+        config.update("jax_enable_x64", True)
+
+    if tf:
+        from tensorflow.python.ops.numpy_ops import np_config
+        np_config.enable_numpy_behavior()
+
+
+def exec_bench(setup, tested_function, param_list, n_runs):
+    backend_list = get_backend_list()
+    results = dict()
+    for param in param_list:
+        L = dict()
+        inputs = setup(param)
+        for nx in backend_list:
+            results_nx = nx._bench(
+                tested_function,
+                *inputs,
+                n_runs=n_runs
+            )
+            L.update(results_nx)
+        results[param] = L
+    return results
+
+
+def get_keys(d):
+    return sorted(list(d.keys()))
+
+
+def convert_to_html_table(results, param_name):
+    string = "<table>\n"
+    keys = get_keys(results)
+    print(results[keys[0]].keys())
+    subkeys = get_keys(results[keys[0]])
+    names, devices, bitsizes = zip(*subkeys)
+
+    names = sorted(list(set(zip(names, devices))))
+    length = len(names) + 1
+
+    for bitsize in sorted(list(set(bitsizes))):
+        string += f'<tr><th align="center" colspan="{length}">{bitsize} bits</td></tr>\n'
+        string += f'<tr><th align="center">{param_name}</td>'
+        for name, device in names:
+            string += f'<th align="center">{name} {device}</td>'
+        string += "</tr>\n"
+
+        for key in keys:
+            subdict = results[key]
+            subkeys = get_keys(subdict)
+            string += f'<tr><td align="center">{key}</td>'
+            for subkey in subkeys:
+                name, device, size = subkey
+                if size == bitsize:
+                    string += f'<td align="center">{subdict[subkey]:.4f}</td>'
+            string += "</tr>\n"
+
+    string += "</table>"
+    return string

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -15,7 +15,7 @@ def setup_backends():
         np_config.enable_numpy_behavior()
 
 
-def exec_bench(setup, tested_function, param_list, n_runs):
+def exec_bench(setup, tested_function, param_list, n_runs, warmup_runs):
     backend_list = get_backend_list()
     results = dict()
     for param in param_list:
@@ -26,7 +26,8 @@ def exec_bench(setup, tested_function, param_list, n_runs):
             results_nx = nx._bench(
                 tested_function,
                 *inputs,
-                n_runs=n_runs
+                n_runs=n_runs,
+                warmup_runs=warmup_runs
             )
             L.update(results_nx)
         results[param] = L

--- a/benchmarks/emd.py
+++ b/benchmarks/emd.py
@@ -22,6 +22,7 @@ def setup(n_samples):
 
 if __name__ == "__main__":
     n_runs = 100
+    warmup_runs = 10
     param_list = [50, 100, 500]  # 1000, 2000, 5000, 10000]
 
     setup_backends()
@@ -29,7 +30,8 @@ if __name__ == "__main__":
         setup=setup,
         tested_function=lambda a, M: ot.emd(a, a, M),
         param_list=param_list,
-        n_runs=n_runs
+        n_runs=n_runs,
+        warmup_runs=warmup_runs
     )
     print(convert_to_html_table(
         results, 

--- a/benchmarks/emd.py
+++ b/benchmarks/emd.py
@@ -23,7 +23,7 @@ def setup(n_samples):
 if __name__ == "__main__":
     n_runs = 100
     warmup_runs = 10
-    param_list = [50, 100, 500]  # 1000, 2000, 5000, 10000]
+    param_list = [50, 100, 500, 1000, 2000, 5000]
 
     setup_backends()
     results = exec_bench(

--- a/benchmarks/emd.py
+++ b/benchmarks/emd.py
@@ -11,15 +11,13 @@ from .benchmark import (
 
 
 def setup(n_samples):
-    rng = np.random.RandomState(123456789)
-    a = rng.rand(n_samples // 4, 100)
-    b = rng.rand(n_samples, 100)
+    rng = np.random.RandomState(789465132)
+    x = rng.randn(n_samples, 2)
+    y = rng.randn(n_samples, 2)
 
-    wa = ot.unif(n_samples // 4)
-    wb = ot.unif(n_samples)
-
-    M = ot.dist(a.copy(), b.copy())
-    return wa, wb, M
+    a = ot.utils.unif(n_samples)
+    M = ot.dist(x, y)
+    return a, M
 
 
 if __name__ == "__main__":
@@ -29,12 +27,12 @@ if __name__ == "__main__":
     setup_backends()
     results = exec_bench(
         setup=setup,
-        tested_function=lambda *args: ot.bregman.sinkhorn(*args, reg=1, stopThr=1e-7),
+        tested_function=lambda a, M: ot.emd(a, a, M),
         param_list=param_list,
         n_runs=n_runs
     )
     print(convert_to_html_table(
         results, 
         param_name="Sample size",
-        main_title=f"Sinkhorn Knopp - Averaged on {n_runs} runs"
+        main_title=f"EMD - Averaged on {n_runs} runs"
     ))

--- a/benchmarks/sinkhorn_knopp.py
+++ b/benchmarks/sinkhorn_knopp.py
@@ -25,7 +25,7 @@ def setup(n_samples):
 if __name__ == "__main__":
     n_runs = 100
     warmup_runs = 10
-    param_list = [50, 100, 500]  # 1000, 2000, 5000, 10000]
+    param_list = [50, 100, 500, 1000, 2000, 5000]
 
     setup_backends()
     results = exec_bench(

--- a/benchmarks/sinkhorn_knopp.py
+++ b/benchmarks/sinkhorn_knopp.py
@@ -23,16 +23,18 @@ def setup(n_samples):
 
 
 if __name__ == "__main__":
+    n_runs = 100
+    param_list = [50]#100, 500]#, 1000, 2000, 5000, 10000]
+
     setup_backends()
     results = exec_bench(
         setup=setup,
         tested_function=lambda *args: ot.bregman.sinkhorn(*args, reg=1, stopThr=1e-7),
-        param_list=[50, 100, 500, 1000], #, 2000, 5000, 10000],
-        n_runs=10
+        param_list=param_list,
+        n_runs=n_runs
     )
-
     print(convert_to_html_table(
         results, 
         param_name="Sample size",
-        comments="Sinkhorn Knopp"
+        main_title=f"Sinkhorn Knopp - Averaged on {n_runs} runs"
     ))

--- a/benchmarks/sinkhorn_knopp.py
+++ b/benchmarks/sinkhorn_knopp.py
@@ -24,6 +24,7 @@ def setup(n_samples):
 
 if __name__ == "__main__":
     n_runs = 100
+    warmup_runs = 10
     param_list = [50, 100, 500]  # 1000, 2000, 5000, 10000]
 
     setup_backends()
@@ -31,7 +32,8 @@ if __name__ == "__main__":
         setup=setup,
         tested_function=lambda *args: ot.bregman.sinkhorn(*args, reg=1, stopThr=1e-7),
         param_list=param_list,
-        n_runs=n_runs
+        n_runs=n_runs,
+        warmup_runs=warmup_runs
     )
     print(convert_to_html_table(
         results, 

--- a/benchmarks/sinkhorn_knopp.py
+++ b/benchmarks/sinkhorn_knopp.py
@@ -1,0 +1,34 @@
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import ot
+from .benchmark import (
+    setup_backends,
+    exec_bench,
+    convert_to_html_table
+)
+
+
+def setup(n_samples):
+    rng = np.random.RandomState(123456789)
+    a = rng.rand(n_samples // 4, 100)
+    b = rng.rand(n_samples, 100)
+
+    wa = ot.unif(n_samples // 4)
+    wb = ot.unif(n_samples)
+
+    M = ot.dist(a.copy(), b.copy())
+    return wa, wb, M
+
+
+if __name__ == "__main__":
+    setup_backends()
+    results = exec_bench(
+        setup=setup,
+        tested_function=lambda *args: ot.bregman.sinkhorn(*args, reg=1, stopThr=1e-7),
+        param_list=[50, 100, 500, 1000], #, 2000, 5000, 10000],
+        n_runs=10
+    )
+
+    print(convert_to_html_table(results, param_name="Sample size"))

--- a/benchmarks/sinkhorn_knopp.py
+++ b/benchmarks/sinkhorn_knopp.py
@@ -31,4 +31,8 @@ if __name__ == "__main__":
         n_runs=10
     )
 
-    print(convert_to_html_table(results, param_name="Sample size"))
+    print(convert_to_html_table(
+        results, 
+        param_name="Sample size",
+        comments="Sinkhorn Knopp"
+    ))

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@ numpydoc
 memory_profiler
 pillow
 networkx
+mistune==0.8.4
 m2r2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ numpydoc
 memory_profiler
 pillow
 networkx
-mistune==0.8.4
-m2r2
+myst-parser

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -3,6 +3,7 @@ numpydoc
 memory_profiler
 pillow
 networkx
+mistune==0.8.4
 m2r2
 numpy
 scipy>=1.0

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -3,8 +3,7 @@ numpydoc
 memory_profiler
 pillow
 networkx
-mistune==0.8.4
-m2r2
+myst-parser
 numpy
 scipy>=1.0
 cython

--- a/docs/source/.github/CODE_OF_CONDUCT.rst
+++ b/docs/source/.github/CODE_OF_CONDUCT.rst
@@ -1,0 +1,6 @@
+Code of Conduct
+===============
+
+.. include:: ../../../.github/CODE_OF_CONDUCT.md
+    :parser: myst_parser.sphinx_
+    :start-line: 2

--- a/docs/source/.github/CONTRIBUTING.rst
+++ b/docs/source/.github/CONTRIBUTING.rst
@@ -1,0 +1,6 @@
+Contributing to POT
+===================
+
+.. include:: ../../../.github/CONTRIBUTING.md
+    :parser: myst_parser.sphinx_
+    :start-line: 3

--- a/docs/source/code_of_conduct.rst
+++ b/docs/source/code_of_conduct.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../.github/CODE_OF_CONDUCT.md

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'sphinx_gallery.gen_gallery',
-    'm2r2'
+    'myst_parser'
 ]
 
 autosummary_generate = True

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../.github/CONTRIBUTING.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,12 +17,11 @@ Contents
    all
    auto_examples/index
    releases
-   contributing
-   Code of Conduct <code_of_conduct>
+   .github/CONTRIBUTING
+   .github/CODE_OF_CONDUCT
 
-.. mdinclude:: ../../README.md
-   :start-line: 2
-
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
 
 
 Indices and tables

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1688,7 +1688,7 @@ class TorchBackend(Backend):
         return torch.finfo(type_as.dtype).bits
 
     def device_type(self, type_as):
-        return "CPU" if "cpu" in str(type_as.device) else "GPU"
+        return type_as.device.type.replace("cuda", "gpu").upper()
 
     def _bench(self, callable, *args, n_runs=1, warmup_runs=1):
         results = dict()
@@ -2337,7 +2337,7 @@ class TensorflowBackend(Backend):
         return type_as.dtype.size * 8
 
     def device_type(self, type_as):
-        return "CPU" if "CPU" in type_as.device else "GPU"
+        return self.dtype_device(type_as)[1].split(":")[0]
 
     def _bench(self, callable, *args, n_runs=1, warmup_runs=1):
         results = dict()

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -694,16 +694,6 @@ class Backend():
         """
         raise NotImplementedError()
 
-    def T(self, a):
-        r"""
-        Returns the transpose of a tensor.
-
-        This function follows the api from :any:`numpy.ndarray.T`.
-
-        See: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.T.html
-        """
-        raise NotImplementedError()
-
     def squeeze(self, a, axis=None):
         r"""
         Remove axes of length one from a.
@@ -950,9 +940,6 @@ class NumpyBackend(Backend):
     def assert_same_dtype_device(self, a, b):
         # numpy has implicit type conversion so we automatically validate the test
         pass
-
-    def T(self, a):
-        return a.T
 
     def squeeze(self, a, axis=None):
         return np.squeeze(a, axis=axis)
@@ -1216,9 +1203,6 @@ class JaxBackend(Backend):
 
         assert a_dtype == b_dtype, "Dtype discrepancy"
         assert a_device == b_device, f"Device discrepancy. First input is on {str(a_device)}, whereas second input is on {str(b_device)}"
-
-    def T(self, a):
-        return a.T
 
     def squeeze(self, a, axis=None):
         return jnp.squeeze(a, axis=axis)
@@ -1562,9 +1546,6 @@ class TorchBackend(Backend):
         assert a_dtype == b_dtype, "Dtype discrepancy"
         assert a_device == b_device, f"Device discrepancy. First input is on {str(a_device)}, whereas second input is on {str(b_device)}"
 
-    def T(self, a):
-        return a.T
-
     def squeeze(self, a, axis=None):
         if axis is None:
             return torch.squeeze(a)
@@ -1854,9 +1835,6 @@ class CupyBackend(Backend):  # pragma: no cover
         # cupy has implicit type conversion so
         # we automatically validate the test for type
         assert a_device == b_device, f"Device discrepancy. First input is on {str(a_device)}, whereas second input is on {str(b_device)}"
-
-    def T(self, a):
-        return a.T
 
     def squeeze(self, a, axis=None):
         return cp.squeeze(a, axis=axis)
@@ -2155,9 +2133,6 @@ class TensorflowBackend(Backend):
 
         assert a_dtype == b_dtype, "Dtype discrepancy"
         assert a_device == b_device, f"Device discrepancy. First input is on {str(a_device)}, whereas second input is on {str(b_device)}"
-
-    def T(self, a):
-        return a.T
 
     def squeeze(self, a, axis=None):
         return tnp.squeeze(a, axis=axis)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -980,6 +980,7 @@ class NumpyBackend(Backend):
             t1 = time.perf_counter()
             key = ("Numpy", self.prettier_device(type_as), self.bitsize(type_as))
             results[key] = (t1 - t0) / n_runs
+            del inputs
         return results
 
 
@@ -1262,6 +1263,7 @@ class JaxBackend(Backend):
             t1 = time.perf_counter()
             key = ("Jax", self.prettier_device(type_as), self.bitsize(type_as))
             results[key] = (t1 - t0) / n_runs
+            del inputs
         return results
 
 
@@ -1626,6 +1628,7 @@ class TorchBackend(Backend):
             t1 = time.perf_counter()
             key = ("Pytorch", self.prettier_device(type_as), self.bitsize(type_as))
             results[key] = (t1 - t0) / n_runs
+            del inputs
         return results
 
 
@@ -1932,6 +1935,7 @@ class CupyBackend(Backend):  # pragma: no cover
             t1 = time.perf_counter()
             key = ("Cupy", self.prettier_device(type_as), self.bitsize(type_as))
             results[key] = (t1 - t0) / n_runs
+            del inputs
         return results
 
 
@@ -2259,5 +2263,6 @@ class TensorflowBackend(Backend):
                         self.bitsize(type_as)
                     )
                     results[key] = (t1 - t0) / n_runs
+                    del inputs
 
         return results

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -50,6 +50,7 @@ try:
     import jax
     import jax.numpy as jnp
     import jax.scipy.special as jscipy
+    from jax.lib import xla_bridge
     jax_type = jax.numpy.ndarray
 except ImportError:
     jax = False
@@ -1011,7 +1012,10 @@ class JaxBackend(Backend):
         self.rng_ = jax.random.PRNGKey(42)
 
         self.__type_list__ = []
-        for d in jax.devices("cpu") + jax.devices("gpu"):
+        available_devices = jax.devices("cpu")
+        if xla_bridge.get_backend().platform == "gpu":
+            available_devices += jax.devices("gpu")
+        for d in available_devices:
             self.__type_list__ += [
                 jax.device_put(jnp.array(1, dtype=jnp.float32), d),
                 jax.device_put(jnp.array(1, dtype=jnp.float64), d)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -85,7 +85,7 @@ def get_backend_list():
     if jax:
         lst.append(JaxBackend())
 
-    if cp:
+    if cp:  # pragma: no cover
         lst.append(CupyBackend())
 
     if tf:
@@ -112,7 +112,7 @@ def get_backend(*args):
         return TorchBackend()
     elif isinstance(args[0], jax_type):
         return JaxBackend()
-    elif isinstance(args[0], cp_type):
+    elif isinstance(args[0], cp_type):  # pragma: no cover
         return CupyBackend()
     elif isinstance(args[0], tf_type):
         return TensorflowBackend()
@@ -1637,7 +1637,7 @@ class TorchBackend(Backend):
         for type_as in self.__type_list__:
             inputs = [self.from_numpy(arg, type_as=type_as) for arg in args]
             callable(*inputs)
-            if self.prettier_device(type_as) == "GPU":
+            if self.prettier_device(type_as) == "GPU":  # pragma: no cover
                 torch.cuda.synchronize()
                 start = torch.cuda.Event(enable_timing=True)
                 end = torch.cuda.Event(enable_timing=True)
@@ -1646,7 +1646,7 @@ class TorchBackend(Backend):
                 start = time.perf_counter()
             for _ in range(n_runs):
                 callable(*inputs)
-            if self.prettier_device(type_as) == "GPU":
+            if self.prettier_device(type_as) == "GPU":  # pragma: no cover
                 end.record()
                 torch.cuda.synchronize()
                 duration = start.elapsed_time(end) / 1000.
@@ -2275,7 +2275,7 @@ class TensorflowBackend(Backend):
     def _bench(self, callable, *args, n_runs=1):
         results = dict()
         device_contexts = [tf.device("/CPU:0")]
-        if len(tf.config.list_physical_devices('GPU')) > 0:
+        if len(tf.config.list_physical_devices('GPU')) > 0:  # pragma: no cover
             device_contexts.append(tf.device("/GPU:0"))
 
         for device_context in device_contexts:

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -22,8 +22,10 @@ Examples
 .. warning::
     Tensorflow only works with the Numpy API. To activate it, please run the following:
 
-    >>> from tensorflow.python.ops.numpy_ops import np_config
-    >>> np_config.enable_numpy_behavior()
+    .. code-block::
+
+        from tensorflow.python.ops.numpy_ops import np_config
+        np_config.enable_numpy_behavior()
 """
 
 # Author: Remi Flamary <remi.flamary@polytechnique.edu>

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1644,7 +1644,7 @@ class TorchBackend(Backend):
                 start = time.perf_counter()
             for _ in range(n_runs):
                 callable(*inputs)
-            if self.prettier_device(type_as) == "GPU":    
+            if self.prettier_device(type_as) == "GPU":
                 end.record()
                 torch.cuda.synchronize()
                 duration = start.elapsed_time(end) / 1000.

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1869,7 +1869,7 @@ class TensorflowBackend(Backend):
     __type_list__ = None
 
     rng_ = None
-    
+
     def __init__(self):
         self.seed(None)
 

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -19,11 +19,11 @@ Examples
 ...     return c
 
 
-.. note::
-Tensorflow only works with the numpy API. To activate it, please run the following:
+.. warning::
+    Tensorflow only works with the Numpy API. To activate it, please run the following:
 
->>> from tensorflow.python.ops.numpy_ops import np_config
->>> np_config.enable_numpy_behavior()
+    >>> from tensorflow.python.ops.numpy_ops import np_config
+    >>> np_config.enable_numpy_behavior()
 """
 
 # Author: Remi Flamary <remi.flamary@polytechnique.edu>

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -3,7 +3,7 @@
 Multi-lib backend for POT
 
 The goal is to write backend-agnostic code. Whether you're using Numpy, PyTorch,
-or Jax, POT code should work nonetheless.
+Jax, or Tensorflow, POT code should work nonetheless.
 To achieve that, POT provides backend classes which implements functions in their respective backend
 imitating Numpy API. As a convention, we use nx instead of np to refer to the backend.
 
@@ -108,7 +108,8 @@ def to_numpy(*args):
 class Backend():
     """
     Backend abstract class.
-    Implementations: :py:class:`JaxBackend`, :py:class:`NumpyBackend`, :py:class:`TorchBackend`
+    Implementations: :py:class:`JaxBackend`, :py:class:`NumpyBackend`, :py:class:`TorchBackend`,
+    :py:class:`TensorflowBackend`
 
     - The `__name__` class attribute refers to the name of the backend.
     - The `__type__` class attribute refers to the data structure used by the backend.

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1338,7 +1338,8 @@ class JaxBackend(Backend):
                 # We are technically doing more calculations but adding one
                 # is expected to be very quick and allows us to access the
                 # block_until_ready method to measure asynchronous calculations
-                add_one(callable(*inputs)).block_until_ready()
+                a = callable(*inputs)
+            add_one(a).block_until_ready()
             t1 = time.perf_counter()
             key = ("Jax", self.device_type(type_as), self.bitsize(type_as))
             results[key] = (t1 - t0) / n_runs

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1552,7 +1552,10 @@ class TorchBackend(Backend):
         return a.T
 
     def squeeze(self, a, axis=None):
-        return torch.squeeze(a, dim=axis)
+        if axis is None:
+            return torch.squeeze(a)
+        else:
+            return torch.squeeze(a, dim=axis)
 
 
 class TensorflowBackend(Backend):

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -18,7 +18,6 @@ Examples
 ...     c = nx.dot(a, b)  # now use the backend to do any calculation
 ...     return c
 
-
 .. warning::
     Tensorflow only works with the Numpy API. To activate it, please run the following:
 
@@ -26,6 +25,60 @@ Examples
 
         from tensorflow.python.ops.numpy_ops import np_config
         np_config.enable_numpy_behavior()
+
+Performance
+--------
+
+- CPU: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
+- GPU: Tesla V100-SXM2-32GB
+- Date of the benchmark: December 8th, 2021
+- Commit of benchmark: PR #316, https://github.com/PythonOT/POT/pull/316
+
+.. raw:: html
+
+    <style>
+    #perftable {
+        width: 100%;
+        margin-bottom: 1em;
+    }
+
+    #perftable table{
+        border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
+    }
+
+    #perftable th, #perftable td {
+        border: 1px solid #ddd;
+        padding: 8px;
+        font-size: smaller;
+    }
+    </style>
+
+    <div id="perftable">
+    <table>
+    <tr><th align="center" colspan="8">Sinkhorn Knopp - Averaged on 100 runs</th></tr>
+    <tr><th align="center">Bitsize</th><th align="center" colspan="7">32 bits</th></tr>
+    <tr><th align="center">Device</th><th align="center" colspan="3.0"">CPU</th><th align="center" colspan="4.0">GPU</tr>
+    <tr><th align="center">Sample size</th><th align="center">Numpy</th><th align="center">Pytorch</th><th align="center">Tensorflow</th><th align="center">Cupy</th><th align="center">Jax</th><th align="center">Pytorch</th><th align="center">Tensorflow</th></tr>
+    <tr><td align="center">50</td><td align="center">0.0008</td><td align="center">0.0022</td><td align="center">0.0151</td><td align="center">0.0095</td><td align="center">0.0193</td><td align="center">0.0051</td><td align="center">0.0293</td></tr>
+    <tr><td align="center">100</td><td align="center">0.0005</td><td align="center">0.0013</td><td align="center">0.0097</td><td align="center">0.0057</td><td align="center">0.0115</td><td align="center">0.0029</td><td align="center">0.0173</td></tr>
+    <tr><td align="center">500</td><td align="center">0.0009</td><td align="center">0.0016</td><td align="center">0.0110</td><td align="center">0.0058</td><td align="center">0.0115</td><td align="center">0.0029</td><td align="center">0.0166</td></tr>
+    <tr><td align="center">1000</td><td align="center">0.0021</td><td align="center">0.0021</td><td align="center">0.0145</td><td align="center">0.0056</td><td align="center">0.0118</td><td align="center">0.0029</td><td align="center">0.0168</td></tr>
+    <tr><td align="center">2000</td><td align="center">0.0069</td><td align="center">0.0043</td><td align="center">0.0278</td><td align="center">0.0059</td><td align="center">0.0118</td><td align="center">0.0030</td><td align="center">0.0165</td></tr>
+    <tr><td align="center">5000</td><td align="center">0.0707</td><td align="center">0.0314</td><td align="center">0.1395</td><td align="center">0.0074</td><td align="center">0.0125</td><td align="center">0.0035</td><td align="center">0.0198</td></tr>
+    <tr><td colspan="8">&nbsp;</td></tr>
+    <tr><th align="center">Bitsize</th><th align="center" colspan="7">64 bits</th></tr>
+    <tr><th align="center">Device</th><th align="center" colspan="3.0"">CPU</th><th align="center" colspan="4.0">GPU</tr>
+    <tr><th align="center">Sample size</th><th align="center">Numpy</th><th align="center">Pytorch</th><th align="center">Tensorflow</th><th align="center">Cupy</th><th align="center">Jax</th><th align="center">Pytorch</th><th align="center">Tensorflow</th></tr>
+    <tr><td align="center">50</td><td align="center">0.0008</td><td align="center">0.0020</td><td align="center">0.0154</td><td align="center">0.0093</td><td align="center">0.0191</td><td align="center">0.0051</td><td align="center">0.0328</td></tr>
+    <tr><td align="center">100</td><td align="center">0.0005</td><td align="center">0.0013</td><td align="center">0.0094</td><td align="center">0.0056</td><td align="center">0.0114</td><td align="center">0.0029</td><td align="center">0.0169</td></tr>
+    <tr><td align="center">500</td><td align="center">0.0013</td><td align="center">0.0017</td><td align="center">0.0120</td><td align="center">0.0059</td><td align="center">0.0116</td><td align="center">0.0029</td><td align="center">0.0168</td></tr>
+    <tr><td align="center">1000</td><td align="center">0.0034</td><td align="center">0.0027</td><td align="center">0.0177</td><td align="center">0.0058</td><td align="center">0.0118</td><td align="center">0.0029</td><td align="center">0.0167</td></tr>
+    <tr><td align="center">2000</td><td align="center">0.0146</td><td align="center">0.0075</td><td align="center">0.0436</td><td align="center">0.0059</td><td align="center">0.0120</td><td align="center">0.0029</td><td align="center">0.0165</td></tr>
+    <tr><td align="center">5000</td><td align="center">0.1467</td><td align="center">0.0568</td><td align="center">0.2468</td><td align="center">0.0077</td><td align="center">0.0146</td><td align="center">0.0045</td><td align="center">0.0204</td></tr>
+    </table>
+    </div>
 """
 
 # Author: Remi Flamary <remi.flamary@polytechnique.edu>

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1253,9 +1253,11 @@ class JaxBackend(Backend):
 
     def _bench(self, callable, *args, n_runs=1):
         results = dict()
+
         @jax.jit
         def add_one(M):
             return M + 1
+
         for type_as in self.__type_list__:
             inputs = [self.from_numpy(arg, type_as=type_as) for arg in args]
             callable(*inputs)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -64,8 +64,7 @@ def get_backend_list():
         lst.append(TorchBackend())
 
     if jax:
-        pass
-        # lst.append(JaxBackend())
+        lst.append(JaxBackend())
 
     if tf:
         lst.append(TensorflowBackend())
@@ -1654,19 +1653,18 @@ class TensorflowBackend(Backend):
         return tnp.minimum(a, b)
 
     def dot(self, a, b):
-        return tnp.dot(a, b)
-        # if len(b.shape) == 1:
-        #     if len(a.shape) == 1:
-        #         # inner product
-        #         return tf.reduce_sum(tf.multiply(a, b))
-        #     else:
-        #         # matrix vector
-        #         return tf.linalg.matvec(a, b)
-        # else:
-        #     if len(a.shape) == 1:
-        #         return self.T(tf.linalg.matvec(self.T(b), self.T(a)))
-        #     else:
-        #         return tf.matmul(a, b)
+        if len(b.shape) == 1:
+            if len(a.shape) == 1:
+                # inner product
+                return tf.reduce_sum(tf.multiply(a, b))
+            else:
+                # matrix vector
+                return tf.linalg.matvec(a, b)
+        else:
+            if len(a.shape) == 1:
+                return tf.linalg.matvec(b.T, a.T).T
+            else:
+                return tf.matmul(a, b)
 
     def abs(self, a):
         return tnp.abs(a)
@@ -1684,7 +1682,7 @@ class TensorflowBackend(Backend):
         return tnp.power(a, exponents)
 
     def norm(self, a):
-        return tnp.sqrt(tnp.sum(tnp.square(a)))
+        return tf.math.reduce_euclidean_norm(a)
 
     def any(self, a):
         return tnp.any(a)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1325,21 +1325,15 @@ class JaxBackend(Backend):
     def _bench(self, callable, *args, n_runs=1, warmup_runs=1):
         results = dict()
 
-        @jax.jit
-        def add_one(M):
-            return M + 1
-
         for type_as in self.__type_list__:
             inputs = [self.from_numpy(arg, type_as=type_as) for arg in args]
             for _ in range(warmup_runs):
-                add_one(callable(*inputs)).block_until_ready()
+                a = callable(*inputs)
+            a.block_until_ready()
             t0 = time.perf_counter()
             for _ in range(n_runs):
-                # We are technically doing more calculations but adding one
-                # is expected to be very quick and allows us to access the
-                # block_until_ready method to measure asynchronous calculations
                 a = callable(*inputs)
-            add_one(a).block_until_ready()
+            a.block_until_ready()
             t1 = time.perf_counter()
             key = ("Jax", self.device_type(type_as), self.bitsize(type_as))
             results[key] = (t1 - t0) / n_runs

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1010,9 +1010,12 @@ class JaxBackend(Backend):
     def __init__(self):
         self.rng_ = jax.random.PRNGKey(42)
 
-        for d in jax.devices():
-            self.__type_list__ = [jax.device_put(jnp.array(1, dtype=jnp.float32), d),
-                                  jax.device_put(jnp.array(1, dtype=jnp.float64), d)]
+        self.__type_list__ = []
+        for d in jax.devices("cpu") + jax.devices("gpu"):
+            self.__type_list__ += [
+                jax.device_put(jnp.array(1, dtype=jnp.float32), d),
+                jax.device_put(jnp.array(1, dtype=jnp.float64), d)
+            ]
 
     def to_numpy(self, a):
         return np.array(a)

--- a/ot/da.py
+++ b/ot/da.py
@@ -906,7 +906,7 @@ def emd_laplace(a, b, xs, xt, M, sim='knn', sim_param=None, reg='pos', eta=1, al
 
 
 def distribution_estimation_uniform(X):
-    """estimates a uniform distribution from an array of samples :math:`\mathbf{X}`
+    r"""estimates a uniform distribution from an array of samples :math:`\mathbf{X}`
 
     Parameters
     ----------
@@ -950,7 +950,7 @@ class BaseTransport(BaseEstimator):
     """
 
     def fit(self, Xs=None, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -1010,7 +1010,7 @@ class BaseTransport(BaseEstimator):
         return self
 
     def fit_transform(self, Xs=None, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
         and transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
 
@@ -1038,7 +1038,7 @@ class BaseTransport(BaseEstimator):
         return self.fit(Xs, ys, Xt, yt).transform(Xs, ys, Xt, yt)
 
     def transform(self, Xs=None, ys=None, Xt=None, yt=None, batch_size=128):
-        """Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
+        r"""Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
 
         Parameters
         ----------
@@ -1105,7 +1105,7 @@ class BaseTransport(BaseEstimator):
             return transp_Xs
 
     def transform_labels(self, ys=None):
-        """Propagate source labels :math:`\mathbf{y_s}` to obtain estimated target labels as in
+        r"""Propagate source labels :math:`\mathbf{y_s}` to obtain estimated target labels as in
         :ref:`[27] <references-basetransport-transform-labels>`.
 
         Parameters
@@ -1152,7 +1152,7 @@ class BaseTransport(BaseEstimator):
 
     def inverse_transform(self, Xs=None, ys=None, Xt=None, yt=None,
                           batch_size=128):
-        """Transports target samples :math:`\mathbf{X_t}` onto source samples :math:`\mathbf{X_s}`
+        r"""Transports target samples :math:`\mathbf{X_t}` onto source samples :math:`\mathbf{X_s}`
 
         Parameters
         ----------
@@ -1218,7 +1218,7 @@ class BaseTransport(BaseEstimator):
             return transp_Xt
 
     def inverse_transform_labels(self, yt=None):
-        """Propagate target labels :math:`\mathbf{y_t}` to obtain estimated source labels
+        r"""Propagate target labels :math:`\mathbf{y_t}` to obtain estimated source labels
         :math:`\mathbf{y_s}`
 
         Parameters
@@ -1307,7 +1307,7 @@ class LinearTransport(BaseTransport):
         self.distribution_estimation = distribution_estimation
 
     def fit(self, Xs=None, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -1354,7 +1354,7 @@ class LinearTransport(BaseTransport):
         return self
 
     def transform(self, Xs=None, ys=None, Xt=None, yt=None, batch_size=128):
-        """Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
+        r"""Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
 
         Parameters
         ----------
@@ -1387,7 +1387,7 @@ class LinearTransport(BaseTransport):
 
     def inverse_transform(self, Xs=None, ys=None, Xt=None, yt=None,
                           batch_size=128):
-        """Transports target samples :math:`\mathbf{X_t}` onto source samples :math:`\mathbf{X_s}`
+        r"""Transports target samples :math:`\mathbf{X_t}` onto source samples :math:`\mathbf{X_s}`
 
         Parameters
         ----------
@@ -1493,7 +1493,7 @@ class SinkhornTransport(BaseTransport):
         self.out_of_sample_map = out_of_sample_map
 
     def fit(self, Xs=None, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -1592,7 +1592,7 @@ class EMDTransport(BaseTransport):
         self.max_iter = max_iter
 
     def fit(self, Xs, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -1711,7 +1711,7 @@ class SinkhornLpl1Transport(BaseTransport):
         self.limit_max = limit_max
 
     def fit(self, Xs, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -1839,7 +1839,7 @@ class EMDLaplaceTransport(BaseTransport):
         self.out_of_sample_map = out_of_sample_map
 
     def fit(self, Xs, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -1962,7 +1962,7 @@ class SinkhornL1l2Transport(BaseTransport):
         self.limit_max = limit_max
 
     def fit(self, Xs, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -2088,7 +2088,7 @@ class MappingTransport(BaseEstimator):
         self.verbose2 = verbose2
 
     def fit(self, Xs=None, ys=None, Xt=None, yt=None):
-        """Builds an optimal coupling and estimates the associated mapping
+        r"""Builds an optimal coupling and estimates the associated mapping
         from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
@@ -2146,7 +2146,7 @@ class MappingTransport(BaseEstimator):
         return self
 
     def transform(self, Xs):
-        """Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
+        r"""Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
 
         Parameters
         ----------
@@ -2261,7 +2261,7 @@ class UnbalancedSinkhornTransport(BaseTransport):
         self.limit_max = limit_max
 
     def fit(self, Xs, ys=None, Xt=None, yt=None):
-        """Build a coupling matrix from source and target sets of samples
+        r"""Build a coupling matrix from source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -2373,7 +2373,7 @@ class JCPOTTransport(BaseTransport):
         self.out_of_sample_map = out_of_sample_map
 
     def fit(self, Xs, ys=None, Xt=None, yt=None):
-        """Building coupling matrices from a list of source and target sets of samples
+        r"""Building coupling matrices from a list of source and target sets of samples
         :math:`(\mathbf{X_s}, \mathbf{y_s})` and :math:`(\mathbf{X_t}, \mathbf{y_t})`
 
         Parameters
@@ -2419,7 +2419,7 @@ class JCPOTTransport(BaseTransport):
         return self
 
     def transform(self, Xs=None, ys=None, Xt=None, yt=None, batch_size=128):
-        """Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
+        r"""Transports source samples :math:`\mathbf{X_s}` onto target ones :math:`\mathbf{X_t}`
 
         Parameters
         ----------
@@ -2491,7 +2491,7 @@ class JCPOTTransport(BaseTransport):
             return transp_Xs
 
     def transform_labels(self, ys=None):
-        """Propagate source labels :math:`\mathbf{y_s}` to obtain target labels as in
+        r"""Propagate source labels :math:`\mathbf{y_s}` to obtain target labels as in
         :ref:`[27] <references-jcpottransport-transform-labels>`
 
         Parameters
@@ -2542,7 +2542,7 @@ class JCPOTTransport(BaseTransport):
             return yt.T
 
     def inverse_transform_labels(self, yt=None):
-        """Propagate target labels :math:`\mathbf{y_t}` to obtain estimated source labels
+        r"""Propagate target labels :math:`\mathbf{y_t}` to obtain estimated source labels
         :math:`\mathbf{y_s}`
 
         Parameters

--- a/ot/datasets.py
+++ b/ot/datasets.py
@@ -41,7 +41,7 @@ def get_1D_gauss(n, m, sigma):
 
 
 def make_2D_samples_gauss(n, m, sigma, random_state=None):
-    """Return `n` samples drawn from 2D gaussian :math:`\mathcal{N}(m, \sigma)`
+    r"""Return `n` samples drawn from 2D gaussian :math:`\mathcal{N}(m, \sigma)`
 
     Parameters
     ----------

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -16,7 +16,7 @@ Dimension reduction with OT
 
 from scipy import linalg
 import autograd.numpy as np
-import pymanopt
+from pymanopt.function import Autograd
 from pymanopt.manifolds import Stiefel
 from pymanopt import Problem
 from pymanopt.solvers import SteepestDescent, TrustRegions
@@ -182,7 +182,7 @@ def wda(X, y, p=2, reg=1, k=10, solver=None, maxiter=100, verbose=0, P0=None, no
     else:
         regmean = np.ones((len(xc), len(xc)))
 
-    @pymanopt.function.Autograd
+    @Autograd
     def cost(P):
         # wda loss
         loss_b = 0

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -16,7 +16,7 @@ Dimension reduction with OT
 
 from scipy import linalg
 import autograd.numpy as np
-from pymanopt.function import Autograd
+import pymanopt
 from pymanopt.manifolds import Stiefel
 from pymanopt import Problem
 from pymanopt.solvers import SteepestDescent, TrustRegions
@@ -182,7 +182,7 @@ def wda(X, y, p=2, reg=1, k=10, solver=None, maxiter=100, verbose=0, P0=None, no
     else:
         regmean = np.ones((len(xc), len(xc)))
 
-    @Autograd
+    @pymanopt.function.Autograd
     def cost(P):
         # wda loss
         loss_b = 0

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -181,6 +181,8 @@ def wda(X, y, p=2, reg=1, k=10, solver=None, maxiter=100, verbose=0, P0=None, no
     else:
         regmean = np.ones((len(xc), len(xc)))
 
+
+    @pymanopt.function.Autograd
     def cost(P):
         # wda loss
         loss_b = 0

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -16,6 +16,7 @@ Dimension reduction with OT
 
 from scipy import linalg
 import autograd.numpy as np
+from pymanopt.function import Autograd
 from pymanopt.manifolds import Stiefel
 from pymanopt import Problem
 from pymanopt.solvers import SteepestDescent, TrustRegions
@@ -181,8 +182,7 @@ def wda(X, y, p=2, reg=1, k=10, solver=None, maxiter=100, verbose=0, P0=None, no
     else:
         regmean = np.ones((len(xc), len(xc)))
 
-
-    @pymanopt.function.Autograd
+    @Autograd
     def cost(P):
         # wda loss
         loss_b = 0

--- a/ot/gromov.py
+++ b/ot/gromov.py
@@ -942,7 +942,7 @@ def pointwise_gromov_wasserstein(C1, C2, p, q, loss_fun,
     for cpt in range(max_iter):
         index[0] = generator.choice(len_p, size=1, p=p)
         T_index0 = nx.reshape(nx.todense(T[index[0], :]), (-1,))
-        index[1] = generator.choice(len_q, size=1, p=T_index0 / T_index0.sum())
+        index[1] = generator.choice(len_q, size=1, p=T_index0 / nx.sum(T_index0))
 
         if alpha == 1:
             T = nx.tocsr(

--- a/ot/lp/solver_1d.py
+++ b/ot/lp/solver_1d.py
@@ -100,11 +100,11 @@ def wasserstein_1d(u_values, v_values, u_weights=None, v_weights=None, p=1, requ
     m = v_values.shape[0]
 
     if u_weights is None:
-        u_weights = nx.full(u_values.shape, 1. / n)
+        u_weights = nx.full(u_values.shape, 1. / n, type_as=u_values)
     elif u_weights.ndim != u_values.ndim:
         u_weights = nx.repeat(u_weights[..., None], u_values.shape[-1], -1)
     if v_weights is None:
-        v_weights = nx.full(v_values.shape, 1. / m)
+        v_weights = nx.full(v_values.shape, 1. / m, type_as=v_values)
     elif v_weights.ndim != v_values.ndim:
         v_weights = nx.repeat(v_weights[..., None], v_values.shape[-1], -1)
 

--- a/ot/plot.py
+++ b/ot/plot.py
@@ -18,7 +18,7 @@ from matplotlib import gridspec
 
 
 def plot1D_mat(a, b, M, title=''):
-    """ Plot matrix :math:`\mathbf{M}`  with the source and target 1D distribution
+    r""" Plot matrix :math:`\mathbf{M}`  with the source and target 1D distribution
 
     Creates a subplot with the source distribution :math:`\mathbf{a}` on the left and
     target distribution :math:`\mathbf{b}` on the top. The matrix :math:`\mathbf{M}` is shown in between.
@@ -61,7 +61,7 @@ def plot1D_mat(a, b, M, title=''):
 
 
 def plot2D_samples_mat(xs, xt, G, thr=1e-8, **kwargs):
-    """ Plot matrix :math:`\mathbf{G}` in 2D with lines using alpha values
+    r""" Plot matrix :math:`\mathbf{G}` in 2D with lines using alpha values
 
     Plot lines between source and target 2D samples with a color
     proportional to the value of the matrix :math:`\mathbf{G}` between samples.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ scikit-learn
 torch
 jax
 jaxlib
+tensorflow
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cython
 matplotlib
 autograd
 pymanopt==0.2.4; python_version <'3'
-git+https://github.com/pymanopt/pymanopt; python_version >= '3'
+pymanopt==0.2.6rc1; python_version >= '3'
 cvxopt
 scikit-learn
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cython
 matplotlib
 autograd
 pymanopt==0.2.4; python_version <'3'
-pymanopt; python_version >= '3'
+git+https://github.com/pymanopt/pymanopt; python_version >= '3'
 cvxopt
 scikit-learn
 torch

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,16 +28,16 @@ def nx(request):
 
 
 def skip_arg(arg, value, reason=None, getter=lambda x: x):
-    if isinstance(arg, tuple) or isinstance(arg, list):
+    if isinstance(arg, (tuple, list)):
         n = len(arg)
     else:
         arg = (arg, )
         n = 1
-    if n != 1 and (isinstance(value, tuple) or isinstance(value, list)):
+    if n != 1 and isinstance(value, (tuple, list)):
         pass
     else:
         value = (value, )
-    if isinstance(getter, tuple) or isinstance(value, list):
+    if isinstance(getter, (tuple, list)):
         pass
     else:
         getter = [getter] * n

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,13 +5,17 @@
 # License: MIT License
 
 import pytest
-from ot.backend import jax
+from ot.backend import jax, tf
 from ot.backend import get_backend_list
 import functools
 
 if jax:
     from jax.config import config
     config.update("jax_enable_x64", True)
+
+if tf:
+    from tensorflow.python.ops.numpy_ops import np_config
+    np_config.enable_numpy_behavior()
 
 backend_list = get_backend_list()
 

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -624,3 +624,17 @@ def test_gradients_backends():
         np.testing.assert_almost_equal(fun(v, c, e), c * np.sum(v ** 4) + e, decimal=4)
         np.testing.assert_allclose(grad_val[0], v, atol=1e-4)
         np.testing.assert_allclose(grad_val[2], 2 * e, atol=1e-4)
+
+    if tf:
+        nx = ot.backend.TensorflowBackend()
+        w = tf.Variable(tf.random.normal((3, 2)), name='w')
+        b = tf.Variable(tf.random.normal((2,), dtype=tf.float32), name='b')
+        x = tf.random.normal((1, 3), dtype=tf.float32)
+
+        with tf.GradientTape() as tape:
+            y = x @ w + b
+            loss = tf.reduce_mean(y ** 2)
+            manipulated_loss = nx.set_gradients(loss, (w, b), (w, b))
+            [dl_dw, dl_db] = tape.gradient(manipulated_loss, [w, b])
+            assert nx.allclose(dl_dw, w)
+            assert nx.allclose(dl_db, b)

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -92,15 +92,14 @@ def test_get_backend():
         B2 = tf.convert_to_tensor(B)
 
         nx = get_backend(A2)
-        assert nx.__name__ == 'tensorflow'
+        assert nx.__name__ == 'tf'
 
         nx = get_backend(A2, B2)
-        assert nx.__name__ == 'tensorflow'
+        assert nx.__name__ == 'tf'
 
         # test not unique types in input
         with pytest.raises(ValueError):
             get_backend(A, B2)
-
 
 
 def test_convert_between_backends(nx):
@@ -487,36 +486,36 @@ def test_func_backends(nx):
         lst_b.append(nx.to_numpy(A))
         lst_name.append('reshape')
 
-        # sp_Mb = nx.coo_matrix(sp_datab, sp_rowb, sp_colb, shape=(4, 4))
-        # nx.todense(Mb)
-        # lst_b.append(nx.to_numpy(nx.todense(sp_Mb)))
-        # lst_name.append('coo_matrix')
+        sp_Mb = nx.coo_matrix(sp_datab, sp_rowb, sp_colb, shape=(4, 4))
+        nx.todense(Mb)
+        lst_b.append(nx.to_numpy(nx.todense(sp_Mb)))
+        lst_name.append('coo_matrix')
 
-        # assert not nx.issparse(Mb), 'Assert fail on: issparse (expected False)'
-        # assert nx.issparse(sp_Mb) or nx.__name__ == "jax", 'Assert fail on: issparse (expected True)'
+        assert not nx.issparse(Mb), 'Assert fail on: issparse (expected False)'
+        assert nx.issparse(sp_Mb) or nx.__name__ == "jax", 'Assert fail on: issparse (expected True)'
 
-        # A = nx.tocsr(sp_Mb)
-        # lst_b.append(nx.to_numpy(nx.todense(A)))
-        # lst_name.append('tocsr')
+        A = nx.tocsr(sp_Mb)
+        lst_b.append(nx.to_numpy(nx.todense(A)))
+        lst_name.append('tocsr')
 
-        # A = nx.eliminate_zeros(nx.copy(sp_datab), threshold=5.)
-        # lst_b.append(nx.to_numpy(A))
-        # lst_name.append('eliminate_zeros (dense)')
+        A = nx.eliminate_zeros(nx.copy(sp_datab), threshold=5.)
+        lst_b.append(nx.to_numpy(A))
+        lst_name.append('eliminate_zeros (dense)')
 
-        # A = nx.eliminate_zeros(sp_Mb)
-        # lst_b.append(nx.to_numpy(nx.todense(A)))
-        # lst_name.append('eliminate_zeros (sparse)')
+        A = nx.eliminate_zeros(sp_Mb)
+        lst_b.append(nx.to_numpy(nx.todense(A)))
+        lst_name.append('eliminate_zeros (sparse)')
 
-        # A = nx.where(Mb >= nx.stack([nx.linspace(0, 1, 10)] * 3, axis=1), Mb, 0.0)
-        # lst_b.append(nx.to_numpy(A))
-        # lst_name.append('where')
+        A = nx.where(Mb >= nx.stack([nx.linspace(0, 1, 10)] * 3, axis=1), Mb, 0.0)
+        lst_b.append(nx.to_numpy(A))
+        lst_name.append('where')
 
-        # A = nx.copy(Mb)
-        # lst_b.append(nx.to_numpy(A))
-        # lst_name.append('copy')
+        A = nx.copy(Mb)
+        lst_b.append(nx.to_numpy(A))
+        lst_name.append('copy')
 
-        # assert nx.allclose(Mb, Mb), 'Assert fail on: allclose (expected True)'
-        # assert not nx.allclose(2 * Mb, Mb), 'Assert fail on: allclose (expected False)'
+        assert nx.allclose(Mb, Mb), 'Assert fail on: allclose (expected True)'
+        assert not nx.allclose(2 * Mb, Mb), 'Assert fail on: allclose (expected False)'
 
         A = nx.T(Mb)
         lst_b.append(nx.to_numpy(A))

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -257,8 +257,6 @@ def test_empty_backend():
     with pytest.raises(NotImplementedError):
         nx.allclose(M, M)
     with pytest.raises(NotImplementedError):
-        nx.T(M)
-    with pytest.raises(NotImplementedError):
         nx.squeeze(M)
 
 
@@ -533,10 +531,6 @@ def test_func_backends(nx):
 
         assert nx.allclose(Mb, Mb), 'Assert fail on: allclose (expected True)'
         assert not nx.allclose(2 * Mb, Mb), 'Assert fail on: allclose (expected False)'
-
-        A = nx.T(Mb)
-        lst_b.append(nx.to_numpy(A))
-        lst_name.append('transpose')
 
         A = nx.squeeze(nx.zeros((3, 1, 4, 1)))
         assert tuple(A.shape) == (3, 4), 'Assert fail on: squeeze'

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -261,7 +261,7 @@ def test_empty_backend():
     with pytest.raises(NotImplementedError):
         nx.bitsize(M)
     with pytest.raises(NotImplementedError):
-        nx.prettier_device(M)
+        nx.device_type(M)
     with pytest.raises(NotImplementedError):
         nx._bench(lambda x: x, M, n_runs=1)
 
@@ -545,7 +545,7 @@ def test_func_backends(nx):
         lst_b.append(float(A))
         lst_name.append("bitsize")
 
-        A = nx.prettier_device(Mb)
+        A = nx.device_type(Mb)
         assert A in ("CPU", "GPU")
 
         nx._bench(lambda x: x, M, n_runs=1)

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -258,6 +258,12 @@ def test_empty_backend():
         nx.allclose(M, M)
     with pytest.raises(NotImplementedError):
         nx.squeeze(M)
+    with pytest.raises(NotImplementedError):
+        nx.bitsize(M)
+    with pytest.raises(NotImplementedError):
+        nx.prettier_device(M)
+    with pytest.raises(NotImplementedError):
+        nx._bench(lambda x: x, M, n_runs=1)
 
 
 def test_func_backends(nx):
@@ -534,6 +540,15 @@ def test_func_backends(nx):
 
         A = nx.squeeze(nx.zeros((3, 1, 4, 1)))
         assert tuple(A.shape) == (3, 4), 'Assert fail on: squeeze'
+
+        A = nx.bitsize(Mb)
+        lst_b.append(float(A))
+        lst_name.append("bitsize")
+
+        A = nx.prettier_device(Mb)
+        assert A in ("CPU", "GPU")
+
+        nx._bench(lambda x: x, M, n_runs=1)
 
         lst_tot.append(lst_b)
 

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -7,7 +7,6 @@
 
 import ot
 import ot.backend
-
 from ot.backend import torch, jax, cp, tf
 
 import pytest

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -7,7 +7,7 @@
 
 import ot
 import ot.backend
-from ot.backend import torch, jax
+from ot.backend import torch, jax, tf
 
 import pytest
 
@@ -86,6 +86,21 @@ def test_get_backend():
         # test not unique types in input
         with pytest.raises(ValueError):
             get_backend(A, B2)
+
+    if tf:
+        A2 = tf.convert_to_tensor(A)
+        B2 = tf.convert_to_tensor(B)
+
+        nx = get_backend(A2)
+        assert nx.__name__ == 'tensorflow'
+
+        nx = get_backend(A2, B2)
+        assert nx.__name__ == 'tensorflow'
+
+        # test not unique types in input
+        with pytest.raises(ValueError):
+            get_backend(A, B2)
+
 
 
 def test_convert_between_backends(nx):
@@ -228,6 +243,8 @@ def test_empty_backend():
         nx.copy(M)
     with pytest.raises(NotImplementedError):
         nx.allclose(M, M)
+    with pytest.raises(NotImplementedError):
+        nx.T(M)
 
 
 def test_func_backends(nx):
@@ -353,7 +370,7 @@ def test_func_backends(nx):
         lst_b.append(nx.to_numpy(A))
         lst_name.append('dot(M,v)')
 
-        A = nx.dot(Mb, Mb.T)
+        A = nx.dot(Mb, nx.T(Mb))
         lst_b.append(nx.to_numpy(A))
         lst_name.append('dot(M,M)')
 
@@ -470,36 +487,40 @@ def test_func_backends(nx):
         lst_b.append(nx.to_numpy(A))
         lst_name.append('reshape')
 
-        sp_Mb = nx.coo_matrix(sp_datab, sp_rowb, sp_colb, shape=(4, 4))
-        nx.todense(Mb)
-        lst_b.append(nx.to_numpy(nx.todense(sp_Mb)))
-        lst_name.append('coo_matrix')
+        # sp_Mb = nx.coo_matrix(sp_datab, sp_rowb, sp_colb, shape=(4, 4))
+        # nx.todense(Mb)
+        # lst_b.append(nx.to_numpy(nx.todense(sp_Mb)))
+        # lst_name.append('coo_matrix')
 
-        assert not nx.issparse(Mb), 'Assert fail on: issparse (expected False)'
-        assert nx.issparse(sp_Mb) or nx.__name__ == "jax", 'Assert fail on: issparse (expected True)'
+        # assert not nx.issparse(Mb), 'Assert fail on: issparse (expected False)'
+        # assert nx.issparse(sp_Mb) or nx.__name__ == "jax", 'Assert fail on: issparse (expected True)'
 
-        A = nx.tocsr(sp_Mb)
-        lst_b.append(nx.to_numpy(nx.todense(A)))
-        lst_name.append('tocsr')
+        # A = nx.tocsr(sp_Mb)
+        # lst_b.append(nx.to_numpy(nx.todense(A)))
+        # lst_name.append('tocsr')
 
-        A = nx.eliminate_zeros(nx.copy(sp_datab), threshold=5.)
+        # A = nx.eliminate_zeros(nx.copy(sp_datab), threshold=5.)
+        # lst_b.append(nx.to_numpy(A))
+        # lst_name.append('eliminate_zeros (dense)')
+
+        # A = nx.eliminate_zeros(sp_Mb)
+        # lst_b.append(nx.to_numpy(nx.todense(A)))
+        # lst_name.append('eliminate_zeros (sparse)')
+
+        # A = nx.where(Mb >= nx.stack([nx.linspace(0, 1, 10)] * 3, axis=1), Mb, 0.0)
+        # lst_b.append(nx.to_numpy(A))
+        # lst_name.append('where')
+
+        # A = nx.copy(Mb)
+        # lst_b.append(nx.to_numpy(A))
+        # lst_name.append('copy')
+
+        # assert nx.allclose(Mb, Mb), 'Assert fail on: allclose (expected True)'
+        # assert not nx.allclose(2 * Mb, Mb), 'Assert fail on: allclose (expected False)'
+
+        A = nx.T(Mb)
         lst_b.append(nx.to_numpy(A))
-        lst_name.append('eliminate_zeros (dense)')
-
-        A = nx.eliminate_zeros(sp_Mb)
-        lst_b.append(nx.to_numpy(nx.todense(A)))
-        lst_name.append('eliminate_zeros (sparse)')
-
-        A = nx.where(Mb >= nx.stack([nx.linspace(0, 1, 10)] * 3, axis=1), Mb, 0.0)
-        lst_b.append(nx.to_numpy(A))
-        lst_name.append('where')
-
-        A = nx.copy(Mb)
-        lst_b.append(nx.to_numpy(A))
-        lst_name.append('copy')
-
-        assert nx.allclose(Mb, Mb), 'Assert fail on: allclose (expected True)'
-        assert not nx.allclose(2 * Mb, Mb), 'Assert fail on: allclose (expected False)'
+        lst_name.append('transpose')
 
         lst_tot.append(lst_b)
 

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -244,6 +244,8 @@ def test_empty_backend():
         nx.allclose(M, M)
     with pytest.raises(NotImplementedError):
         nx.T(M)
+    with pytest.raises(NotImplementedError):
+        nx.squeeze(M)
 
 
 def test_func_backends(nx):
@@ -369,7 +371,7 @@ def test_func_backends(nx):
         lst_b.append(nx.to_numpy(A))
         lst_name.append('dot(M,v)')
 
-        A = nx.dot(Mb, nx.T(Mb))
+        A = nx.dot(Mb, Mb.T)
         lst_b.append(nx.to_numpy(A))
         lst_name.append('dot(M,M)')
 
@@ -492,7 +494,7 @@ def test_func_backends(nx):
         lst_name.append('coo_matrix')
 
         assert not nx.issparse(Mb), 'Assert fail on: issparse (expected False)'
-        assert nx.issparse(sp_Mb) or nx.__name__ == "jax", 'Assert fail on: issparse (expected True)'
+        assert nx.issparse(sp_Mb) or nx.__name__ in ("jax", "tf"), 'Assert fail on: issparse (expected True)'
 
         A = nx.tocsr(sp_Mb)
         lst_b.append(nx.to_numpy(nx.todense(A)))
@@ -520,6 +522,9 @@ def test_func_backends(nx):
         A = nx.T(Mb)
         lst_b.append(nx.to_numpy(A))
         lst_name.append('transpose')
+
+        A = nx.squeeze(nx.zeros((3, 1, 4, 1)))
+        assert tuple(A.shape) == (3, 4), 'Assert fail on: squeeze'
 
         lst_tot.append(lst_b)
 

--- a/test/test_bregman.py
+++ b/test/test_bregman.py
@@ -248,6 +248,7 @@ def test_sinkhorn_empty():
     ot.sinkhorn([], [], M, 1, method='greenkhorn', stopThr=1e-10, log=True)
 
 
+@pytest.skip_backend('tf')
 @pytest.skip_backend("jax")
 def test_sinkhorn_variants(nx):
     # test sinkhorn
@@ -282,6 +283,8 @@ def test_sinkhorn_variants(nx):
                                     "sinkhorn_epsilon_scaling",
                                     "greenkhorn",
                                     "sinkhorn_log"])
+@pytest.skip_arg(("nx", "method"), ("tf", "sinkhorn_epsilon_scaling"), reason="tf does not support sinkhorn_epsilon_scaling", getter=str)
+@pytest.skip_arg(("nx", "method"), ("tf", "greenkhorn"), reason="tf does not support greenkhorn", getter=str)
 @pytest.skip_arg(("nx", "method"), ("jax", "sinkhorn_epsilon_scaling"), reason="jax does not support sinkhorn_epsilon_scaling", getter=str)
 @pytest.skip_arg(("nx", "method"), ("jax", "greenkhorn"), reason="jax does not support greenkhorn", getter=str)
 def test_sinkhorn_variants_dtype_device(nx, method):
@@ -323,6 +326,7 @@ def test_sinkhorn2_variants_dtype_device(nx, method):
         nx.assert_same_dtype_device(Mb, lossb)
 
 
+@pytest.skip_backend('tf')
 @pytest.skip_backend("jax")
 def test_sinkhorn_variants_multi_b(nx):
     # test sinkhorn
@@ -352,6 +356,7 @@ def test_sinkhorn_variants_multi_b(nx):
     np.testing.assert_allclose(G0, Gs, atol=1e-05)
 
 
+@pytest.skip_backend('tf')
 @pytest.skip_backend("jax")
 def test_sinkhorn2_variants_multi_b(nx):
     # test sinkhorn
@@ -454,7 +459,7 @@ def test_barycenter(nx, method, verbose, warn):
     weights_nx = nx.from_numpy(weights)
     reg = 1e-2
 
-    if nx.__name__ == "jax" and method == "sinkhorn_log":
+    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
         with pytest.raises(NotImplementedError):
             ot.bregman.barycenter(A_nx, M_nx, reg, weights, method=method)
     else:
@@ -495,7 +500,7 @@ def test_barycenter_debiased(nx, method, verbose, warn):
 
     # wasserstein
     reg = 1e-2
-    if nx.__name__ == "jax" and method == "sinkhorn_log":
+    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
         with pytest.raises(NotImplementedError):
             ot.bregman.barycenter_debiased(A_nx, M_nx, reg, weights, method=method)
     else:
@@ -597,7 +602,7 @@ def test_wasserstein_bary_2d(nx, method):
 
     # wasserstein
     reg = 1e-2
-    if nx.__name__ == "jax" and method == "sinkhorn_log":
+    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
         with pytest.raises(NotImplementedError):
             ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
     else:
@@ -629,7 +634,7 @@ def test_wasserstein_bary_2d_debiased(nx, method):
 
     # wasserstein
     reg = 1e-2
-    if nx.__name__ == "jax" and method == "sinkhorn_log":
+    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
         with pytest.raises(NotImplementedError):
             ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
     else:
@@ -888,6 +893,7 @@ def test_implemented_methods():
             ot.bregman.sinkhorn2(a, b, M, epsilon, method=method)
 
 
+@pytest.skip_backend('tf')
 @pytest.skip_backend("jax")
 @pytest.mark.filterwarnings("ignore:Bottleneck")
 def test_screenkhorn(nx):

--- a/test/test_bregman.py
+++ b/test/test_bregman.py
@@ -328,7 +328,7 @@ def test_sinkhorn2_variants_dtype_device(nx, method):
 
 @pytest.mark.skipif(not tf, reason="tf not installed")
 @pytest.mark.parametrize("method", ["sinkhorn", "sinkhorn_stabilized", "sinkhorn_log"])
-def test_sinkhorn2_variants_dtype_device(method):
+def test_sinkhorn2_variants_device_tf(method):
     nx = ot.backend.TensorflowBackend()
     n = 100
     x = np.random.randn(n, 2)

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -147,6 +147,7 @@ def test_gromov2_gradients():
 
 
 @pytest.skip_backend("jax", reason="test very slow with jax backend")
+@pytest.skip_backend("tf", reason="test very slow with tf backend")
 def test_entropic_gromov(nx):
     n_samples = 50  # nb samples
 
@@ -204,6 +205,7 @@ def test_entropic_gromov(nx):
 
 
 @pytest.skip_backend("jax", reason="test very slow with jax backend")
+@pytest.skip_backend("tf", reason="test very slow with tf backend")
 def test_entropic_gromov_dtype_device(nx):
     # setup
     n_samples = 50  # nb samples
@@ -302,6 +304,7 @@ def test_pointwise_gromov(nx):
     np.testing.assert_allclose(logb['gw_dist_std'], 0.0015952535464736394, atol=1e-8)
 
 
+@pytest.skip_backend("tf", reason="test very slow with tf backend")
 @pytest.skip_backend("jax", reason="test very slow with jax backend")
 def test_sampled_gromov(nx):
     n_samples = 50  # nb samples

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -152,7 +152,6 @@ def test_gromov_device_tf():
         assert nx.dtype_device(Gb)[1].startswith("GPU")
 
 
-
 def test_gromov2_gradients():
     n_samples = 50  # nb samples
 


### PR DESCRIPTION
## Personal To do
- [x] Prettify benchmark results presentation
- [x] Include benchmark for EMD
- [x] Correct time measure for each backend (does time.perf_counter work on GPUs ??)
- [x] Make real benchmark for Sinkhorn Knopp that is pretty for this PR (with every single backend and device)
- [x] Put aforementioned benchmark in backend.py's docstring
- [x] Check if set_gradient works as intended for tensorflow and add test
- [x] Add to backend.py docstrings a comment about tensorflow requiring the numpy API
- [x] Replace m2r2 by myst_parser (https://myst-parser.readthedocs.io/en/latest/) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
- Backend for tensorflow. 
- Also adds a benchmark folder which allows to easily benchmark every backend and present results in a html table (compatible with github comments and PR text).
- Also replaced m2r2 by myst_parser. It allows to use markdown files in our official docs. Myst_parser seems more maintained. It also happens to solve the issue with internal links introduced by the m2r2 update few PRs ago.

Note that tensorflow does not know how to transpose inplace, which can have a negative impact on performance for any function which requires the usage of a transpose (More information here: https://www.tensorflow.org/api_docs/python/tf/transpose#expandable-1)

Note that nothing was done regarding the device consistency of our calculation (unlike TorchBackend for instance). This is due to the fact that tensorflow chooses the device automatically without caring about the device where inputs are located. If the user wants a specific device, this should be done outside of POT, probably something like
```
with tf.device("/GPU:1"):
    ot.sinkhorn(args, **kwargs)
```
More information here: https://www.tensorflow.org/guide/gpu#overview


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
Tested with Tensorflow 2.6.0 and 2.7.0. Benchmark with Tensorflow 2.6.0


## Performance on Sinkhorn Knopp
The speedup is not as convincing as with cupy, might be due to how inefficient tensorflow transpose are. Still a great choice for very high dimensions.
Used pretty much the code from test/test_gpu.py::test_gpu_sinkhorn.
Tests were performed with Tensorflow 2.6.0, results in seconds, averaged over 100 runs.

<table>
<tr><th align="center" colspan="8">Sinkhorn Knopp - Averaged on 100 runs</th></tr>
    <tr><th align="center">Bitsize</th><th align="center" colspan="7">32 bits</th></tr>
    <tr><th align="center">Device</th><th align="center" colspan="3.0"">CPU</th><th align="center" colspan="4.0">GPU</tr>
    <tr><th align="center">Sample size</th><th align="center">Numpy</th><th align="center">Pytorch</th><th align="center">Tensorflow</th><th align="center">Cupy</th><th align="center">Jax</th><th align="center">Pytorch</th><th align="center">Tensorflow</th></tr>
    <tr><td align="center">50</td><td align="center">0.0008</td><td align="center">0.0022</td><td align="center">0.0151</td><td align="center">0.0095</td><td align="center">0.0193</td><td align="center">0.0051</td><td align="center">0.0293</td></tr>
    <tr><td align="center">100</td><td align="center">0.0005</td><td align="center">0.0013</td><td align="center">0.0097</td><td align="center">0.0057</td><td align="center">0.0115</td><td align="center">0.0029</td><td align="center">0.0173</td></tr>
    <tr><td align="center">500</td><td align="center">0.0009</td><td align="center">0.0016</td><td align="center">0.0110</td><td align="center">0.0058</td><td align="center">0.0115</td><td align="center">0.0029</td><td align="center">0.0166</td></tr>
    <tr><td align="center">1000</td><td align="center">0.0021</td><td align="center">0.0021</td><td align="center">0.0145</td><td align="center">0.0056</td><td align="center">0.0118</td><td align="center">0.0029</td><td align="center">0.0168</td></tr>
    <tr><td align="center">2000</td><td align="center">0.0069</td><td align="center">0.0043</td><td align="center">0.0278</td><td align="center">0.0059</td><td align="center">0.0118</td><td align="center">0.0030</td><td align="center">0.0165</td></tr>
    <tr><td align="center">5000</td><td align="center">0.0707</td><td align="center">0.0314</td><td align="center">0.1395</td><td align="center">0.0074</td><td align="center">0.0125</td><td align="center">0.0035</td><td align="center">0.0198</td></tr>
    <tr><td colspan="8">&nbsp;</td></tr>
    <tr><th align="center">Bitsize</th><th align="center" colspan="7">64 bits</th></tr>
    <tr><th align="center">Device</th><th align="center" colspan="3.0"">CPU</th><th align="center" colspan="4.0">GPU</tr>
    <tr><th align="center">Sample size</th><th align="center">Numpy</th><th align="center">Pytorch</th><th align="center">Tensorflow</th><th align="center">Cupy</th><th align="center">Jax</th><th align="center">Pytorch</th><th align="center">Tensorflow</th></tr>
    <tr><td align="center">50</td><td align="center">0.0008</td><td align="center">0.0020</td><td align="center">0.0154</td><td align="center">0.0093</td><td align="center">0.0191</td><td align="center">0.0051</td><td align="center">0.0328</td></tr>
    <tr><td align="center">100</td><td align="center">0.0005</td><td align="center">0.0013</td><td align="center">0.0094</td><td align="center">0.0056</td><td align="center">0.0114</td><td align="center">0.0029</td><td align="center">0.0169</td></tr>
    <tr><td align="center">500</td><td align="center">0.0013</td><td align="center">0.0017</td><td align="center">0.0120</td><td align="center">0.0059</td><td align="center">0.0116</td><td align="center">0.0029</td><td align="center">0.0168</td></tr>
    <tr><td align="center">1000</td><td align="center">0.0034</td><td align="center">0.0027</td><td align="center">0.0177</td><td align="center">0.0058</td><td align="center">0.0118</td><td align="center">0.0029</td><td align="center">0.0167</td></tr>
    <tr><td align="center">2000</td><td align="center">0.0146</td><td align="center">0.0075</td><td align="center">0.0436</td><td align="center">0.0059</td><td align="center">0.0120</td><td align="center">0.0029</td><td align="center">0.0165</td></tr>
    <tr><td align="center">5000</td><td align="center">0.1467</td><td align="center">0.0568</td><td align="center">0.2468</td><td align="center">0.0077</td><td align="center">0.0146</td><td align="center">0.0045</td><td align="center">0.0204</td></tr>
    </table>

<details>
<summary>Code used for the test</summary>

```
python3 -m benchmarks.sinkhorn_knopp
```

</details>

## Checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
