### PR TITLE
[WIP] Add backend dual loss and plan computation for stochastic optimization or regularized OT

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,8 @@
 
 #### New features
 
+- Add stochastic loss and OT plan computation for regularized OT and 
+  backend examples(PR #360).
 - Implementation of factored OT with emd and sinkhorn (PR #358).
 - A brand new logo for POT (PR #357)
 - Better list of related examples in quick start guide with `minigallery` (PR #334).

--- a/examples/backends/plot_dual_ot_pytorch.py
+++ b/examples/backends/plot_dual_ot_pytorch.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+r"""
+======================================================================
+Dual OT solvers for entropic and quadratic regularized OT with Pytorch
+======================================================================
+
+
+"""
+
+# Author: Remi Flamary <remi.flamary@polytechnique.edu>
+#
+# License: MIT License
+
+# sphinx_gallery_thumbnail_number = 3
+
+import numpy as np
+import matplotlib.pyplot as pl
+import torch
+import ot
+import ot.plot
+
+# %%
+# Data generation
+# ---------------
+
+torch.manual_seed(1)
+
+n_source_samples = 100
+n_target_samples = 100
+theta = 2 * np.pi / 20
+noise_level = 0.1
+
+Xs, ys = ot.datasets.make_data_classif(
+    'gaussrot', n_source_samples, nz=noise_level)
+Xt, yt = ot.datasets.make_data_classif(
+    'gaussrot', n_target_samples, theta=theta, nz=noise_level)
+
+# one of the target mode changes its variance (no linear mapping)
+Xt[yt == 2] *= 3
+Xt = Xt + 4
+
+
+# %%
+# Plot data
+# ---------
+
+pl.figure(1, (10, 5))
+pl.clf()
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples')
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples')
+pl.legend(loc=0)
+pl.title('Source and target distributions')
+
+# %%
+# Convert data to torch tensors
+# -----------------------------
+
+xs = torch.tensor(Xs)
+xt = torch.tensor(Xt)
+
+# %%
+# Estimating dual variables for entropic OT
+# -----------------------------------------
+
+u = torch.randn(n_source_samples, requires_grad=True)
+v = torch.randn(n_source_samples, requires_grad=True)
+
+reg=0.5
+
+optimizer = torch.optim.Adam([u,v], lr=1)
+
+# number of iteration 
+n_iter = 200  
+
+
+losses = []
+
+for i in range(n_iter):
+
+    # generate noise samples
+    
+    # minus because we maximize te dual loss
+    loss = -ot.stochastic.loss_dual_entropic(u, v, xs, xt, reg=reg)
+    losses.append(float(loss.detach()))
+
+    if i % 10 == 0:
+        print("Iter: {:3d}, loss={}".format(i, losses[-1]))
+
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+
+
+pl.figure(2)
+pl.plot(losses)
+pl.grid()
+pl.title('Dual objective (negative)')
+pl.xlabel("Iterations")
+
+Ge = ot.stochastic.plan_dual_entropic(u, v, xs, xt, reg=reg)
+
+# %%
+# Plot teh estimated entropic OT plan
+# -----------------------------------
+
+pl.figure(3, (10, 5))
+pl.clf()
+ot.plot.plot2D_samples_mat(Xs, Xt, Ge.detach().numpy(),alpha=0.1)
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2)
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2)
+pl.legend(loc=0)
+pl.title('Source and target distributions')
+
+
+
+# %%
+# Estimating dual variables for quadratic OT
+# -----------------------------------------
+
+u = torch.randn(n_source_samples, requires_grad=True)
+v = torch.randn(n_source_samples, requires_grad=True)
+
+reg=0.01
+
+optimizer = torch.optim.Adam([u,v], lr=1)
+
+# number of iteration 
+n_iter = 200 
+
+
+losses = []
+
+
+for i in range(n_iter):
+
+    # generate noise samples
+    
+    # minus because we maximize te dual loss
+    loss = -ot.stochastic.loss_dual_quadratic(u, v, xs, xt, reg=reg)
+    losses.append(float(loss.detach()))
+
+    if i % 10 == 0:
+        print("Iter: {:3d}, loss={}".format(i, losses[-1]))
+
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+
+
+pl.figure(4)
+pl.plot(losses)
+pl.grid()
+pl.title('Dual objective (negative)')
+pl.xlabel("Iterations")
+
+Gq = ot.stochastic.plan_dual_quadratic(u, v, xs, xt, reg=reg)
+
+
+# %%
+# Plot the estimated quadratic OT plan
+# -----------------------------------
+
+pl.figure(5, (10, 5))
+pl.clf()
+ot.plot.plot2D_samples_mat(Xs, Xt, Gq.detach().numpy(),alpha=0.1)
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2)
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2)
+pl.legend(loc=0)
+pl.title('OT plan with quadratic regularization')

