### PR TITLE
[DOC] Fix gradient update for "Wasserstein 2 Minibatch GAN" example

### DIFF
--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -151,6 +151,7 @@ for i in range(n_iter):
 
     loss.backward()
     optimizer.step()
+    optimizer.zero_grad()
 
     del M
 


### PR DESCRIPTION
## Types of changes
The code sample from the documentation page "Wasserstein 2 Minibatch GAN" has been updated to zero out the gradient after each batch. 


## Motivation and context / Related issue
The issue was described in #464.  I also reviewed other sections in the documentation where the PyTorch optimizer is used, and found that all other code samples properly call `zero_grad()`.

I experimented with various optimizers and settings, such as `SGD`, but the difference in wall time was negligible. I'm not sure if it's worth updating for performance reasons alone. @rflamary let me know what do you think.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
