### PR TITLE
[WIP] Crash when computing weightless Hamming distance

### DIFF
--- a/ot/utils.py
+++ b/ot/utils.py
@@ -234,7 +234,9 @@ def dist(x1, x2=None, metric='sqeuclidean', p=2, w=None):
         else:
             if isinstance(metric, str) and metric.endswith("minkowski"):
                 return cdist(x1, x2, metric=metric, p=p, w=w)
-            return cdist(x1, x2, metric=metric, w=w)
+            if w is not None:
+                return cdist(x1, x2, metric=metric, w=w)
+            return cdist(x1, x2, metric=metric)
 
 
 def dist0(n, method='lin_square'):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -143,6 +143,7 @@ def test_dist():
     for metric in metrics_w:
         print(metric)
         ot.dist(x, x, metric=metric, p=3, w=np.random.random((2, )))
+        ot.dist(x, x, metric=metric, p=3, w=None) # check that not having any weight does not cause issues
     for metric in metrics:
         print(metric)
         ot.dist(x, x, metric=metric, p=3)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
The issue definitely comes from a bug in scipy's code and not ours. Anyway, here's a workaround, for when scipy gets fixed.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Resolves #400.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
Tested on Jean Zay.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