--- a/examples/backends/plot_dual_ot_pytorch.py
+++ b/examples/backends/plot_dual_ot_pytorch.py
@@ -65,12 +65,12 @@ xt = torch.tensor(Xt)
 u = torch.randn(n_source_samples, requires_grad=True)
 v = torch.randn(n_source_samples, requires_grad=True)
 
-reg=0.5
+reg = 0.5
 
-optimizer = torch.optim.Adam([u,v], lr=1)
+optimizer = torch.optim.Adam([u, v], lr=1)
 
-# number of iteration 
-n_iter = 200  
+# number of iteration
+n_iter = 200
 
 
 losses = []
@@ -78,7 +78,7 @@ losses = []
 for i in range(n_iter):
 
     # generate noise samples
-    
+
     # minus because we maximize te dual loss
     loss = -ot.stochastic.loss_dual_entropic(u, v, xs, xt, reg=reg)
     losses.append(float(loss.detach()))
@@ -105,12 +105,11 @@ Ge = ot.stochastic.plan_dual_entropic(u, v, xs, xt, reg=reg)
 
 pl.figure(3, (10, 5))
 pl.clf()
-ot.plot.plot2D_samples_mat(Xs, Xt, Ge.detach().numpy(),alpha=0.1)
+ot.plot.plot2D_samples_mat(Xs, Xt, Ge.detach().numpy(), alpha=0.1)
 pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2)
 pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2)
 pl.legend(loc=0)
 pl.title('Source and target distributions')
-
 
 
 # %%
@@ -120,12 +119,12 @@ pl.title('Source and target distributions')
 u = torch.randn(n_source_samples, requires_grad=True)
 v = torch.randn(n_source_samples, requires_grad=True)
 
-reg=0.01
+reg = 0.01
 
-optimizer = torch.optim.Adam([u,v], lr=1)
+optimizer = torch.optim.Adam([u, v], lr=1)
 
-# number of iteration 
-n_iter = 200 
+# number of iteration
+n_iter = 200
 
 
 losses = []
@@ -134,7 +133,7 @@ losses = []
 for i in range(n_iter):
 
     # generate noise samples
-    
+
     # minus because we maximize te dual loss
     loss = -ot.stochastic.loss_dual_quadratic(u, v, xs, xt, reg=reg)
     losses.append(float(loss.detach()))
@@ -162,7 +161,7 @@ Gq = ot.stochastic.plan_dual_quadratic(u, v, xs, xt, reg=reg)
 
 pl.figure(5, (10, 5))
 pl.clf()
-ot.plot.plot2D_samples_mat(Xs, Xt, Gq.detach().numpy(),alpha=0.1)
+ot.plot.plot2D_samples_mat(Xs, Xt, Gq.detach().numpy(), alpha=0.1)
 pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2)
 pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2)
 pl.legend(loc=0)

