### PR TITLE
[WIP] raise error if mass mismatch in emd2

### DIFF
--- a/ot/lp/__init__.py
+++ b/ot/lp/__init__.py
@@ -483,6 +483,11 @@ def emd2(a, b, M, processes=1,
     assert (a.shape[0] == M.shape[0] and b.shape[0] == M.shape[1]), \
         "Dimension mismatch, check dimensions of M with a and b"
 
+    # ensure that same mass
+    np.testing.assert_almost_equal(a.sum(0),
+                                   b.sum(0), err_msg='a and b vector must have the same sum')
+    b = b * a.sum() / b.sum()
+
     asel = a != 0
 
     numThreads = check_number_threads(numThreads)

--- a/ot/lp/__init__.py
+++ b/ot/lp/__init__.py
@@ -483,17 +483,17 @@ def emd2(a, b, M, processes=1,
     assert (a.shape[0] == M.shape[0] and b.shape[0] == M.shape[1]), \
         "Dimension mismatch, check dimensions of M with a and b"
 
-    # ensure that same mass
-    np.testing.assert_almost_equal(a.sum(0),
-                                   b.sum(0), err_msg='a and b vector must have the same sum')
-    b = b * a.sum() / b.sum()
-
     asel = a != 0
 
     numThreads = check_number_threads(numThreads)
 
     if log or return_matrix:
         def f(b):
+            # ensure that same mass
+            np.testing.assert_almost_equal(a.sum(0),
+                                           b.sum(0), err_msg='a and b vector must have the same sum')
+            b = b * a.sum() / b.sum()
+
             bsel = b != 0
 
             G, cost, u, v, result_code = emd_c(a, b, M, numItermax, numThreads)
@@ -526,6 +526,11 @@ def emd2(a, b, M, processes=1,
             return [cost, log]
     else:
         def f(b):
+            # ensure that same mass
+            np.testing.assert_almost_equal(a.sum(0),
+                                           b.sum(0), err_msg='a and b vector must have the same sum')
+            b = b * a.sum() / b.sum()
+
             bsel = b != 0
             G, cost, u, v, result_code = emd_c(a, b, M, numItermax, numThreads)
 

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -29,9 +29,12 @@ def test_emd_dimension_and_mass_mismatch():
 
     np.testing.assert_raises(AssertionError, ot.emd2, a, a, M)
 
+    # test emd and emd2 for mass mismatch
+    a = ot.utils.unif(n_samples)
     b = a.copy()
     a[0] = 100
     np.testing.assert_raises(AssertionError, ot.emd, a, b, M)
+    np.testing.assert_raises(AssertionError, ot.emd2, a, b, M)
 
 
 def test_emd_backends(nx):


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Add a test on the masses of the distributions in emd2. If the histograms (a and b) do not have the same sum (up to a certain precision), an AssertionError is raised. 
- The sum of the target histogram (b) is adjusted to match the sum of the source histogram (a).


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
