### PR TITLE
[MRG] Make partial_wasserstein, partial_wasserstein2 and entropic_partial_wasserstein work with backend

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,7 @@
 - Added Generalized Wasserstein Barycenter solver + example (PR #372), fixed graphical details on the example (PR #376)
 - Added Free Support Sinkhorn Barycenter + example (PR #387)
 - New API for OT solver using function `ot.solve` (PR #388)
-- Backend version of `ot.partial` and `ot.smooth` (PR #388)
+- Backend version of `ot.partial` and `ot.smooth` (PR #388 and #449)
 - Added argument for warmstart of dual potentials in Sinkhorn-based methods in `ot.bregman` (PR #437)
 - Add parameters method in `ot.da.SinkhornTransport` (PR #440)
 - `ot.dr` now uses the new Pymanopt API and POT is compatible with current Pymanopt (PR #443)

--- a/ot/partial.py
+++ b/ot/partial.py
@@ -120,7 +120,7 @@ def partial_wasserstein_lagrange(a, b, M, reg_m=None, nb_dummies=1, log=False,
 
     nx = get_backend(a, b, M)
 
-    if nx.sum(a) > 1 or nx.sum(b) > 1:
+    if nx.sum(a) > 1 + 1e-15 or nx.sum(b) > 1 + 1e-15:  # 1e-15 for numerical errors
         raise ValueError("Problem infeasible. Check that a and b are in the "
                          "simplex")
 
@@ -269,6 +269,12 @@ def partial_wasserstein(a, b, M, m=None, nb_dummies=1, log=False, **kwargs):
     a, b, M = list_to_array(a, b, M)
 
     nx = get_backend(a, b, M)
+
+    dim_a, dim_b = M.shape
+    if len(a) == 0:
+        a = nx.ones(dim_a, type_as=a) / dim_a
+    if len(b) == 0:
+        b = nx.ones(dim_b, type_as=b) / dim_b
 
     if m is None:
         return partial_wasserstein_lagrange(a, b, M, log=log, **kwargs)

--- a/ot/partial.py
+++ b/ot/partial.py
@@ -390,14 +390,18 @@ def partial_wasserstein2(a, b, M, m=None, nb_dummies=1, log=False, **kwargs):
         NeurIPS.
     """
 
+    a, b, M = list_to_array(a, b, M)
+
+    nx = get_backend(a, b, M)
+
     partial_gw, log_w = partial_wasserstein(a, b, M, m, nb_dummies, log=True,
                                             **kwargs)
     log_w['T'] = partial_gw
 
     if log:
-        return np.sum(partial_gw * M), log_w
+        return nx.sum(partial_gw * M), log_w
     else:
-        return np.sum(partial_gw * M)
+        return nx.sum(partial_gw * M)
 
 
 def gwgrad_partial(C1, C2, T):

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -103,25 +103,18 @@ def test_partial_wasserstein():
 
     m = 0.5
 
-    w0, log0 = ot.partial.partial_wasserstein(p, q, M, m=m, log=True)
-    w, log = ot.partial.entropic_partial_wasserstein(p, q, M, reg=1, m=m,
-                                                     log=True, verbose=True)
+    w0 = ot.partial.partial_wasserstein(p, q, M, m=m, log=False)
+    w = ot.partial.entropic_partial_wasserstein(p, q, M, reg=1, m=m, log=False, verbose=False)
 
     # check constraints
-    np.testing.assert_equal(
-        w0.sum(1) - p <= 1e-5, [True] * len(p))  # cf convergence wasserstein
-    np.testing.assert_equal(
-        w0.sum(0) - q <= 1e-5, [True] * len(q))  # cf convergence wasserstein
-    np.testing.assert_equal(
-        w.sum(1) - p <= 1e-5, [True] * len(p))  # cf convergence wasserstein
-    np.testing.assert_equal(
-        w.sum(0) - q <= 1e-5, [True] * len(q))  # cf convergence wasserstein
+    np.testing.assert_equal(w0.sum(1) - p <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(w0.sum(0) - q <= 1e-5, [True] * len(q))
+    np.testing.assert_equal(w.sum(1) - p <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(w.sum(0) - q <= 1e-5, [True] * len(q))
 
     # check transported mass
-    np.testing.assert_allclose(
-        np.sum(w0), m, atol=1e-04)
-    np.testing.assert_allclose(
-        np.sum(w), m, atol=1e-04)
+    np.testing.assert_allclose(np.sum(w0), m, atol=1e-04)
+    np.testing.assert_allclose(np.sum(w), m, atol=1e-04)
 
     w0, log0 = ot.partial.partial_wasserstein2(p, q, M, m=m, log=True)
     w0_val = ot.partial.partial_wasserstein2(p, q, M, m=m, log=False)
@@ -131,38 +124,39 @@ def test_partial_wasserstein():
     np.testing.assert_allclose(w0, w0_val, atol=1e-1, rtol=1e-1)
 
     # check constraints
-    np.testing.assert_equal(
-        G.sum(1) - p <= 1e-5, [True] * len(p))  # cf convergence wasserstein
-    np.testing.assert_equal(
-        G.sum(0) - q <= 1e-5, [True] * len(q))  # cf convergence wasserstein
-    np.testing.assert_allclose(
-        np.sum(G), m, atol=1e-04)
+    np.testing.assert_equal(G.sum(1) - p <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(G.sum(0) - q <= 1e-5, [True] * len(q))
+    np.testing.assert_allclose(np.sum(G), m, atol=1e-04)
 
     # check with torch
     if torch:
-        p1 = torch.tensor(p, dtype=torch.float64)
-        q1 = torch.tensor(q, dtype=torch.float64)
-        M1 = torch.tensor(M, dtype=torch.float64)
+        p_torch = torch.tensor(p, dtype=torch.float64)
+        q_torch = torch.tensor(q, dtype=torch.float64)
+        M_torch = torch.tensor(M, dtype=torch.float64)
 
-        G, log = ot.partial.partial_wasserstein(p1, q1, M1, m=m, log=True)
+        G = ot.partial.partial_wasserstein(p_torch, q_torch, M_torch, m=m, log=False)
+        G_entropic = ot.partial.entropic_partial_wasserstein(p_torch, q_torch, M_torch, reg=1, m=m, log=False)
 
         assert G.shape == (len(p), len(q))
         assert type(G) == torch.Tensor
+        assert G_entropic.shape == (len(p), len(q))
+        assert type(G_entropic) == torch.Tensor
 
         # check constraints
-        np.testing.assert_equal(
-            np.array(G.sum(1) - p) <= 1e-5, [True] * len(p))  # cf convergence wasserstein
-        np.testing.assert_equal(
-            np.array(G.sum(0) - q) <= 1e-5, [True] * len(q))  # cf convergence wasserstein
+        np.testing.assert_equal(np.array(G.sum(1) - p) <= 1e-5, [True] * len(p))
+        np.testing.assert_equal(np.array(G.sum(0) - q) <= 1e-5, [True] * len(q))
+        np.testing.assert_equal(np.array(G_entropic.sum(1) - p) <= 1e-5, [True] * len(p))
+        np.testing.assert_equal(np.array(G_entropic.sum(0) - q) <= 1e-5, [True] * len(q))
 
         # check transported mass
         np.testing.assert_allclose(G.sum(), m, atol=1e-04)
+        np.testing.assert_allclose(G_entropic.sum(), m, atol=1e-04)
 
         # compute associated loss val
-        w = torch.sum(G * M1)
+        w = torch.sum(G * M_torch)
 
         # compute directly loss val
-        w1, log = ot.partial.partial_wasserstein2(p1, q1, M1, m=m, log=True)
+        w1, log = ot.partial.partial_wasserstein2(p_torch, q_torch, M_torch, m=m, log=True)
         G1 = log['T']
 
         # test G1 shape and type
@@ -198,7 +192,7 @@ def test_partial_wasserstein2_gradient():
     m = 0.5
 
     w, log = ot.partial.partial_wasserstein2(p, q, M, m=m, log=True)
-    
+
     w.backward()
 
     assert M.grad is not None

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -8,11 +8,8 @@
 import numpy as np
 import scipy as sp
 import ot
-from ot.backend import get_backend_list, tf, to_numpy
+from ot.backend import to_numpy, torch
 import pytest
-
-
-backend_list = get_backend_list()
 
 
 def test_raise_errors():
@@ -86,7 +83,6 @@ def test_partial_wasserstein_lagrange():
     w0, log0 = ot.partial.partial_wasserstein_lagrange(p, q, M, 100, log=True)
 
 
-@pytest.mark.parametrize('nx', backend_list)
 def test_partial_wasserstein(nx):
 
     n_samples = 20  # nb samples (gaussian)
@@ -136,56 +132,58 @@ def test_partial_wasserstein(nx):
 
 
 def test_partial_wasserstein2_gradient():
-    n_samples = 40
+    if torch:
+        n_samples = 40
 
-    mu = np.array([0, 0])
-    cov = np.array([[1, 0], [0, 2]])
+        mu = np.array([0, 0])
+        cov = np.array([[1, 0], [0, 2]])
 
-    xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
-    xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+        xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+        xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
 
-    M = torch.tensor(ot.dist(xs, xt), requires_grad=True, dtype=torch.float64)
+        M = torch.tensor(ot.dist(xs, xt), requires_grad=True, dtype=torch.float64)
 
-    p = torch.tensor(ot.unif(n_samples), dtype=torch.float64)
-    q = torch.tensor(ot.unif(n_samples), dtype=torch.float64)
+        p = torch.tensor(ot.unif(n_samples), dtype=torch.float64)
+        q = torch.tensor(ot.unif(n_samples), dtype=torch.float64)
 
-    m = 0.5
+        m = 0.5
 
-    w, log = ot.partial.partial_wasserstein2(p, q, M, m=m, log=True)
+        w, log = ot.partial.partial_wasserstein2(p, q, M, m=m, log=True)
 
-    w.backward()
+        w.backward()
 
-    assert M.grad is not None
-    assert M.grad.shape == M.shape
+        assert M.grad is not None
+        assert M.grad.shape == M.shape
 
 
 def test_entropic_partial_wasserstein_gradient():
-    n_samples = 40
+    if torch:
+        n_samples = 40
 
-    mu = np.array([0, 0])
-    cov = np.array([[1, 0], [0, 2]])
+        mu = np.array([0, 0])
+        cov = np.array([[1, 0], [0, 2]])
 
-    xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
-    xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+        xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+        xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
 
-    M = torch.tensor(ot.dist(xs, xt), requires_grad=True, dtype=torch.float64)
+        M = torch.tensor(ot.dist(xs, xt), requires_grad=True, dtype=torch.float64)
 
-    p = torch.tensor(ot.unif(n_samples), requires_grad=True, dtype=torch.float64)
-    q = torch.tensor(ot.unif(n_samples), requires_grad=True, dtype=torch.float64)
+        p = torch.tensor(ot.unif(n_samples), requires_grad=True, dtype=torch.float64)
+        q = torch.tensor(ot.unif(n_samples), requires_grad=True, dtype=torch.float64)
 
-    m = 0.5
-    reg = 1
+        m = 0.5
+        reg = 1
 
-    _, log = ot.partial.entropic_partial_wasserstein(p, q, M, m=m, reg=reg, log=True)
+        _, log = ot.partial.entropic_partial_wasserstein(p, q, M, m=m, reg=reg, log=True)
 
-    log['partial_w_dist'].backward()
+        log['partial_w_dist'].backward()
 
-    assert M.grad is not None
-    assert p.grad is not None
-    assert q.grad is not None
-    assert M.grad.shape == M.shape
-    assert p.grad.shape == p.shape
-    assert q.grad.shape == q.shape
+        assert M.grad is not None
+        assert p.grad is not None
+        assert q.grad is not None
+        assert M.grad.shape == M.shape
+        assert p.grad.shape == p.shape
+        assert q.grad.shape == q.shape
 
 
 def test_partial_gromov_wasserstein():

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -8,7 +8,7 @@
 import numpy as np
 import scipy as sp
 import ot
-from ot.backend import torch, tf
+from ot.backend import torch
 import pytest
 
 

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -181,6 +181,30 @@ def test_partial_wasserstein():
         np.testing.assert_allclose(G1.sum(), m, atol=1e-04)
 
 
+def test_partial_wasserstein2_gradient():
+    n_samples = 40
+
+    mu = np.array([0, 0])
+    cov = np.array([[1, 0], [0, 2]])
+
+    xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+    xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+
+    M = torch.tensor(ot.dist(xs, xt), requires_grad=True, dtype=torch.float64)
+
+    p = torch.tensor(ot.unif(n_samples), dtype=torch.float64)
+    q = torch.tensor(ot.unif(n_samples), dtype=torch.float64)
+
+    m = 0.5
+
+    w, log = ot.partial.partial_wasserstein2(p, q, M, m=m, log=True)
+    
+    w.backward()
+
+    assert M.grad is not None
+    assert M.grad.shape == M.shape
+
+
 def test_partial_gromov_wasserstein():
     rng = np.random.RandomState(seed=42)
     n_samples = 20  # nb samples

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -152,20 +152,18 @@ def test_partial_wasserstein_gradients():
     M = ot.dist(x, y)
 
     if torch:
+        a1 = torch.tensor(a, requires_grad=True, dtype=torch.float64)
+        b1 = torch.tensor(a, requires_grad=True, dtype=torch.float64)
+        M1 = torch.tensor(M, requires_grad=True, dtype=torch.float64)
 
-        a1 = torch.tensor(a, requires_grad=True)
-        b1 = torch.tensor(a, requires_grad=True)
-        M1 = torch.tensor(M, requires_grad=True)
-
-        val = ot.partial.partial_wasserstein(a1, b1, M1, m=m)
-
-        val.backward()
+        gamma = ot.partial.partial_wasserstein(a1, b1, M1, m=m)
+        
+        cost = torch.sum(gamma * M1)
+        cost.backward()
 
         assert a1.shape == a1.grad.shape
         assert b1.shape == b1.grad.shape
         assert M1.shape == M1.grad.shape
-
-        val = ot.partial.entropic_partial_wasserstein(p, q, M, reg=1, m=m)
 
 
 def test_partial_gromov_wasserstein():

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -105,8 +105,8 @@ def test_partial_wasserstein(nx):
 
     p, q, M = nx.from_numpy(p, q, M)
 
-    w0 = ot.partial.partial_wasserstein(p, q, M, m=m, log=False)
-    w = ot.partial.entropic_partial_wasserstein(p, q, M, reg=1, m=m, log=False, verbose=False)
+    w0, log0 = ot.partial.partial_wasserstein(p, q, M, m=m, log=True)
+    w, log = ot.partial.entropic_partial_wasserstein(p, q, M, reg=1, m=m, log=True, verbose=True)
 
     # check constraints
     np.testing.assert_equal(to_numpy(nx.sum(w0, axis=1) - p) <= 1e-5, [True] * len(p))
@@ -129,6 +129,29 @@ def test_partial_wasserstein(nx):
     np.testing.assert_equal(to_numpy(nx.sum(G, axis=1) - p) <= 1e-5, [True] * len(p))
     np.testing.assert_equal(to_numpy(nx.sum(G, axis=0) - q) <= 1e-5, [True] * len(q))
     np.testing.assert_allclose(np.sum(to_numpy(G)), m, atol=1e-04)
+
+    empty_array = nx.zeros(0, type_as=M)
+    w = ot.partial.partial_wasserstein(empty_array, empty_array, M=M, m=None)
+
+    # check constraints
+    np.testing.assert_equal(to_numpy(nx.sum(w, axis=1) - p) <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(to_numpy(nx.sum(w, axis=0) - q) <= 1e-5, [True] * len(q))
+    np.testing.assert_equal(to_numpy(nx.sum(w, axis=1) - p) <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(to_numpy(nx.sum(w, axis=0) - q) <= 1e-5, [True] * len(q))
+
+    # check transported mass
+    np.testing.assert_allclose(np.sum(to_numpy(w)), 1, atol=1e-04)
+
+    w0 = ot.partial.entropic_partial_wasserstein(empty_array, empty_array, M=M, reg=10, m=None)
+
+    # check constraints
+    np.testing.assert_equal(to_numpy(nx.sum(w0, axis=1) - p) <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(to_numpy(nx.sum(w0, axis=0) - q) <= 1e-5, [True] * len(q))
+    np.testing.assert_equal(to_numpy(nx.sum(w0, axis=1) - p) <= 1e-5, [True] * len(p))
+    np.testing.assert_equal(to_numpy(nx.sum(w0, axis=0) - q) <= 1e-5, [True] * len(q))
+
+    # check transported mass
+    np.testing.assert_allclose(np.sum(to_numpy(w0)), 1, atol=1e-04)
 
 
 def test_partial_wasserstein2_gradient():

--- a/test/test_partial.py
+++ b/test/test_partial.py
@@ -199,6 +199,35 @@ def test_partial_wasserstein2_gradient():
     assert M.grad.shape == M.shape
 
 
+def test_entropic_partial_wasserstein_gradient():
+    n_samples = 40
+
+    mu = np.array([0, 0])
+    cov = np.array([[1, 0], [0, 2]])
+
+    xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+    xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov)
+
+    M = torch.tensor(ot.dist(xs, xt), requires_grad=True, dtype=torch.float64)
+
+    p = torch.tensor(ot.unif(n_samples), requires_grad=True, dtype=torch.float64)
+    q = torch.tensor(ot.unif(n_samples), requires_grad=True, dtype=torch.float64)
+
+    m = 0.5
+    reg = 1
+
+    _, log = ot.partial.entropic_partial_wasserstein(p, q, M, m=m, reg=reg, log=True)
+
+    log['partial_w_dist'].backward()
+
+    assert M.grad is not None
+    assert p.grad is not None
+    assert q.grad is not None
+    assert M.grad.shape == M.shape
+    assert p.grad.shape == p.shape
+    assert q.grad.shape == q.shape
+
+
 def test_partial_gromov_wasserstein():
     rng = np.random.RandomState(seed=42)
     n_samples = 20  # nb samples


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

The functions `partial_wasserstein`, `partial_wasserstein2` and `entropic_partial_wasserstein` have been adapted to work with any backend (not only numpy) and are tested with torch. In particular, backward passes through them are tested.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The functions mentioned above did not leverage the `nx` backend.

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

Forward and backward passes of the functions mentioned are tested with torch.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