--- a/examples/backends/plot_stoch_continuous_ot_pytorch.py
+++ b/examples/backends/plot_stoch_continuous_ot_pytorch.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+r"""
+======================================================================
+Continuous OT plan estimation with Pytorch
+======================================================================
+
+
+"""
+
+# Author: Remi Flamary <remi.flamary@polytechnique.edu>
+#
+# License: MIT License
+
+# sphinx_gallery_thumbnail_number = 3
+
+import numpy as np
+import matplotlib.pyplot as pl
+import matplotlib.animation as animation
+import torch
+from torch import nn
+import ot
+import ot.plot
+
+# %%
+# Data generation
+# ---------------
+
+torch.manual_seed(42)
+np.random.seed(42)
+
+n_source_samples = 300
+n_target_samples = 300
+theta = 2 * np.pi / 20
+noise_level = 0.1
+
+Xs = np.random.randn(n_source_samples, 2) * 0.5
+Xt = np.random.randn(n_target_samples, 2) * 2
+
+# one of the target mode changes its variance (no linear mapping)
+Xt = Xt + 4
+
+
+# %%
+# Plot data
+# ---------
+
+pl.figure(1, (5, 5))
+pl.clf()
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples')
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples')
+pl.legend(loc=0)
+ax_bounds = pl.axis()
+pl.title('Source and target distributions')
+
+# %%
+# Convert data to torch tensors
+# -----------------------------
+
+xs = torch.tensor(Xs)
+xt = torch.tensor(Xt)
+
+# %%
+# Estimating dual variables for entropic OT
+# -----------------------------------------
+
+torch.manual_seed(42)
+
+# define the MLP model
+
+
+class Potential(torch.nn.Module):
+    def __init__(self):
+        super(Potential, self).__init__()
+        self.fc1 = nn.Linear(2, 100)
+        self.fc2 = nn.Linear(100, 1)
+        self.relu = torch.nn.ReLU()  # instead of Heaviside step fn
+
+    def forward(self, x):
+        output = self.fc1(x)
+        output = self.relu(output)  # instead of Heaviside step fn
+        output = self.fc2(output)
+        return output.ravel()
+
+
+u = Potential().double()
+v = Potential().double()
+
+reg = 1
+
+optimizer = torch.optim.Adam(list(u.parameters()) + list(v.parameters()), lr=.005)
+
+# number of iteration
+n_iter = 2000
+
+
+losses = []
+
+for i in range(n_iter):
+
+    # generate noise samples
+
+    # minus because we maximize te dual loss
+    loss = -ot.stochastic.loss_dual_entropic(u(xs), v(xt), xs, xt, reg=reg)
+    losses.append(float(loss.detach()))
+
+    if i % 10 == 0:
+        print("Iter: {:3d}, loss={}".format(i, losses[-1]))
+
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+
+
+pl.figure(2)
+pl.plot(losses)
+pl.grid()
+pl.title('Dual objective (negative)')
+pl.xlabel("Iterations")
+
+Ge = ot.stochastic.plan_dual_entropic(u(xs), v(xt), xs, xt, reg=reg)
+
+# %%
+# Plot teh estimated entropic OT plan
+# -----------------------------------
+
+# pl.figure(3, (5, 5))
+# pl.clf()
+# ot.plot.plot2D_samples_mat(Xs, Xt, Ge.detach().numpy(), alpha=0.1)
+# pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2)
+# pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2)
+# pl.legend(loc=0)
+# ax_bounds = pl.axis()
+# pl.title('Entropic OT plan')
+
+
+#%%
+nv = 100
+xl = np.linspace(ax_bounds[0], ax_bounds[1], nv)
+yl = np.linspace(ax_bounds[2], ax_bounds[3], nv)
+
+XX, YY = np.meshgrid(xl, yl)
+
+xg = np.concatenate((XX.ravel()[:, None], YY.ravel()[:, None]), axis=1)
+
+wxg = np.exp(-((xg[:, 0] - 4)**2 + (xg[:, 1] - 4)**2) / (2 * 2))
+wxg = wxg / np.sum(wxg)
+
+xg = torch.tensor(xg)
+wxg = torch.tensor(wxg)
+
+
+pl.figure(4, (15, 5))
+pl.clf()
+pl.subplot(1, 3, 1)
+
+iv = 0
+Gg = ot.stochastic.plan_dual_entropic(u(xs[iv:iv + 1, :]), v(xg), xs[iv:iv + 1, :], xg, reg=reg, wt=wxg)
+Gg = Gg.reshape((nv, nv)).detach().numpy()
+
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2, alpha=0.1)
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2, alpha=0.1)
+pl.scatter(Xs[iv:iv + 1, 0], Xs[iv:iv + 1, 1], marker='+', label='Source sample', zorder=2, alpha=1, color='C0')
+pl.pcolormesh(XX, YY, Gg, cmap='Blues', label='Density of transported sourec sample')
+pl.legend(loc=0)
+ax_bounds = pl.axis()
+pl.title('Density of transported source sample')
+
+pl.subplot(1, 3, 2)
+
+iv = 1
+Gg = ot.stochastic.plan_dual_entropic(u(xs[iv:iv + 1, :]), v(xg), xs[iv:iv + 1, :], xg, reg=reg, wt=wxg)
+Gg = Gg.reshape((nv, nv)).detach().numpy()
+
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2, alpha=0.1)
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2, alpha=0.1)
+pl.scatter(Xs[iv:iv + 1, 0], Xs[iv:iv + 1, 1], marker='+', label='Source sample', zorder=2, alpha=1, color='C0')
+pl.pcolormesh(XX, YY, Gg, cmap='Blues', label='Density of transported sourec sample')
+pl.legend(loc=0)
+ax_bounds = pl.axis()
+pl.title('Density of transported source sample')
+
+pl.subplot(1, 3, 3)
+
+iv = 6
+Gg = ot.stochastic.plan_dual_entropic(u(xs[iv:iv + 1, :]), v(xg), xs[iv:iv + 1, :], xg, reg=reg, wt=wxg)
+Gg = Gg.reshape((nv, nv)).detach().numpy()
+
+pl.scatter(Xs[:, 0], Xs[:, 1], marker='+', label='Source samples', zorder=2, alpha=0.1)
+pl.scatter(Xt[:, 0], Xt[:, 1], marker='o', label='Target samples', zorder=2, alpha=0.1)
+pl.scatter(Xs[iv:iv + 1, 0], Xs[iv:iv + 1, 1], marker='+', label='Source sample', zorder=2, alpha=1, color='C0')
+pl.pcolormesh(XX, YY, Gg, cmap='Blues', label='Density of transported sourec sample')
+pl.legend(loc=0)
+ax_bounds = pl.axis()
+pl.title('Density of transported source sample')

