### PR TITLE
[WIP] Build POT against oldest-supported-numpy

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -U "cython"
 
     - name: Install cibuildwheel
       run: |
@@ -37,7 +36,6 @@ jobs:
     - name: Build wheels
       env:
         CIBW_SKIP: "pp*-win* pp*-macosx* cp2* pp* cp36*" # remove pypy on mac and win (wrong version)
-        CIBW_BEFORE_BUILD: "pip install numpy cython"
       run: |
         python -m cibuildwheel --output-dir wheelhouse
 
@@ -81,7 +79,6 @@ jobs:
     - name: Build wheels
       env:
         CIBW_SKIP: "pp*-win* pp*-macosx* cp2* pp* cp*musl* cp36*" # remove pypy on mac and win (wrong version)
-        CIBW_BEFORE_BUILD: "pip install numpy cython"
         CIBW_ARCHS_LINUX: auto aarch64 # force aarch64 with QEMU
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.20", "cython>=0.23"]
+requires = ["setuptools", "wheel", "oldest-supported-nunpy", "cython>=0.23"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy>=1.20
 scipy>=1.3
-cython
 matplotlib
 autograd
 pymanopt==0.2.4; python_version <'3'

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     data_files=[],
     setup_requires=["oldest-supported-numpy", "cython>=0.23"],
     install_requires=["numpy>=1.20", "scipy>=1.0"],
+    python_requires=">=3.7",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -91,7 +92,6 @@ setup(
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     license='MIT',
     scripts=[],
     data_files=[],
-    setup_requires=["numpy>=1.20", "cython>=0.23"],
+    setup_requires=["oldest-supported-numpy", "cython>=0.23"],
     install_requires=["numpy>=1.20", "scipy>=1.0"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Build / setup:
* Compiling against the oldest possible `numpy` version possible given the platform, while also still allowing `numpy>=1.20` to be used
* Removing legacy code workarounds to build-time dependency problems which were fixed by the inclusion of a `pyproject.toml` in https://github.com/PythonOT/POT/pull/293
* Set `python_requires` to `>=3.7`. Python 3.6 support was dropped in [POT release `0.8.1`](https://github.com/PythonOT/POT/releases/tag/0.8.1). This configuration is also necessary to help `oldest-supported-numpy` properly determine what the oldest version of `numpy` it should use during setup.



## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Address #346 



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
