### PR TITLE
Improve Bures-Wasserstein distance

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@
 - Fix issues with cuda for ot.binary_search_circle and with gradients for ot.sliced_wasserstein_sphere (PR #457)
 - Major documentation cleanup (PR #462, #467)
 - Fix gradients for "Wasserstein2 Minibatch GAN" example (PR #466)
+- Faster Bures-Wasserstein distance with NumPy backend (PR #468)
 
 ## 0.9.0
 

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -844,6 +844,16 @@ class Backend():
         """
         raise NotImplementedError()
 
+    def eigvals(self, a):
+        r"""
+        Computes the matrix eigenvalues. Requires input to be square.
+
+        This function follows the api from :any:`np.linalg.sqrtm`.
+
+        See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigvals.html
+        """
+        raise NotImplementedError()
+
     def sqrtm(self, a):
         r"""
         Computes the matrix square root. Requires input to be definite positive.
@@ -1234,6 +1244,9 @@ class NumpyBackend(Backend):
     def inv(self, a):
         return scipy.linalg.inv(a)
 
+    def eigvals(self, a):
+        return np.linalg.eigvals(a)
+
     def sqrtm(self, a):
         return scipy.linalg.sqrtm(a)
 
@@ -1601,6 +1614,9 @@ class JaxBackend(Backend):
 
     def inv(self, a):
         return jnp.linalg.inv(a)
+
+    def eigvals(self, a):
+        return jnp.linalg.eigvals(a)
 
     def sqrtm(self, a):
         L, V = jnp.linalg.eigh(a)
@@ -2053,6 +2069,9 @@ class TorchBackend(Backend):
     def inv(self, a):
         return torch.linalg.inv(a)
 
+    def eigvals(self, a):
+        return torch.linalg.eigvals(a)
+
     def sqrtm(self, a):
         L, V = torch.linalg.eigh(a)
         return (V * torch.sqrt(L)[None, :]) @ V.T
@@ -2430,6 +2449,9 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def inv(self, a):
         return cp.linalg.inv(a)
+
+    def eigvals(self, a):
+        return cp.linalg.eigvals(a)
 
     def sqrtm(self, a):
         L, V = cp.linalg.eigh(a)
@@ -2822,6 +2844,9 @@ class TensorflowBackend(Backend):
 
     def inv(self, a):
         return tf.linalg.inv(a)
+
+    def eigvals(self, a):
+        return tf.linalg.eigvals(a)
 
     def sqrtm(self, a):
         return tf.linalg.sqrtm(a)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -844,16 +844,6 @@ class Backend():
         """
         raise NotImplementedError()
 
-    def eigvals(self, a):
-        r"""
-        Computes the matrix eigenvalues. Requires input to be square.
-
-        This function follows the api from :any:`np.linalg.sqrtm`.
-
-        See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigvals.html
-        """
-        raise NotImplementedError()
-
     def sqrtm(self, a):
         r"""
         Computes the matrix square root. Requires input to be definite positive.
@@ -1244,11 +1234,9 @@ class NumpyBackend(Backend):
     def inv(self, a):
         return scipy.linalg.inv(a)
 
-    def eigvals(self, a):
-        return np.linalg.eigvals(a)
-
     def sqrtm(self, a):
-        return scipy.linalg.sqrtm(a)
+        L, V = np.linalg.eigh(a)
+        return (V * np.sqrt(L)[None, :]) @ V.T
 
     def kl_div(self, p, q, eps=1e-16):
         return np.sum(p * np.log(p / q + eps))
@@ -1614,9 +1602,6 @@ class JaxBackend(Backend):
 
     def inv(self, a):
         return jnp.linalg.inv(a)
-
-    def eigvals(self, a):
-        return jnp.linalg.eigvals(a)
 
     def sqrtm(self, a):
         L, V = jnp.linalg.eigh(a)
@@ -2069,9 +2054,6 @@ class TorchBackend(Backend):
     def inv(self, a):
         return torch.linalg.inv(a)
 
-    def eigvals(self, a):
-        return torch.linalg.eigvals(a)
-
     def sqrtm(self, a):
         L, V = torch.linalg.eigh(a)
         return (V * torch.sqrt(L)[None, :]) @ V.T
@@ -2450,12 +2432,9 @@ class CupyBackend(Backend):  # pragma: no cover
     def inv(self, a):
         return cp.linalg.inv(a)
 
-    def eigvals(self, a):
-        return cp.linalg.eigvals(a)
-
     def sqrtm(self, a):
         L, V = cp.linalg.eigh(a)
-        return (V * self.sqrt(L)[None, :]) @ V.T
+        return (V * cp.sqrt(L)[None, :]) @ V.T
 
     def kl_div(self, p, q, eps=1e-16):
         return cp.sum(p * cp.log(p / q + eps))
@@ -2845,11 +2824,9 @@ class TensorflowBackend(Backend):
     def inv(self, a):
         return tf.linalg.inv(a)
 
-    def eigvals(self, a):
-        return tf.linalg.eigvals(a)
-
     def sqrtm(self, a):
-        return tf.linalg.sqrtm(a)
+        L, V = tf.linalg.eigh(a)
+        return (V * tf.sqrt(L)[None, :]) @ V.T
 
     def kl_div(self, p, q, eps=1e-16):
         return tnp.sum(p * tnp.log(p / q + eps))

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -202,7 +202,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s\Sigma_t}} \right)
 
     Parameters
     ----------
@@ -236,13 +236,11 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     ms, mt, Cs, Ct = list_to_array(ms, mt, Cs, Ct)
     nx = get_backend(ms, mt, Cs, Ct)
 
-    Cs12 = nx.sqrtm(Cs)
-
-    B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
+    B = nx.trace(Cs) + nx.trace(Ct) - 2 * nx.sum(nx.sqrt(nx.eigvals(nx.dot(Cs, Ct))).real, axis=-1)
     W = nx.sqrt(nx.norm(ms - mt)**2 + B)
+
     if log:
         log = {}
-        log['Cs12'] = Cs12
         return W, log
     else:
         return W
@@ -264,7 +262,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s^{1/2} + \Sigma_t^{1/2} - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s\Sigma_t}} \right)
 
     Parameters
     ----------

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -202,7 +202,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t}\Sigma_s^{1/2}} \right)
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)
 
     Parameters
     ----------