--- a/examples/backends/plot_stoch_continuous_ot_pytorch.py
+++ b/examples/backends/plot_stoch_continuous_ot_pytorch.py
@@ -70,8 +70,8 @@ torch.manual_seed(42)
 class Potential(torch.nn.Module):
     def __init__(self):
         super(Potential, self).__init__()
-        self.fc1 = nn.Linear(2, 300)
-        self.fc2 = nn.Linear(300, 1)
+        self.fc1 = nn.Linear(2, 200)
+        self.fc2 = nn.Linear(200, 1)
         self.relu = torch.nn.ReLU()  # instead of Heaviside step fn
 
     def forward(self, x):
@@ -86,10 +86,10 @@ v = Potential().double()
 
 reg = 1
 
-optimizer = torch.optim.Adam(list(u.parameters()) + list(v.parameters()), lr=.002)
+optimizer = torch.optim.Adam(list(u.parameters()) + list(v.parameters()), lr=.005)
 
 # number of iteration
-n_iter = 2000
+n_iter = 1000
 n_batch = 500
 
 

--- a/ot/stochastic.py
+++ b/ot/stochastic.py
@@ -4,7 +4,8 @@ Stochastic solvers for regularized OT.
 
 """
 
-# Author: Kilian Fatras <kilian.fatras@gmail.com>
+# Authors: Kilian Fatras <kilian.fatras@gmail.com>
+#          Rémi Flamary <remi.flamary@polytechnique.edu>
 #
 # License: MIT License
 

--- a/ot/stochastic.py
+++ b/ot/stochastic.py
@@ -754,11 +754,11 @@ def solve_dual_entropic(a, b, M, reg, batch_size, numItermax=10000, lr=1,
 # Losses for stochastic optimization
 ################################################################################
 
-def loss_dual_entropic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean'):
+def loss_dual_entropic(u, v, xs, xt, reg=1, ws=None, wt=None, metric='sqeuclidean'):
     r"""
     Compute the dual loss of the entropic OT as in equation (6)-(7) of [19]
 
-    This loss is backend compatible and can be used for stochastic optimization 
+    This loss is backend compatible and can be used for stochastic optimization
     of the dual potentials. It can be used on the full dataset (beware of
     memory) or on minibatches.
 
