### PR TITLE
[MRG] OT for Gaussian distributions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ The contributors to this library are:
 * [Eloi Tanguy](https://github.com/eloitanguy) (Generalized Wasserstein Barycenters)
 * [Camille Le Coz](https://www.linkedin.com/in/camille-le-coz-8593b91a1/) (EMD2 debug)
 * [Eduardo Fernandes Montesuma](https://eddardd.github.io/my-personal-blog/) (Free support sinkhorn barycenter)
+* [Theo Gnassounou](https://github.com/tgnassou) (OT between Gaussian distributions)
 
 ## Acknowledgments
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 #### New features
 
+- Added Bures Wasserstein distance in `ot.gaussian` (PR ##428)
 - Added Generalized Wasserstein Barycenter solver + example (PR #372), fixed graphical details on the example (PR #376)
 - Added Free Support Sinkhorn Barycenter + example (PR #387)
 - New API for OT solver using function `ot.solve` (PR #388)

--- a/docs/source/all.rst
+++ b/docs/source/all.rst
@@ -31,6 +31,7 @@ API and modules
    sliced
    weak
    factored
+   gaussian
 
 .. autosummary::
    :toctree: ../modules/generated/

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -279,7 +279,7 @@ distributions. In this case there exists a close form solution given in Remark
 2.29 in [15]_ and the Monge mapping is an affine function and can be
 also computed from the covariances and means of the source and target
 distributions. In the case when the finite sample dataset is supposed Gaussian,
-we provide :any:`ot.da.OT_mapping_linear` that returns the parameters for the
+we provide :any:`ot.gaussian.bures_wasserstein_mapping` that returns the parameters for the
 Monge mapping.
 
 
@@ -628,7 +628,7 @@ approximate a Monge mapping from finite distributions.
 First note that when the source and target distributions are supposed to be Gaussian
 distributions, there exists a close form solution for the mapping and its an
 affine function [14]_ of the form :math:`T(x)=Ax+b` . In this case we provide the function
-:any:`ot.da.OT_mapping_linear` that returns the operator :math:`A` and vector
+:any:`ot.gaussian.bures_wasserstein_mapping` that returns the operator :math:`A` and vector
 :math:`b`. Note that if the number of samples is too small there is a parameter
 :code:`reg` that provides a regularization for the covariance matrix estimation.
 
@@ -640,7 +640,7 @@ method proposed in [8]_ that estimates a continuous mapping approximating the
 barycentric mapping is provided in :any:`ot.da.joint_OT_mapping_linear` for
 linear mapping and :any:`ot.da.joint_OT_mapping_kernel` for non-linear mapping.
 
-.. minigallery:: ot.da.joint_OT_mapping_linear ot.da.joint_OT_mapping_linear ot.da.OT_mapping_linear
+.. minigallery:: ot.da.joint_OT_mapping_linear ot.da.joint_OT_mapping_linear ot.gaussian.bures_wasserstein_mapping
     :add-heading: Examples of Monge mapping estimation
     :heading-level: "
 

--- a/examples/domain-adaptation/plot_otda_linear_mapping.py
+++ b/examples/domain-adaptation/plot_otda_linear_mapping.py
@@ -61,7 +61,7 @@ plt.plot(xt[:, 0], xt[:, 1], 'o')
 # Estimate linear mapping and transport
 # -------------------------------------
 
-Ae, be = ot.gaussian.bures_wasserstein_mapping(xs, xt)
+Ae, be = ot.gaussian.empirical_bures_wasserstein_mapping(xs, xt)
 
 xst = xs.dot(Ae) + be
 

--- a/examples/domain-adaptation/plot_otda_linear_mapping.py
+++ b/examples/domain-adaptation/plot_otda_linear_mapping.py
@@ -61,7 +61,7 @@ plt.plot(xt[:, 0], xt[:, 1], 'o')
 # Estimate linear mapping and transport
 # -------------------------------------
 
-Ae, be = ot.da.OT_mapping_linear(xs, xt)
+Ae, be = ot.gaussian.bures_wasserstein_mapping(xs, xt)
 
 xst = xs.dot(Ae) + be
 

--- a/examples/gromov/plot_barycenter_fgw.py
+++ b/examples/gromov/plot_barycenter_fgw.py
@@ -174,7 +174,7 @@ A, C, log = fgw_barycenters(sizebary, Ys, Cs, ps, lambdas, alpha=0.95, log=True)
 # -------------------------
 
 #%% Create the barycenter
-bary = nx.from_numpy_matrix(sp_to_adjency(C, threshinf=0, threshsup=find_thresh(C, sup=100, step=100)[0]))
+bary = nx.from_numpy_array(sp_to_adjency(C, threshinf=0, threshsup=find_thresh(C, sup=100, step=100)[0]))
 for i, v in enumerate(A.ravel()):
     bary.add_node(i, attr_name=v)
 

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -65,4 +65,5 @@ __all__ = ['emd', 'emd2', 'emd_1d', 'sinkhorn', 'sinkhorn2', 'utils',
            'gromov_wasserstein', 'gromov_wasserstein2', 'gromov_barycenters', 'fused_gromov_wasserstein', 'fused_gromov_wasserstein2',
             'max_sliced_wasserstein_distance', 'weak_optimal_transport',
             'factored_optimal_transport', 'solve',
-           'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers', 'bures_wasserstein_distance']
+           'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers',
+           'bures_wasserstein_distance', 'empirical_bures_wasserstein_distance']

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -35,6 +35,7 @@ from . import regpath
 from . import weak
 from . import factored
 from . import solvers
+from . import gaussian
 
 # OT functions
 from .lp import emd, emd2, emd_1d, emd2_1d, wasserstein_1d
@@ -48,6 +49,7 @@ from .gromov import (gromov_wasserstein, gromov_wasserstein2,
 from .weak import weak_optimal_transport
 from .factored import factored_optimal_transport
 from .solvers import solve
+from .gaussian import bures_wasserstein_distance
 
 # utils functions
 from .utils import dist, unif, tic, toc, toq
@@ -63,4 +65,4 @@ __all__ = ['emd', 'emd2', 'emd_1d', 'sinkhorn', 'sinkhorn2', 'utils',
            'gromov_wasserstein', 'gromov_wasserstein2', 'gromov_barycenters', 'fused_gromov_wasserstein', 'fused_gromov_wasserstein2',
             'max_sliced_wasserstein_distance', 'weak_optimal_transport',
             'factored_optimal_transport', 'solve',
-           'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers']
+           'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers', 'bures_wasserstein_distance']

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -49,7 +49,6 @@ from .gromov import (gromov_wasserstein, gromov_wasserstein2,
 from .weak import weak_optimal_transport
 from .factored import factored_optimal_transport
 from .solvers import solve
-from .gaussian import bures_wasserstein_distance
 
 # utils functions
 from .utils import dist, unif, tic, toc, toq
@@ -58,12 +57,11 @@ __version__ = "0.8.3dev"
 
 __all__ = ['emd', 'emd2', 'emd_1d', 'sinkhorn', 'sinkhorn2', 'utils',
            'datasets', 'bregman', 'lp', 'tic', 'toc', 'toq', 'gromov',
-           'emd2_1d', 'wasserstein_1d', 'backend',
+           'emd2_1d', 'wasserstein_1d', 'backend', 'gaussian',
            'dist', 'unif', 'barycenter', 'sinkhorn_lpl1_mm', 'da', 'optim',
            'sinkhorn_unbalanced', 'barycenter_unbalanced',
            'sinkhorn_unbalanced2', 'sliced_wasserstein_distance',
            'gromov_wasserstein', 'gromov_wasserstein2', 'gromov_barycenters', 'fused_gromov_wasserstein', 'fused_gromov_wasserstein2',
             'max_sliced_wasserstein_distance', 'weak_optimal_transport',
             'factored_optimal_transport', 'solve',
-           'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers',
-           'bures_wasserstein_distance', 'empirical_bures_wasserstein_distance']
+           'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers']

--- a/ot/da.py
+++ b/ot/da.py
@@ -19,7 +19,7 @@ from .lp import emd
 from .utils import unif, dist, kernel, cost_normalization, label_normalization, laplacian, dots
 from .utils import list_to_array, check_params, BaseEstimator
 from .unbalanced import sinkhorn_unbalanced
-from .gaussian import OT_mapping_linear
+from .gaussian import empirical_bures_wasserstein_mapping
 from .optim import cg
 from .optim import gcg
 
@@ -1271,10 +1271,10 @@ class LinearTransport(BaseTransport):
         self.mu_t = self.distribution_estimation(Xt)
 
         # coupling estimation
-        returned_ = OT_mapping_linear(Xs, Xt, reg=self.reg,
-                                      ws=nx.reshape(self.mu_s, (-1, 1)),
-                                      wt=nx.reshape(self.mu_t, (-1, 1)),
-                                      bias=self.bias, log=self.log)
+        returned_ = empirical_bures_wasserstein_mapping(Xs, Xt, reg=self.reg,
+                                                        ws=nx.reshape(self.mu_s, (-1, 1)),
+                                                        wt=nx.reshape(self.mu_t, (-1, 1)),
+                                                        bias=self.bias, log=self.log)
 
         # deal with the value of log
         if self.log:

--- a/ot/da.py
+++ b/ot/da.py
@@ -17,7 +17,7 @@ from .backend import get_backend
 from .bregman import sinkhorn, jcpot_barycenter
 from .lp import emd
 from .utils import unif, dist, kernel, cost_normalization, label_normalization, laplacian, dots
-from .utils import list_to_array, check_params, BaseEstimator
+from .utils import list_to_array, check_params, BaseEstimator, deprecated
 from .unbalanced import sinkhorn_unbalanced
 from .gaussian import empirical_bures_wasserstein_mapping
 from .optim import cg
@@ -678,6 +678,14 @@ def joint_OT_mapping_kernel(xs, xt, mu=1, eta=0.001, kerneltype='gaussian',
         return G, L, log
     else:
         return G, L
+
+
+@deprecated()
+def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
+                      wt=None, bias=True, log=False):
+    """ Deprecated see  ot.gaussian.empirical_bures_wasserstein_mapping"""
+    return empirical_bures_wasserstein_mapping(xs, xt, reg=1e-6, ws=None,
+                                               wt=None, bias=True, log=False)
 
 
 def emd_laplace(a, b, xs, xt, M, sim='knn', sim_param=None, reg='pos', eta=1, alpha=.5,

--- a/ot/da.py
+++ b/ot/da.py
@@ -19,6 +19,7 @@ from .lp import emd
 from .utils import unif, dist, kernel, cost_normalization, label_normalization, laplacian, dots
 from .utils import list_to_array, check_params, BaseEstimator
 from .unbalanced import sinkhorn_unbalanced
+from .gaussian import OT_mapping_linear
 from .optim import cg
 from .optim import gcg
 
@@ -677,114 +678,6 @@ def joint_OT_mapping_kernel(xs, xt, mu=1, eta=0.001, kerneltype='gaussian',
         return G, L, log
     else:
         return G, L
-
-
-def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
-                      wt=None, bias=True, log=False):
-    r"""Return OT linear operator between samples.
-
-    The function estimates the optimal linear operator that aligns the two
-    empirical distributions. This is equivalent to estimating the closed
-    form mapping between two Gaussian distributions :math:`\mathcal{N}(\mu_s,\Sigma_s)`
-    and :math:`\mathcal{N}(\mu_t,\Sigma_t)` as proposed in
-    :ref:`[14] <references-OT-mapping-linear>` and discussed in remark 2.29 in
-    :ref:`[15] <references-OT-mapping-linear>`.
-
-    The linear operator from source to target :math:`M`
-
-    .. math::
-        M(\mathbf{x})= \mathbf{A} \mathbf{x} + \mathbf{b}
-
-    where :
-
-    .. math::
-        \mathbf{A} &= \Sigma_s^{-1/2} \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
-        \Sigma_s^{-1/2}
-
-        \mathbf{b} &= \mu_t - \mathbf{A} \mu_s
-
-    Parameters
-    ----------
-    xs : array-like (ns,d)
-        samples in the source domain
-    xt : array-like (nt,d)
-        samples in the target domain
-    reg : float,optional
-        regularization added to the diagonals of covariances (>0)
-    ws : array-like (ns,1), optional
-        weights for the source samples
-    wt : array-like (ns,1), optional
-        weights for the target samples
-    bias: boolean, optional
-        estimate bias :math:`\mathbf{b}` else :math:`\mathbf{b} = 0` (default:True)
-    log : bool, optional
-        record log if True
-
-
-    Returns
-    -------
-    A : (d, d) array-like
-        Linear operator
-    b : (1, d) array-like
-        bias
-    log : dict
-        log dictionary return only if log==True in parameters
-
-
-    .. _references-OT-mapping-linear:
-    References
-    ----------
-    .. [14] Knott, M. and Smith, C. S. "On the optimal mapping of
-        distributions", Journal of Optimization Theory and Applications
-        Vol 43, 1984
-
-    .. [15] Peyré, G., & Cuturi, M. (2017). "Computational Optimal
-        Transport", 2018.
-
-
-    """
-    xs, xt = list_to_array(xs, xt)
-    nx = get_backend(xs, xt)
-
-    d = xs.shape[1]
-
-    if bias:
-        mxs = nx.mean(xs, axis=0)[None, :]
-        mxt = nx.mean(xt, axis=0)[None, :]
-
-        xs = xs - mxs
-        xt = xt - mxt
-    else:
-        mxs = nx.zeros((1, d), type_as=xs)
-        mxt = nx.zeros((1, d), type_as=xs)
-
-    if ws is None:
-        ws = nx.ones((xs.shape[0], 1), type_as=xs) / xs.shape[0]
-
-    if wt is None:
-        wt = nx.ones((xt.shape[0], 1), type_as=xt) / xt.shape[0]
-
-    Cs = nx.dot((xs * ws).T, xs) / nx.sum(ws) + reg * nx.eye(d, type_as=xs)
-    Ct = nx.dot((xt * wt).T, xt) / nx.sum(wt) + reg * nx.eye(d, type_as=xt)
-
-    Cs12 = nx.sqrtm(Cs)
-    Cs_12 = nx.inv(Cs12)
-
-    M0 = nx.sqrtm(dots(Cs12, Ct, Cs12))
-
-    A = dots(Cs_12, M0, Cs_12)
-
-    b = mxt - nx.dot(mxs, A)
-
-    if log:
-        log = {}
-        log['Cs'] = Cs
-        log['Ct'] = Ct
-        log['Cs12'] = Cs12
-        log['Cs_12'] = Cs_12
-        return A, b, log
-    else:
-        return A, b
 
 
 def emd_laplace(a, b, xs, xt, M, sim='knn', sim_param=None, reg='pos', eta=1, alpha=.5,

--- a/ot/da.py
+++ b/ot/da.py
@@ -680,12 +680,7 @@ def joint_OT_mapping_kernel(xs, xt, mu=1, eta=0.001, kerneltype='gaussian',
         return G, L
 
 
-@deprecated()
-def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
-                      wt=None, bias=True, log=False):
-    """ Deprecated see  ot.gaussian.empirical_bures_wasserstein_mapping"""
-    return empirical_bures_wasserstein_mapping(xs, xt, reg=1e-6, ws=None,
-                                               wt=None, bias=True, log=False)
+OT_mapping_linear = deprecated(empirical_bures_wasserstein_mapping)
 
 
 def emd_laplace(a, b, xs, xt, M, sim='knn', sim_param=None, reg='pos', eta=1, alpha=.5,

--- a/ot/datasets.py
+++ b/ot/datasets.py
@@ -40,6 +40,34 @@ def get_1D_gauss(n, m, sigma):
     return make_1D_gauss(n, m, sigma)
 
 
+def make_1D_samples_gauss(n, m, sigma, random_state=None):
+    r"""Return `n` samples drawn from 1D gaussian :math:`\mathcal{N}(m, \sigma)`
+
+    Parameters
+    ----------
+    n : int
+        number of samples to make
+    m : float
+        mean value of the gaussian distribution
+    sigma : float
+        std of the gaussian distribution
+    random_state : int, RandomState instance or None, optional (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    Returns
+    -------
+    X : ndarray, shape (`n`, 1)
+        n samples drawn from :math:`\mathcal{N}(m, \sigma)`.
+    """
+
+    generator = check_random_state(random_state)
+    res = generator.randn(n, 1) * np.sqrt(sigma) + m
+    return res
+
+
 def make_2D_samples_gauss(n, m, sigma, random_state=None):
     r"""Return `n` samples drawn from 2D gaussian :math:`\mathcal{N}(m, \sigma)`
 

--- a/ot/datasets.py
+++ b/ot/datasets.py
@@ -40,34 +40,6 @@ def get_1D_gauss(n, m, sigma):
     return make_1D_gauss(n, m, sigma)
 
 
-def make_1D_samples_gauss(n, m, sigma, random_state=None):
-    r"""Return `n` samples drawn from 1D gaussian :math:`\mathcal{N}(m, \sigma)`
-
-    Parameters
-    ----------
-    n : int
-        number of samples to make
-    m : float
-        mean value of the gaussian distribution
-    sigma : float
-        std of the gaussian distribution
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
-
-    Returns
-    -------
-    X : ndarray, shape (`n`, 1)
-        n samples drawn from :math:`\mathcal{N}(m, \sigma)`.
-    """
-
-    generator = check_random_state(random_state)
-    res = generator.randn(n, 1) * np.sqrt(sigma) + m
-    return res
-
-
 def make_2D_samples_gauss(n, m, sigma, random_state=None):
     r"""Return `n` samples drawn from 2D gaussian :math:`\mathcal{N}(m, \sigma)`
 

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -84,8 +84,6 @@ def bures_wasserstein_mapping(ms, mt, Cs, Ct, log=False):
 
     if log:
         log = {}
-        log['Cs'] = Cs
-        log['Ct'] = Ct
         log['Cs12'] = Cs12
         log['Cs12inv'] = Cs12inv
         return A, b, log
@@ -179,23 +177,13 @@ def empirical_bures_wasserstein_mapping(xs, xt, reg=1e-6, ws=None,
     Cs = nx.dot((xs * ws).T, xs) / nx.sum(ws) + reg * nx.eye(d, type_as=xs)
     Ct = nx.dot((xt * wt).T, xt) / nx.sum(wt) + reg * nx.eye(d, type_as=xt)
 
-    Cs12 = nx.sqrtm(Cs)
-    Cs12inv = nx.inv(Cs12)
-
-    M0 = nx.sqrtm(dots(Cs12, Ct, Cs12))
-
-    A = dots(Cs12inv, M0, Cs12inv)
-
-    b = mxt - nx.dot(mxs, A)
-
     if log:
-        log = {}
+        A, b, log = bures_wasserstein_mapping(mxs, mxt, Cs, Ct, log=log)
         log['Cs'] = Cs
         log['Ct'] = Ct
-        log['Cs12'] = Cs12
-        log['Cs12inv'] = Cs12inv
         return A, b, log
     else:
+        A, b = bures_wasserstein_mapping(mxs, mxt, Cs, Ct)
         return A, b
 
 
@@ -251,7 +239,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     Cs12 = nx.sqrtm(Cs)
 
     B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
-    W = nx.norm(ms - mt) + B
+    W = nx.sqrt(nx.norm(ms - mt)**2 + B)
     if log:
         log = {}
         log['Cs12'] = Cs12
@@ -334,15 +322,12 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
 
     Cs = nx.dot((xs * ws).T, xs) / nx.sum(ws) + reg * nx.eye(d, type_as=xs)
     Ct = nx.dot((xt * wt).T, xt) / nx.sum(wt) + reg * nx.eye(d, type_as=xt)
-    Cs12 = nx.sqrtm(Cs)
 
-    B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
-    W = nx.norm(mxs - mxt) + B
     if log:
-        log = {}
+        W, log = bures_wasserstein_distance(mxs, mxt, Cs, Ct, log=log)
         log['Cs'] = Cs
         log['Ct'] = Ct
-        log['Cs12'] = Cs12
         return W, log
     else:
+        W = bures_wasserstein_distance(mxs, mxt, Cs, Ct)
         return W

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -213,7 +213,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)^{1/2}
 
     Parameters
     ----------
@@ -275,7 +275,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)^{1/2}
 
     Parameters
     ----------

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -103,7 +103,7 @@ def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
 
     M0 = nx.sqrtm(dots(Cs12, Ct, Cs12))
 
-    A = dots(Cs_12, M0, Cs_12)
+    A = dots(Cs12inv, M0, Cs12inv)
 
     b = mxt - nx.dot(mxs, A)
 

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -73,8 +73,6 @@ def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
 
     .. [2] Peyré, G., & Cuturi, M. (2017). "Computational Optimal
         Transport", 2018.
-
-
     """
     xs, xt = list_to_array(xs, xt)
     nx = get_backend(xs, xt)
@@ -128,7 +126,7 @@ def bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     empirical distributions source :math:`\mu_s` and target :math:`\mu_t`,
     discussed in remark 2.31 :ref:`[1] <references-bures-wasserstein-distance>`.
 
-    The Bures Wasserstein distance beween source and target distribution :math:`\mathcal{W}`
+    The Bures Wasserstein distance between source and target distribution :math:`\mathcal{W}`
 
     .. math::
         \mathcal{W}(\mu_s, \mu_t)_2^2= \left\lVert \mathbf{m}_s - \mathbf{m}_t \right\rVert^2 + \mathcal{B}(\Sigma_s, \Sigma_t)^{2}

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -112,7 +112,7 @@ def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
         log['Cs'] = Cs
         log['Ct'] = Ct
         log['Cs12'] = Cs12
-        log['Cs_12'] = Cs_12
+        log['Cs12inv'] = Cs12inv
         return A, b, log
     else:
         return A, b

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -213,7 +213,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)^{1/2}
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)
 
     Parameters
     ----------
@@ -275,7 +275,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)^{1/2}
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)
 
     Parameters
     ----------

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+"""
+Domain adaptation with optimal transport
+"""
+
+# Author: Theo Gnassounou <theo.gnassounou@inria.fr>
+#
+# License: MIT License
+
+from .backend import get_backend
+from .utils import dots
+from .utils import list_to_array
+
+
+def OT_mapping_linear(xs, xt, reg=1e-6, ws=None,
+                      wt=None, bias=True, log=False):
+    r"""Return OT linear operator between samples.
+
+    The function estimates the optimal linear operator that aligns the two
+    empirical distributions. This is equivalent to estimating the closed
+    form mapping between two Gaussian distributions :math:`\mathcal{N}(\mu_s,\Sigma_s)`
+    and :math:`\mathcal{N}(\mu_t,\Sigma_t)` as proposed in
+    :ref:`[1] <references-OT-mapping-linear>` and discussed in remark 2.29 in
+    :ref:`[2] <references-OT-mapping-linear>`.
+
+    The linear operator from source to target :math:`M`
+
+    .. math::
+        M(\mathbf{x})= \mathbf{A} \mathbf{x} + \mathbf{b}
+
+    where :
+
+    .. math::
+        \mathbf{A} &= \Sigma_s^{-1/2} \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
+        \Sigma_s^{-1/2}
+
+        \mathbf{b} &= \mu_t - \mathbf{A} \mu_s
+
+    Parameters
+    ----------
+    xs : array-like (ns,d)
+        samples in the source domain
+    xt : array-like (nt,d)
+        samples in the target domain
+    reg : float,optional
+        regularization added to the diagonals of covariances (>0)
+    ws : array-like (ns,1), optional
+        weights for the source samples
+    wt : array-like (ns,1), optional
+        weights for the target samples
+    bias: boolean, optional
+        estimate bias :math:`\mathbf{b}` else :math:`\mathbf{b} = 0` (default:True)
+    log : bool, optional
+        record log if True
+
+
+    Returns
+    -------
+    A : (d, d) array-like
+        Linear operator
+    b : (1, d) array-like
+        bias
+    log : dict
+        log dictionary return only if log==True in parameters
+
+
+    .. _references-OT-mapping-linear:
+    References
+    ----------
+    .. [1] Knott, M. and Smith, C. S. "On the optimal mapping of
+        distributions", Journal of Optimization Theory and Applications
+        Vol 43, 1984
+
+    .. [2] Peyré, G., & Cuturi, M. (2017). "Computational Optimal
+        Transport", 2018.
+
+
+    """
+    xs, xt = list_to_array(xs, xt)
+    nx = get_backend(xs, xt)
+
+    d = xs.shape[1]
+
+    if bias:
+        mxs = nx.mean(xs, axis=0)[None, :]
+        mxt = nx.mean(xt, axis=0)[None, :]
+
+        xs = xs - mxs
+        xt = xt - mxt
+    else:
+        mxs = nx.zeros((1, d), type_as=xs)
+        mxt = nx.zeros((1, d), type_as=xs)
+
+    if ws is None:
+        ws = nx.ones((xs.shape[0], 1), type_as=xs) / xs.shape[0]
+
+    if wt is None:
+        wt = nx.ones((xt.shape[0], 1), type_as=xt) / xt.shape[0]
+
+    Cs = nx.dot((xs * ws).T, xs) / nx.sum(ws) + reg * nx.eye(d, type_as=xs)
+    Ct = nx.dot((xt * wt).T, xt) / nx.sum(wt) + reg * nx.eye(d, type_as=xt)
+
+    Cs12 = nx.sqrtm(Cs)
+    Cs_12 = nx.inv(Cs12)
+
+    M0 = nx.sqrtm(dots(Cs12, Ct, Cs12))
+
+    A = dots(Cs_12, M0, Cs_12)
+
+    b = mxt - nx.dot(mxs, A)
+
+    if log:
+        log = {}
+        log['Cs'] = Cs
+        log['Ct'] = Ct
+        log['Cs12'] = Cs12
+        log['Cs_12'] = Cs_12
+        return A, b, log
+    else:
+        return A, b
+
+
+def bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
+                               wt=None, bias=True, log=False):
+    r"""Return Bures Wasserstein distance between samples.
+
+    The function estimates the Bures-Wasserstein distance between two
+    empirical distributions source :math:`\mu_s` and target :math:`\mu_t`,
+    discussed in remark 2.31 :ref:`[1] <references-bures-wasserstein-distance>`.
+
+    The Bures Wasserstein distance beween source and target distribution :math:`\mathcal{W}`
+
+    .. math::
+        \mathcal{W}(\mu_s, \mu_t)_2^2= \left\lVert \mathbf{m}_s - \mathbf{m}_t \right\rVert^2 + \mathcal{B}(\Sigma_s, \Sigma_t)^{2}
+
+    where :
+
+    .. math::
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} &= \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
+
+    Parameters
+    ----------
+    xs : array-like (ns,d)
+        samples in the source domain
+    xt : array-like (nt,d)
+        samples in the target domain
+    reg : float,optional
+        regularization added to the diagonals of covariances (>0)
+    ws : array-like (ns,1), optional
+        weights for the source samples
+    wt : array-like (ns,1), optional
+        weights for the target samples
+    bias: boolean, optional
+        estimate bias :math:`\mathbf{b}` else :math:`\mathbf{b} = 0` (default:True)
+    log : bool, optional
+        record log if True
+
+
+    Returns
+    -------
+    W : float
+        bures Wasserstein distance
+    log : dict
+        log dictionary return only if log==True in parameters
+
+
+    .. _references-bures-wasserstein-distance:
+    References
+    ----------
+
+    .. [1] Peyré, G., & Cuturi, M. (2017). "Computational Optimal
+        Transport", 2018.
+
+
+    """
+    xs, xt = list_to_array(xs, xt)
+    nx = get_backend(xs, xt)
+
+    d = xs.shape[1]
+
+    if bias:
+        mxs = nx.mean(xs, axis=0)[None, :]
+        mxt = nx.mean(xt, axis=0)[None, :]
+
+        xs = xs - mxs
+        xt = xt - mxt
+    else:
+        mxs = nx.zeros((1, d), type_as=xs)
+        mxt = nx.zeros((1, d), type_as=xs)
+
+    if ws is None:
+        ws = nx.ones((xs.shape[0], 1), type_as=xs) / xs.shape[0]
+
+    if wt is None:
+        wt = nx.ones((xt.shape[0], 1), type_as=xt) / xt.shape[0]
+
+    Cs = nx.dot((xs * ws).T, xs) / nx.sum(ws) + reg * nx.eye(d, type_as=xs)
+    Ct = nx.dot((xt * wt).T, xt) / nx.sum(wt) + reg * nx.eye(d, type_as=xt)
+    Cs12 = nx.sqrtm(Cs)
+
+    B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
+    print(nx.norm(mxs - mxt), mxs, mxt)
+    W = nx.norm(mxs - mxt) + B
+    if log:
+        log = {}
+        log['Cs'] = Cs
+        log['Ct'] = Ct
+        log['Cs12'] = Cs12
+        return W, log
+    else:
+        return W

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -168,8 +168,6 @@ def bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
 
     .. [1] Peyré, G., & Cuturi, M. (2017). "Computational Optimal
         Transport", 2018.
-
-
     """
     xs, xt = list_to_array(xs, xt)
     nx = get_backend(xs, xt)

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -4,6 +4,7 @@ Optimal transport for Gaussian distributions
 """
 
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
+#         Remi Flamary <remi.flamary@polytehnique.edu>
 #
 # License: MIT License
 

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -213,7 +213,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} &= \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
 
     Parameters
     ----------
@@ -232,7 +232,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     Returns
     -------
     W : float
-        bures Wasserstein distance
+        Bures Wasserstein distance
     log : dict
         log dictionary return only if log==True in parameters
 
@@ -275,7 +275,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} &= \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \left(\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2} \right)^{1/2}
 
     Parameters
     ----------
@@ -298,7 +298,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     Returns
     -------
     W : float
-        bures Wasserstein distance
+        Bures Wasserstein distance
     log : dict
         log dictionary return only if log==True in parameters
 

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -577,27 +577,6 @@ def test_mapping_transport_class_specific_seed(nx):
 
 @pytest.skip_backend("jax")
 @pytest.skip_backend("tf")
-def test_linear_mapping(nx):
-    ns = 50
-    nt = 50
-
-    Xs, ys = make_data_classif('3gauss', ns)
-    Xt, yt = make_data_classif('3gauss2', nt)
-
-    Xsb, Xtb = nx.from_numpy(Xs, Xt)
-
-    A, b = ot.da.OT_mapping_linear(Xsb, Xtb)
-
-    Xst = nx.to_numpy(nx.dot(Xsb, A) + b)
-
-    Ct = np.cov(Xt.T)
-    Cst = np.cov(Xst.T)
-
-    np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
-
-
-@pytest.skip_backend("jax")
-@pytest.skip_backend("tf")
 def test_linear_mapping_class(nx):
     ns = 50
     nt = 50

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -83,10 +83,10 @@ def test_bures_wasserstein_distance(nx):
 
 @pytest.mark.parametrize("bias", [True, False])
 def test_empirical_bures_wasserstein_distance(nx, bias):
-    ns = 200
-    nt = 200
+    ns = 400
+    nt = 400
 
-    rng = np.random.RandomState(2)
+    rng = np.random.RandomState(10)
     Xs = rng.normal(0, 1, ns)[:, np.newaxis]
     Xt = rng.normal(10 * bias, 1, nt)[:, np.newaxis]
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -1,0 +1,47 @@
+"""Tests for module da on Domain Adaptation """
+
+# Author: Remi Flamary <remi.flamary@unice.fr>
+#
+# License: MIT License
+
+import numpy as np
+import pytest
+
+import ot
+from ot.datasets import make_data_classif, make_1D_samples_gauss
+
+
+@pytest.skip_backend("jax")
+@pytest.skip_backend("tf")
+def test_linear_mapping(nx):
+    ns = 50
+    nt = 50
+
+    Xs, ys = make_data_classif('3gauss', ns)
+    Xt, yt = make_data_classif('3gauss2', nt)
+
+    Xsb, Xtb = nx.from_numpy(Xs, Xt)
+
+    A, b = ot.gaussian.OT_mapping_linear(Xsb, Xtb)
+
+    Xst = nx.to_numpy(nx.dot(Xsb, A) + b)
+
+    Ct = np.cov(Xt.T)
+    Cst = np.cov(Xst.T)
+
+    np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
+
+
+@pytest.skip_backend("jax")
+@pytest.skip_backend("tf")
+def test_bures_wasserstein_distance(nx):
+    ns = 200
+    nt = 200
+
+    Xs = make_1D_samples_gauss(ns, 0, 1, random_state=42)
+    Xt = make_1D_samples_gauss(nt, 10, 1, random_state=42)
+
+    Xsb, Xtb = nx.from_numpy(Xs, Xt)
+    Wb = ot.gaussian.bures_wasserstein_distance(Xsb, Xtb, bias=True)
+
+    np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -32,7 +32,8 @@ def test_linear_mapping(nx):
 
 def test_bures_wasserstein_distance(nx):
     ms, mt, Cs, Ct = [0], [10], [[1]], [[1]]
-    Wb = ot.gaussian.bures_wasserstein_distance(ms, mt, Cs, Ct)
+    msb, mtb, Csb, Ctb = nx.from_numpy(ms, mt, Cs, Ct)
+    Wb = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb)
 
     np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -1,25 +1,57 @@
 """Tests for module gaussian"""
 
-# Author: Remi Flamary <remi.flamary@unice.fr>
+# Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #
 # License: MIT License
 
 import numpy as np
 
+import pytest
+
 import ot
 from ot.datasets import make_data_classif
 
 
-def test_linear_mapping(nx):
+def test_bures_wasserstein_mapping(nx):
+    ns = 50
+    nt = 50
+
+    Xs, ys = make_data_classif('3gauss', ns)
+    Xt, yt = make_data_classif('3gauss2', nt)
+    ms = np.mean(Xs, axis=0)[None, :]
+    mt = np.mean(Xt, axis=0)[None, :]
+    Cs = np.cov(Xs.T)
+    Ct = np.cov(Xt.T)
+
+    Xsb, msb, mtb, Csb, Ctb = nx.from_numpy(Xs, ms, mt, Cs, Ct)
+
+    A, b, log = ot.gaussian.bures_wasserstein_mapping(msb, mtb, Csb, Ctb, log=True)
+
+    Xst = nx.to_numpy(nx.dot(Xsb, A) + b)
+
+    Cst = np.cov(Xst.T)
+
+    np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("bias", [True, False])
+def test_empirical_bures_wasserstein_mapping(nx, bias):
     ns = 50
     nt = 50
 
     Xs, ys = make_data_classif('3gauss', ns)
     Xt, yt = make_data_classif('3gauss2', nt)
 
+    if not bias:
+        ms = np.mean(Xs, axis=0)[None, :]
+        mt = np.mean(Xt, axis=0)[None, :]
+
+        Xs = Xs - ms
+        Xt = Xt - mt
+
     Xsb, Xtb = nx.from_numpy(Xs, Xt)
 
-    A, b = ot.gaussian.OT_mapping_linear(Xsb, Xtb)
+    A, b, log = ot.gaussian.empirical_bures_wasserstein_mapping(Xsb, Xtb, log=True, bias=bias)
 
     Xst = nx.to_numpy(nx.dot(Xsb, A) + b)
 
@@ -33,19 +65,21 @@ def test_bures_wasserstein_distance(nx):
     ms, mt = np.array([0]), np.array([10])
     Cs, Ct = np.array([[1]]).astype(np.float32), np.array([[1]]).astype(np.float32)
     msb, mtb, Csb, Ctb = nx.from_numpy(ms, mt, Cs, Ct)
-    Wb = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb)
+    Wb, log = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb, log=True)
 
     np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
 
 
-def test_empirical_bures_wasserstein_distance(nx):
+@pytest.mark.parametrize("bias", [True, False])
+def test_empirical_bures_wasserstein_distance(nx, bias):
     ns = 200
     nt = 200
 
-    rng = np.random.RandomState(1)
+    rng = np.random.RandomState(2)
     Xs = rng.normal(0, 1, ns)[:, np.newaxis]
-    Xt = rng.normal(10, 1, nt)[:, np.newaxis]
-    Xsb, Xtb = nx.from_numpy(Xs, Xt)
-    Wb = ot.gaussian.empirical_bures_wasserstein_distance(Xsb, Xtb, bias=True)
+    Xt = rng.normal(10 * bias, 1, nt)[:, np.newaxis]
 
-    np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
+    Xsb, Xtb = nx.from_numpy(Xs, Xt)
+    Wb, log = ot.gaussian.empirical_bures_wasserstein_distance(Xsb, Xtb, log=True, bias=bias)
+
+    np.testing.assert_allclose(10 * bias, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -1,4 +1,4 @@
-"""Tests for module da on Domain Adaptation """
+"""Tests for module gaussian"""
 
 # Author: Remi Flamary <remi.flamary@unice.fr>
 #
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import ot
-from ot.datasets import make_data_classif, make_1D_samples_gauss
+from ot.datasets import make_data_classif
 
 
 @pytest.skip_backend("jax")
@@ -35,13 +35,22 @@ def test_linear_mapping(nx):
 @pytest.skip_backend("jax")
 @pytest.skip_backend("tf")
 def test_bures_wasserstein_distance(nx):
+    ms, mt, Cs, Ct = [0], [10], [[1]], [[1]]
+    Wb = ot.gaussian.bures_wasserstein_distance(ms, mt, Cs, Ct)
+
+    np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
+
+
+@pytest.skip_backend("jax")
+@pytest.skip_backend("tf")
+def test_empirical_bures_wasserstein_distance(nx):
     ns = 200
     nt = 200
 
-    Xs = make_1D_samples_gauss(ns, 0, 1, random_state=42)
-    Xt = make_1D_samples_gauss(nt, 10, 1, random_state=42)
-
+    rng = np.random.RandomState(1)
+    Xs = rng.normal(0, 1, ns)[:, np.newaxis]
+    Xt = rng.normal(10, 1, nt)[:, np.newaxis]
     Xsb, Xtb = nx.from_numpy(Xs, Xt)
-    Wb = ot.gaussian.bures_wasserstein_distance(Xsb, Xtb, bias=True)
+    Wb = ot.gaussian.empirical_bures_wasserstein_distance(Xsb, Xtb, bias=True)
 
     np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -25,12 +25,16 @@ def test_bures_wasserstein_mapping(nx):
 
     Xsb, msb, mtb, Csb, Ctb = nx.from_numpy(Xs, ms, mt, Cs, Ct)
 
-    A, b, log = ot.gaussian.bures_wasserstein_mapping(msb, mtb, Csb, Ctb, log=True)
+    A_log, b_log, log = ot.gaussian.bures_wasserstein_mapping(msb, mtb, Csb, Ctb, log=True)
+    A, b = ot.gaussian.bures_wasserstein_mapping(msb, mtb, Csb, Ctb, log=False)
 
     Xst = nx.to_numpy(nx.dot(Xsb, A) + b)
+    Xst_log = nx.to_numpy(nx.dot(Xsb, A_log) + b_log)
 
     Cst = np.cov(Xst.T)
+    Cst_log = np.cov(Xst_log.T)
 
+    np.testing.assert_allclose(Cst_log, Cst, rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
 
 
@@ -52,12 +56,16 @@ def test_empirical_bures_wasserstein_mapping(nx, bias):
     Xsb, Xtb = nx.from_numpy(Xs, Xt)
 
     A, b, log = ot.gaussian.empirical_bures_wasserstein_mapping(Xsb, Xtb, log=True, bias=bias)
+    A_log, b_log = ot.gaussian.empirical_bures_wasserstein_mapping(Xsb, Xtb, log=False, bias=bias)
 
     Xst = nx.to_numpy(nx.dot(Xsb, A) + b)
+    Xst_log = nx.to_numpy(nx.dot(Xsb, A_log) + b_log)
 
     Ct = np.cov(Xt.T)
     Cst = np.cov(Xst.T)
+    Cst_log = np.cov(Xst_log.T)
 
+    np.testing.assert_allclose(Cst_log, Cst, rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
 
 
@@ -65,8 +73,10 @@ def test_bures_wasserstein_distance(nx):
     ms, mt = np.array([0]), np.array([10])
     Cs, Ct = np.array([[1]]).astype(np.float32), np.array([[1]]).astype(np.float32)
     msb, mtb, Csb, Ctb = nx.from_numpy(ms, mt, Cs, Ct)
-    Wb, log = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb, log=True)
+    Wb_log, log = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb, log=True)
+    Wb = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb, log=False)
 
+    np.testing.assert_allclose(nx.to_numpy(Wb_log), nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
 
 
@@ -80,6 +90,8 @@ def test_empirical_bures_wasserstein_distance(nx, bias):
     Xt = rng.normal(10 * bias, 1, nt)[:, np.newaxis]
 
     Xsb, Xtb = nx.from_numpy(Xs, Xt)
-    Wb, log = ot.gaussian.empirical_bures_wasserstein_distance(Xsb, Xtb, log=True, bias=bias)
+    Wb_log, log = ot.gaussian.empirical_bures_wasserstein_distance(Xsb, Xtb, log=True, bias=bias)
+    Wb = ot.gaussian.empirical_bures_wasserstein_distance(Xsb, Xtb, log=False, bias=bias)
 
+    np.testing.assert_allclose(nx.to_numpy(Wb_log), nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(10 * bias, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -11,8 +11,6 @@ import ot
 from ot.datasets import make_data_classif
 
 
-@pytest.skip_backend("jax")
-@pytest.skip_backend("tf")
 def test_linear_mapping(nx):
     ns = 50
     nt = 50
@@ -32,8 +30,6 @@ def test_linear_mapping(nx):
     np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
 
 
-@pytest.skip_backend("jax")
-@pytest.skip_backend("tf")
 def test_bures_wasserstein_distance(nx):
     ms, mt, Cs, Ct = [0], [10], [[1]], [[1]]
     Wb = ot.gaussian.bures_wasserstein_distance(ms, mt, Cs, Ct)
@@ -41,8 +37,6 @@ def test_bures_wasserstein_distance(nx):
     np.testing.assert_allclose(10, nx.to_numpy(Wb), rtol=1e-2, atol=1e-2)
 
 
-@pytest.skip_backend("jax")
-@pytest.skip_backend("tf")
 def test_empirical_bures_wasserstein_distance(nx):
     ns = 200
     nt = 200

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -1,6 +1,7 @@
 """Tests for module gaussian"""
 
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
+#         Remi Flamary <remi.flamary@polytehnique.edu>
 #
 # License: MIT License
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -5,7 +5,6 @@
 # License: MIT License
 
 import numpy as np
-import pytest
 
 import ot
 from ot.datasets import make_data_classif
@@ -31,7 +30,8 @@ def test_linear_mapping(nx):
 
 
 def test_bures_wasserstein_distance(nx):
-    ms, mt, Cs, Ct = [0], [10], [[1]], [[1]]
+    ms, mt = np.array([0]), np.array([10])
+    Cs, Ct = np.array([[1]]).astype(np.float32), np.array([[1]]).astype(np.float32)
     msb, mtb, Csb, Ctb = nx.from_numpy(ms, mt, Cs, Ct)
     Wb = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb)
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
This introduce Gaussian modules, a file comprising all the modules of optimal transport for Gaussian distributions. 
The OT_mapping_linear moved from da.py to gaussian.py. 
I added Bures Wasserstein distance to gaussian.py.
Also update examples/gromov/plot_barycenter_fgw.py to fit the new networkx API

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Add new methods for Gaussian distributions.

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
The test for Bures Wasserstein distance is done on two 1D Gaussian distributions centered on 0 and 10 respectively. with the same variance The Bures Wasserstein distance is tested to be close of 10.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
