### PR TITLE
[WIP] Silence std::cerr calls inside of python

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,8 @@
 
 - Fixed an issue where we could not ask TorchBackend to place a random tensor on GPU
   (Issue #371, PR #373)
+- Fixed an issue where hitting iteration limits would be reported to stderr by std::cerr regardless of Python's stderr stream status.
+
 
 ## 0.8.2
 

--- a/ot/lp/network_simplex_simple.h
+++ b/ot/lp/network_simplex_simple.h
@@ -1432,9 +1432,7 @@ namespace lemon {
             // Execute the Network Simplex algorithm
             while (pivot.findEnteringArc()) {
                 if(max_iter > 0 && ++iter_number>=max_iter&&max_iter>0){
-                    char errMess[1000];
-                    sprintf( errMess, "RESULT MIGHT BE INACURATE\nMax number of iteration reached, currently \%d. Sometimes iterations go on in cycle even though the solution has been reached, to check if it's the case here have a look at the minimal reduced cost. If it is very close to machine precision, you might actually have the correct solution, if not try setting the maximum number of iterations a bit higher\n",iter_number );
-                    std::cerr << errMess;
+                    // max iterations hit
 					retVal = MAX_ITER_REACHED;
                     break;
                 }

--- a/ot/lp/network_simplex_simple_omp.h
+++ b/ot/lp/network_simplex_simple_omp.h
@@ -1610,9 +1610,7 @@ namespace lemon_omp {
 
 
 				} else {
-					char errMess[1000];
-					sprintf( errMess, "RESULT MIGHT BE INACURATE\nMax number of iteration reached, currently \%d. Sometimes iterations go on in cycle even though the solution has been reached, to check if it's the case here have a look at the minimal reduced cost. If it is very close to machine precision, you might actually have the correct solution, if not try setting the maximum number of iterations a bit higher\n",iter_number );
-					std::cerr << errMess;
+					// max iters
 					retVal =  MAX_ITER_REACHED;
 					break;
 				}


### PR DESCRIPTION

## Types of changes
Adds flags to disable std::cerr reporting in the cpp backend. Adds parameter `ot.backend.use_cerr` as parameter and `ot.backend.get_cerr()` getter to enable/disable `cerr` reporting inside of python. The parameter defaults to False.


## Motivation and context / Related issue
We are using POT inside of jupyter notebook and running into a problem that hits its iter limits. The warnings flood our console. Because the backend code is calling std::cerr directly, rather than passing the error string up to the python stderr stream, traditional context management based redirection (or simply killing sys.stderr inside of python)  does not work.



## How has this been tested (if it applies)
Have tested the basic use case and enable/disabling the cerr. Works in ipython on 3.9.7.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x ] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