@@ -794,28 +794,29 @@ def loss_dual_entropic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean')
     .. [19] Seguy, V., Bhushan Damodaran, B., Flamary, R., Courty, N., Rolet, A.& Blondel, M. Large-scale Optimal Transport and Mapping Estimation. International Conference on Learning Representation (2018)
     """
 
-    nx = get_backend(u,v,xs,xt)
+    nx = get_backend(u, v, xs, xt)
 
     if ws is None:
-        ws = nx.ones(xs.shape[0], type_as=xs)/xs.shape[0]
+        ws = nx.ones(xs.shape[0], type_as=xs) / xs.shape[0]
 
     if wt is None:
-        wt = nx.ones(xt.shape[0], type_as=xt)/xt.shape[0] 
+        wt = nx.ones(xt.shape[0], type_as=xt) / xt.shape[0]
 
     if callable(metric):
-        M = metric(xs,xt)
-    else :
-        M = dist(xs,xt,metric=metric)
+        M = metric(xs, xt)
+    else:
+        M = dist(xs, xt, metric=metric)
 
-    F = -reg * nx.exp((u[:,None]+v[None,:]-M)/reg)
+    F = -reg * nx.exp((u[:, None] + v[None, :] - M) / reg)
 
-    return nx.sum(u*ws)+nx.sum(v*wt)+nx.sum(ws[:,None]*F*wt[None,:])
+    return nx.sum(u * ws) + nx.sum(v * wt) + nx.sum(ws[:, None] * F * wt[None, :])
 
-def plan_dual_entropic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean'):
+
+def plan_dual_entropic(u, v, xs, xt, reg=1, ws=None, wt=None, metric='sqeuclidean'):
     r"""
     Compute the primal OT plan the entropic OT as in equation (8) of [19]
 
-    This loss is backend compatible and can be used for stochastic optimization 
+    This loss is backend compatible and can be used for stochastic optimization
     of the dual potentials. It can be used on the full dataset (beware of
     memory) or on minibatches.
 
@@ -851,29 +852,29 @@ def plan_dual_entropic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean')
     .. [19] Seguy, V., Bhushan Damodaran, B., Flamary, R., Courty, N., Rolet, A.& Blondel, M. Large-scale Optimal Transport and Mapping Estimation. International Conference on Learning Representation (2018)
     """
 
-    nx = get_backend(u,v,xs,xt)
+    nx = get_backend(u, v, xs, xt)
 
     if ws is None:
-        ws = nx.ones(xs.shape[0], type_as=xs)/xs.shape[0]
+        ws = nx.ones(xs.shape[0], type_as=xs) / xs.shape[0]
 
     if wt is None:
-        wt = nx.ones(xt.shape[0], type_as=xt)/xt.shape[0] 
+        wt = nx.ones(xt.shape[0], type_as=xt) / xt.shape[0]
 
     if callable(metric):
-        M = metric(xs,xt)
-    else :
-        M = dist(xs,xt,metric=metric)   
+        M = metric(xs, xt)
+    else:
+        M = dist(xs, xt, metric=metric)
 
-    H = nx.exp((u[:,None]+v[None,:]-M)/reg)
+    H = nx.exp((u[:, None] + v[None, :] - M) / reg)
 
-    return ws[:,None]*H*wt[None,:]
+    return ws[:, None] * H * wt[None, :]
 
 
-def loss_dual_quadratic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean'):
+def loss_dual_quadratic(u, v, xs, xt, reg=1, ws=None, wt=None, metric='sqeuclidean'):
     r"""
     Compute the dual loss of the quadratic regularized OT as in equation (6)-(7) of [19]
 
-    This loss is backend compatible and can be used for stochastic optimization 
+    This loss is backend compatible and can be used for stochastic optimization
     of the dual potentials. It can be used on the full dataset (beware of
     memory) or on minibatches.
 
