### PR TITLE
[MRG] Replaces numpy compiler with setuptools

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,7 @@ roughly 2^31) (PR #381)
 - Fixed an issue where a pytorch example would throw an error if executed on a GPU (Issue #389, PR #391)
 - Added a work-around for scipy's bug, where you cannot compute the Hamming distance with a "None" weight attribute. (Issue #400, PR #402)
 - Fixed an issue where the doc could not be built due to some changes in matplotlib's API (Issue #403, PR #402)
+- Replaced Numpy C Compiler with Setuptools C Compiler due to deprecation issues (Issue #408, PR #409)
 
 
 ## 0.8.2

--- a/ot/helpers/pre_build_helpers.py
+++ b/ot/helpers/pre_build_helpers.py
@@ -4,34 +4,14 @@ import os
 import sys
 import glob
 import tempfile
-import setuptools  # noqa
 import subprocess
 
-from distutils.dist import Distribution
-from distutils.sysconfig import customize_compiler
-from numpy.distutils.ccompiler import new_compiler
-from numpy.distutils.command.config_compiler import config_cc
+from setuptools.command.build_ext import customize_compiler, new_compiler
 
 
 def _get_compiler():
-    """Get a compiler equivalent to the one that will be used to build POT
-    Handles compiler specified as follows:
-        - python setup.py build_ext --compiler=<compiler>
-        - CC=<compiler> python setup.py build_ext
-    """
-    dist = Distribution({'script_name': os.path.basename(sys.argv[0]),
-                         'script_args': sys.argv[1:],
-                         'cmdclass': {'config_cc': config_cc}})
-
-    cmd_opts = dist.command_options.get('build_ext')
-    if cmd_opts is not None and 'compiler' in cmd_opts:
-        compiler = cmd_opts['compiler'][1]
-    else:
-        compiler = None
-
-    ccompiler = new_compiler(compiler=compiler)
+    ccompiler = new_compiler()
     customize_compiler(ccompiler)
-
     return ccompiler
 
 

--- a/ot/lp/network_simplex_simple_omp.h
+++ b/ot/lp/network_simplex_simple_omp.h
@@ -268,7 +268,6 @@ namespace lemon_omp {
             omp_set_num_threads(num_threads);
 #else
             num_threads = 1;
-			printf("%d\n", 1 / 0);
 #endif
 		}
 

--- a/ot/lp/network_simplex_simple_omp.h
+++ b/ot/lp/network_simplex_simple_omp.h
@@ -67,7 +67,7 @@
 //#include "core.h"
 //#include "lmath.h"
 
-#ifdef OMP
+#ifdef _OPENMP
 #include <omp.h>
 #endif
 #include <cmath>
@@ -254,7 +254,7 @@ namespace lemon_omp {
 			// Reset data structures
 			reset();
 			max_iter = maxiters;
-#ifdef OMP
+#ifdef _OPENMP
             if (max_threads < 0) {
                 max_threads = omp_get_max_threads();
             }
@@ -268,6 +268,7 @@ namespace lemon_omp {
             omp_set_num_threads(num_threads);
 #else
             num_threads = 1;
+			printf("%d\n", 1 / 0);
 #endif
 		}
 
@@ -513,7 +514,7 @@ namespace lemon_omp {
 					int j;
 #pragma omp parallel
 					{
-#ifdef OMP
+#ifdef _OPENMP
 						int t = omp_get_thread_num();
 #else
 						int t = 0;

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ compile_args = ["/O2" if sys.platform == "win32" else "-O3"]
 link_args = []
 
 if openmp_supported:
-    compile_args += flags + ["/DOMP" if sys.platform == 'win32' else "-DOMP"]
+    compile_args += flags
     link_args += flags
 
 if sys.platform.startswith('darwin'):

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -204,6 +204,22 @@ def test_emd_emd2():
     np.testing.assert_allclose(w, 0)
 
 
+def test_omp_emd2():
+    # test emd2 and emd2 with openmp for simple identity
+    n = 100
+    rng = np.random.RandomState(0)
+
+    x = rng.randn(n, 2)
+    u = ot.utils.unif(n)
+
+    M = ot.dist(x, x)
+
+    w = ot.emd2(u, u, M)
+    w2 = ot.emd2(u, u, M, numThreads=2)
+
+    np.testing.assert_allclose(w, w2)
+
+
 def test_emd_empty():
     # test emd and emd2 for simple identity
     n = 100


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Removes numpy ccompiler dependency. Replaces it with setuptools. The solution is based on scikit-learn (https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/_build_utils/pre_build_helpers.py)


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Resolves #408.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