@@ -264,7 +264,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t}\Sigma_s^{1/2}} \right)
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t\Sigma_s^{1/2}} \right)
 
     Parameters
     ----------

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -202,7 +202,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s\Sigma_t}} \right)
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t}\Sigma_s^{1/2}} \right)
 
     Parameters
     ----------
@@ -236,11 +236,13 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     ms, mt, Cs, Ct = list_to_array(ms, mt, Cs, Ct)
     nx = get_backend(ms, mt, Cs, Ct)
 
-    B = nx.trace(Cs) + nx.trace(Ct) - 2 * nx.sum(nx.sqrt(nx.eigvals(nx.dot(Cs, Ct))).real, axis=-1)
-    W = nx.sqrt(nx.norm(ms - mt)**2 + B)
+    Cs12 = nx.sqrtm(Cs)
 
+    B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
+    W = nx.sqrt(nx.norm(ms - mt)**2 + B)
     if log:
         log = {}
+        log['Cs12'] = Cs12
         return W, log
     else:
         return W
@@ -262,7 +264,7 @@ def empirical_bures_wasserstein_distance(xs, xt, reg=1e-6, ws=None,
     where :
 
     .. math::
-        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s\Sigma_t}} \right)
+        \mathbf{B}(\Sigma_s, \Sigma_t)^{2} = \text{Tr}\left(\Sigma_s + \Sigma_t - 2 \sqrt{\Sigma_s^{1/2}\Sigma_t}\Sigma_s^{1/2}} \right)
 
     Parameters
     ----------


### PR DESCRIPTION
## Types of changes

* Fixed typo in the documentation of the Bures-Wasserstein distance ($\Sigma_s$ instead of $\Sigma_s^{1/2}$).
* Faster way of computing the trace of the square-root of the product of $\Sigma_s$ and $\Sigma_t$.

The implementation is based on two facts:

1. The trace of $A$ equals the sum of its eigenvalues.
2. The eigenvalues of $\sqrt{A}$ are the square-roots of the eigenvalues of $A$.

Then, $\mathrm{tr}(\sqrt{A})$ is the sum of the square-roots of the eigenvalues of $A$.

See https://github.com/Lightning-AI/torchmetrics/issues/1705.

## Motivation and context / Related issue

Computing the square-root of a matrix is slow and unstable.

## How has this been tested (if it applies)

The new implementation still passes the tests (at least with NumPy backend).

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
