### PR TITLE
Change the number of projection to match the predefined case

### DIFF
--- a/ot/sliced.py
+++ b/ot/sliced.py
@@ -147,6 +147,8 @@ def sliced_wasserstein_distance(X_s, X_t, a=None, b=None, n_projections=50, p=2,
 
     if projections is None:
         projections = get_random_projections(d, n_projections, seed, backend=nx, type_as=X_s)
+    else:
+        n_projections = projections.shape[1]
 
     X_s_projections = nx.dot(X_s, projections)
     X_t_projections = nx.dot(X_t, projections)

--- a/test/test_sliced.py
+++ b/test/test_sliced.py
@@ -110,6 +110,20 @@ def test_max_sliced_different_dists():
     assert res > 0.
 
 
+def test_sliced_same_proj():
+    n_projections = 10
+    seed = 12
+    rng = np.random.RandomState(0)
+    X = rng.randn(8, 2)
+    Y = rng.randn(8, 2)
+    cost1, log1 = ot.sliced_wasserstein_distance(X, Y, seed=seed, n_projections=n_projections, log=True)
+    P = get_random_projections(X.shape[1], n_projections=10, seed=seed)
+    cost2, log2 = ot.sliced_wasserstein_distance(X, Y, projections=P, log=True)
+
+    assert np.allclose(log1['projections'], log2['projections'])
+    assert np.isclose(cost1, cost2)
+
+
 def test_sliced_backend(nx):
 
     n = 100


### PR DESCRIPTION
I changed the number of projections for ```ot.sliced.sliced_wasserstein_distance``` when the parameter ```projections```of the function is not ```None``` (i.e. when we predefine a projection matrix for the sliced Wasserstein distance). I have also added a test function that verify that the two projections are the same when using predefined projections or random ones with the same seed. 

Closes #418 
