### PR TITLE
[MRG] Fix instantiation of `ValFunction` (which raises a warning with PyTorch)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,10 @@
 
 - Better list of related examples in quick start guide with `minigallery` (PR #334)
 
+#### Closed issues
+
+- Bug in instantiating an `autograd` function (`ValFunction`, Issue #337, PR #337)
+
 ## 0.8.1.0
 *December 2021*
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,7 +8,7 @@
 
 #### Closed issues
 
-- Bug in instantiating an `autograd` function (`ValFunction`, Issue #337, PR #337)
+- Bug in instantiating an `autograd` function (`ValFunction`, Issue #337, PR #338)
 
 ## 0.8.1.0
 *December 2021*

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1397,7 +1397,7 @@ class TorchBackend(Backend):
 
     def set_gradients(self, val, inputs, grads):
 
-        Func = self.ValFunction()
+        Func = self.ValFunction
 
         res = Func.apply(val, grads, *inputs)
 


### PR DESCRIPTION


`ValFunction` should not be instantiated since `autograd` functions are
supposed to only ever use static methods. This solves a warning message
raised by PyTorch.

The warning message of PyTorch indicates that this behaviour may raise
an error in future versions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

With PyTorch 1.10.1+cu102, using OT on a `tensor` with a gradient, the following warning message is raised:

> [....] valfunction should not be instantiated. Methods on autograd functions are all static, so you should
> invoke them on the class itself. Instantiating an autograd function will raise an error in a future version
> of PyTorch.

This pull request fixes the instantiation, thus also fixing issue #337.

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

Used my own code with the fork of `POT`. The warning is not raised any more; further behaviour remains exactly the same.

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