@@ -909,28 +910,29 @@ def loss_dual_quadratic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean'
     .. [19] Seguy, V., Bhushan Damodaran, B., Flamary, R., Courty, N., Rolet, A.& Blondel, M. Large-scale Optimal Transport and Mapping Estimation. International Conference on Learning Representation (2018)
     """
 
-    nx = get_backend(u,v,xs,xt)
+    nx = get_backend(u, v, xs, xt)
 
     if ws is None:
-        ws = nx.ones(xs.shape[0], type_as=xs)/xs.shape[0]
+        ws = nx.ones(xs.shape[0], type_as=xs) / xs.shape[0]
 
     if wt is None:
-        wt = nx.ones(xt.shape[0], type_as=xt)/xt.shape[0] 
+        wt = nx.ones(xt.shape[0], type_as=xt) / xt.shape[0]
 
     if callable(metric):
-        M = metric(xs,xt)
-    else :
-        M = dist(xs,xt,metric=metric)
+        M = metric(xs, xt)
+    else:
+        M = dist(xs, xt, metric=metric)
 
-    F = -1.0/(4*reg)*nx.maximum(u[:,None]+v[None,:]-M,0.0)**2
+    F = -1.0 / (4 * reg) * nx.maximum(u[:, None] + v[None, :] - M, 0.0)**2
 
-    return nx.sum(u*ws)+nx.sum(v*wt)+nx.sum(ws[:,None]*F*wt[None,:])
+    return nx.sum(u * ws) + nx.sum(v * wt) + nx.sum(ws[:, None] * F * wt[None, :])
 
-def plan_dual_quadratic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean'):
+
+def plan_dual_quadratic(u, v, xs, xt, reg=1, ws=None, wt=None, metric='sqeuclidean'):
     r"""
     Compute the primal OT plan the quadratic regularized OT as in equation (8) of [19]
 
-    This loss is backend compatible and can be used for stochastic optimization 
+    This loss is backend compatible and can be used for stochastic optimization
     of the dual potentials. It can be used on the full dataset (beware of
     memory) or on minibatches.
 
