### PR TITLE
[MRG] Fix#421 pass stopThr to the sinkhorn function in empirical_sinkhorn_divergence

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -32,6 +32,7 @@ roughly 2^31) (PR #381)
 - Fixed weak optimal transport docstring (Issue #404, PR #410)
 - Fixed error whith parameter `log=True`for `SinkhornLpl1Transport` (Issue #412, 
 PR #413)
+- Fix an issue where the parameter `stopThr` in `empirical_sinkhorn_divergence` was rendered useless by subcalls that explicitly specified `stopThr=1e-9` (Issue #421).
 
 ## 0.8.2
 

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -1278,7 +1278,7 @@ def sinkhorn_epsilon_scaling(a, b, M, reg, numItermax=100, epsilon0=1e4,
         regi = get_reg(ii)
 
         G, logi = sinkhorn_stabilized(a, b, M, regi,
-                                      numItermax=numInnerItermax, stopThr=1e-9,
+                                      numItermax=numInnerItermax, stopThr=stopThr,
                                       warmstart=(alpha, beta), verbose=False,
                                       print_period=20, tau=tau, log=True)
 
@@ -3293,17 +3293,17 @@ def empirical_sinkhorn_divergence(X_s, X_t, reg, a=None, b=None, metric='sqeucli
     if log:
         sinkhorn_loss_ab, log_ab = empirical_sinkhorn2(X_s, X_t, reg, a, b, metric=metric,
                                                        numIterMax=numIterMax,
-                                                       stopThr=1e-9, verbose=verbose,
+                                                       stopThr=stopThr, verbose=verbose,
                                                        log=log, warn=warn, **kwargs)
 
         sinkhorn_loss_a, log_a = empirical_sinkhorn2(X_s, X_s, reg, a, a, metric=metric,
                                                      numIterMax=numIterMax,
-                                                     stopThr=1e-9, verbose=verbose,
+                                                     stopThr=stopThr, verbose=verbose,
                                                      log=log, warn=warn, **kwargs)
 
         sinkhorn_loss_b, log_b = empirical_sinkhorn2(X_t, X_t, reg, b, b, metric=metric,
                                                      numIterMax=numIterMax,
-                                                     stopThr=1e-9, verbose=verbose,
+                                                     stopThr=stopThr, verbose=verbose,
                                                      log=log, warn=warn, **kwargs)
 
         sinkhorn_div = sinkhorn_loss_ab - 0.5 * (sinkhorn_loss_a + sinkhorn_loss_b)
@@ -3320,17 +3320,17 @@ def empirical_sinkhorn_divergence(X_s, X_t, reg, a=None, b=None, metric='sqeucli
 
     else:
         sinkhorn_loss_ab = empirical_sinkhorn2(X_s, X_t, reg, a, b, metric=metric,
-                                               numIterMax=numIterMax, stopThr=1e-9,
+                                               numIterMax=numIterMax, stopThr=stopThr,
                                                verbose=verbose, log=log,
                                                warn=warn, **kwargs)
 
         sinkhorn_loss_a = empirical_sinkhorn2(X_s, X_s, reg, a, a, metric=metric,
-                                              numIterMax=numIterMax, stopThr=1e-9,
+                                              numIterMax=numIterMax, stopThr=stopThr,
                                               verbose=verbose, log=log,
                                               warn=warn, **kwargs)
 
         sinkhorn_loss_b = empirical_sinkhorn2(X_t, X_t, reg, b, b, metric=metric,
-                                              numIterMax=numIterMax, stopThr=1e-9,
+                                              numIterMax=numIterMax, stopThr=stopThr,
                                               verbose=verbose, log=log,
                                               warn=warn, **kwargs)
 


### PR DESCRIPTION
## Types of changes

Variable default values. 

## Motivation and context / Related issue

Fix small typo in the code, where the parameter `stopThr` in `empirical_sinkhorn_divergence` was useless because subcalls used `stopThr=1e-9` instead of `stopThr=stopThr`. 

Same for a similar instance occuring in `sinkhorn_epsilon_scaling`. 

Documented in Issue #421 .



## PR checklist

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.