@@ -966,19 +968,19 @@ def plan_dual_quadratic(u,v,xs,xt,reg=1, ws=None, wt = None,metric='sqeuclidean'
     .. [19] Seguy, V., Bhushan Damodaran, B., Flamary, R., Courty, N., Rolet, A.& Blondel, M. Large-scale Optimal Transport and Mapping Estimation. International Conference on Learning Representation (2018)
     """
 
-    nx = get_backend(u,v,xs,xt)
+    nx = get_backend(u, v, xs, xt)
 
     if ws is None:
-        ws = nx.ones(xs.shape[0], type_as=xs)/xs.shape[0]
+        ws = nx.ones(xs.shape[0], type_as=xs) / xs.shape[0]
 
     if wt is None:
-        wt = nx.ones(xt.shape[0], type_as=xt)/xt.shape[0] 
+        wt = nx.ones(xt.shape[0], type_as=xt) / xt.shape[0]
 
     if callable(metric):
-        M = metric(xs,xt)
-    else :
-        M = dist(xs,xt,metric=metric)   
+        M = metric(xs, xt)
+    else:
+        M = dist(xs, xt, metric=metric)
 
-    H = 1.0/(2*reg)*nx.maximum(u[:,None]+v[None,:]-M,0.0)
+    H = 1.0 / (2 * reg) * nx.maximum(u[:, None] + v[None, :] - M, 0.0)
 
-    return ws[:,None]*H*wt[None,:]
+    return ws[:, None] * H * wt[None, :]

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -213,3 +213,115 @@ def test_dual_sgd_sinkhorn():
         G_sgd.sum(0), G_sinkhorn.sum(0), atol=1e-03)
     np.testing.assert_allclose(
         G_sgd, G_sinkhorn, atol=1e-03)  # cf convergence sgd
+
+
+
+def test_loss_dual_entropic(nx):
+
+    nx.seed(0)
+
+    xs = nx.randn(50,2)
+    xt = nx.randn(40,2)+2
+
+    ws = nx.rand(50)
+    ws = ws/nx.sum(ws)
+
+    wt = nx.rand(40)
+    wt = wt/nx.sum(wt)
+
+    u = nx.randn(50)
+    v = nx.randn(40)
+
+    def metric(x,y):
+        return -nx.dot(x,y.T)
+
+    ot.stochastic.loss_dual_entropic(u, v, xs, xt)
+
+    ot.stochastic.loss_dual_entropic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+
+
+def test_plan_dual_entropic(nx):
+
+    nx.seed(0)
+
+    xs = nx.randn(50,2)
+    xt = nx.randn(40,2)+2
+
+    ws = nx.rand(50)
+    ws = ws/nx.sum(ws)
+
+    wt = nx.rand(40)
+    wt = wt/nx.sum(wt)
+
+    u = nx.randn(50)
+    v = nx.randn(40)
+
+    def metric(x,y):
+        return -nx.dot(x,y.T)
+
+    G1 = ot.stochastic.plan_dual_entropic(u, v, xs, xt)
+
+    assert np.all(nx.to_numpy(G1)>=0)
+    assert G1.shape[0] == 50
+    assert G1.shape[1] == 40
+
+    G2 = ot.stochastic.plan_dual_entropic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+
+    assert np.all(nx.to_numpy(G2)>=0)
+    assert G2.shape[0] == 50
+    assert G2.shape[1] == 40
+
+def test_loss_dual_quadratic(nx):
+
+    nx.seed(0)
+
+    xs = nx.randn(50,2)
+    xt = nx.randn(40,2)+2
+
+    ws = nx.rand(50)
+    ws = ws/nx.sum(ws)
+
+    wt = nx.rand(40)
+    wt = wt/nx.sum(wt)
+
+    u = nx.randn(50)
+    v = nx.randn(40)
+
+    def metric(x,y):
+        return -nx.dot(x,y.T)
+
+    ot.stochastic.loss_dual_quadratic(u, v, xs, xt)
+
+    ot.stochastic.loss_dual_quadratic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+
+
+def test_plan_dual_quadratic(nx):
+
+    nx.seed(0)
+
+    xs = nx.randn(50,2)
+    xt = nx.randn(40,2)+2
+
+    ws = nx.rand(50)
+    ws = ws/nx.sum(ws)
+
+    wt = nx.rand(40)
+    wt = wt/nx.sum(wt)
+
+    u = nx.randn(50)
+    v = nx.randn(40)
+
+    def metric(x,y):
+        return -nx.dot(x,y.T)
+
+    G1 = ot.stochastic.plan_dual_quadratic(u, v, xs, xt)
+
+    assert np.all(nx.to_numpy(G1)>=0)
+    assert G1.shape[0] == 50
+    assert G1.shape[1] == 40
+
+    G2 = ot.stochastic.plan_dual_quadratic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+
+    assert np.all(nx.to_numpy(G2)>=0)
+    assert G2.shape[0] == 50
+    assert G2.shape[1] == 40

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -215,113 +215,113 @@ def test_dual_sgd_sinkhorn():
         G_sgd, G_sinkhorn, atol=1e-03)  # cf convergence sgd
 
 
-
 def test_loss_dual_entropic(nx):
 
     nx.seed(0)
 
-    xs = nx.randn(50,2)
-    xt = nx.randn(40,2)+2
+    xs = nx.randn(50, 2)
+    xt = nx.randn(40, 2) + 2
 
     ws = nx.rand(50)
-    ws = ws/nx.sum(ws)
+    ws = ws / nx.sum(ws)
 
     wt = nx.rand(40)
-    wt = wt/nx.sum(wt)
+    wt = wt / nx.sum(wt)
 
     u = nx.randn(50)
     v = nx.randn(40)
 
-    def metric(x,y):
-        return -nx.dot(x,y.T)
+    def metric(x, y):
+        return -nx.dot(x, y.T)
 
     ot.stochastic.loss_dual_entropic(u, v, xs, xt)
 
-    ot.stochastic.loss_dual_entropic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+    ot.stochastic.loss_dual_entropic(u, v, xs, xt, ws=ws, wt=wt, metric=metric)
 
 
 def test_plan_dual_entropic(nx):
 
     nx.seed(0)
 
-    xs = nx.randn(50,2)
-    xt = nx.randn(40,2)+2
+    xs = nx.randn(50, 2)
+    xt = nx.randn(40, 2) + 2
 
     ws = nx.rand(50)
-    ws = ws/nx.sum(ws)
+    ws = ws / nx.sum(ws)
 
     wt = nx.rand(40)
-    wt = wt/nx.sum(wt)
+    wt = wt / nx.sum(wt)
 
     u = nx.randn(50)
     v = nx.randn(40)
 
-    def metric(x,y):
-        return -nx.dot(x,y.T)
+    def metric(x, y):
+        return -nx.dot(x, y.T)
 
     G1 = ot.stochastic.plan_dual_entropic(u, v, xs, xt)
 
-    assert np.all(nx.to_numpy(G1)>=0)
+    assert np.all(nx.to_numpy(G1) >= 0)
     assert G1.shape[0] == 50
     assert G1.shape[1] == 40
 
-    G2 = ot.stochastic.plan_dual_entropic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+    G2 = ot.stochastic.plan_dual_entropic(u, v, xs, xt, ws=ws, wt=wt, metric=metric)
 
-    assert np.all(nx.to_numpy(G2)>=0)
+    assert np.all(nx.to_numpy(G2) >= 0)
     assert G2.shape[0] == 50
     assert G2.shape[1] == 40
+
 
 def test_loss_dual_quadratic(nx):
 
     nx.seed(0)
 
-    xs = nx.randn(50,2)
-    xt = nx.randn(40,2)+2
+    xs = nx.randn(50, 2)
+    xt = nx.randn(40, 2) + 2
 
     ws = nx.rand(50)
-    ws = ws/nx.sum(ws)
+    ws = ws / nx.sum(ws)
 
     wt = nx.rand(40)
-    wt = wt/nx.sum(wt)
+    wt = wt / nx.sum(wt)
 
     u = nx.randn(50)
     v = nx.randn(40)
 
-    def metric(x,y):
-        return -nx.dot(x,y.T)
+    def metric(x, y):
+        return -nx.dot(x, y.T)
 
     ot.stochastic.loss_dual_quadratic(u, v, xs, xt)
 
-    ot.stochastic.loss_dual_quadratic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+    ot.stochastic.loss_dual_quadratic(u, v, xs, xt, ws=ws, wt=wt, metric=metric)
 
 
 def test_plan_dual_quadratic(nx):
 
     nx.seed(0)
 
-    xs = nx.randn(50,2)
-    xt = nx.randn(40,2)+2
+    xs = nx.randn(50, 2)
+    xt = nx.randn(40, 2) + 2
 
     ws = nx.rand(50)
-    ws = ws/nx.sum(ws)
+    ws = ws / nx.sum(ws)
 
     wt = nx.rand(40)
-    wt = wt/nx.sum(wt)
+    wt = wt / nx.sum(wt)
 
     u = nx.randn(50)
     v = nx.randn(40)
 
-    def metric(x,y):
-        return -nx.dot(x,y.T)
+    def metric(x, y):
+        return -nx.dot(x, y.T)
 
     G1 = ot.stochastic.plan_dual_quadratic(u, v, xs, xt)
 
-    assert np.all(nx.to_numpy(G1)>=0)
+    assert np.all(nx.to_numpy(G1) >= 0)
     assert G1.shape[0] == 50
     assert G1.shape[1] == 40
 
-    G2 = ot.stochastic.plan_dual_quadratic(u, v, xs, xt, ws=ws, wt = wt, metric=metric)
+    G2 = ot.stochastic.plan_dual_quadratic(u, v, xs, xt, ws=ws, wt=wt, metric=metric)
 
-    assert np.all(nx.to_numpy(G2)>=0)
+    assert np.all(nx.to_numpy(G2) >= 0)
     assert G2.shape[0] == 50
     assert G2.shape[1] == 40

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -8,7 +8,8 @@ for descrete and semicontinous measures from the POT library.
 
 """
 
-# Author: Kilian Fatras <kilian.fatras@gmail.com>
+# Authors: Kilian Fatras <kilian.fatras@gmail.com>
+#          Rémi Flamary <remi.flamary@polytechnique.edu>
 #
 # License: MIT License
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->



## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Add differentiable losses for stochastic optimization of entropic and quadratic OT and functions to recover the OT plkan thanks to the primal-dual relations.

Adds two exmapels of use of those  functions:
+ [Dual OT solvers for entropic and quadratic regularized OT with Pytorch](https://output.circle-artifacts.com/output/job/9d1e10e8-3efa-4d04-9146-886824b2c866/artifacts/0/dev/auto_examples/backends/plot_dual_ot_pytorch.html#sphx-glr-auto-examples-backends-plot-dual-ot-pytorch-py)
+ [Continuous OT plan estimation with Pytorch](https://output.circle-artifacts.com/output/job/9d1e10e8-3efa-4d04-9146-886824b2c866/artifacts/0/dev/auto_examples/backends/plot_stoch_continuous_ot_pytorch.html#sphx-glr-auto-examples-backends-plot-stoch-continuous-ot-pytorch-py)

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
