### PR TITLE
Refactor the function `utils.cost_normalization` to work with multiple backends

### DIFF
--- a/ot/backend.py
+++ b/ot/backend.py
@@ -574,6 +574,16 @@ class Backend():
         """
         raise NotImplementedError()
 
+    def median(self, a, axis=None):
+        r"""
+        Computes the median of a tensor along given dimensions.
+
+        This function follows the api from :any:`numpy.median`
+
+        See: https://numpy.org/doc/stable/reference/generated/numpy.median.html
+        """
+        raise NotImplementedError()
+
     def std(self, a, axis=None):
         r"""
         Computes the standard deviation of a tensor along given dimensions.
@@ -1115,6 +1125,9 @@ class NumpyBackend(Backend):
     def mean(self, a, axis=None):
         return np.mean(a, axis=axis)
 
+    def median(self, a, axis=None):
+        return np.median(a, axis=axis)
+
     def std(self, a, axis=None):
         return np.std(a, axis=axis)
 
@@ -1469,6 +1482,9 @@ class JaxBackend(Backend):
 
     def mean(self, a, axis=None):
         return jnp.mean(a, axis=axis)
+
+    def median(self, a, axis=None):
+        return jnp.median(a, axis=axis)
 
     def std(self, a, axis=None):
         return jnp.std(a, axis=axis)
@@ -1884,6 +1900,12 @@ class TorchBackend(Backend):
         else:
             return torch.mean(a)
 
+    def median(self, a, axis=None):
+        if axis is not None:
+            return torch.median(a, dim=axis)
+        else:
+            return torch.median(a)
+
     def std(self, a, axis=None):
         if axis is not None:
             return torch.std(a, dim=axis, unbiased=False)
@@ -2270,6 +2292,9 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def mean(self, a, axis=None):
         return cp.mean(a, axis=axis)
+
+    def median(self, a, axis=None):
+        return cp.median(a, axis=axis)
 
     def std(self, a, axis=None):
         return cp.std(a, axis=axis)

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -359,16 +359,18 @@ def cost_normalization(C, norm=None):
         The input cost matrix normalized according to given norm.
     """
 
+    nx = get_backend(C)
+
     if norm is None:
         pass
     elif norm == "median":
-        C /= float(np.median(C))
+        C /= float(nx.median(C))
     elif norm == "max":
-        C /= float(np.max(C))
+        C /= float(nx.max(C))
     elif norm == "log":
-        C = np.log(1 + C)
+        C = nx.log(1 + C)
     elif norm == "loglog":
-        C = np.log1p(np.log1p(C))
+        C = nx.log(1 + nx.log(1 + C))
     else:
         raise ValueError('Norm %s is not a valid option.\n'
                          'Valid options are:\n'

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -222,6 +222,8 @@ def test_empty_backend():
     with pytest.raises(NotImplementedError):
         nx.mean(M)
     with pytest.raises(NotImplementedError):
+        nx.median(M)
+    with pytest.raises(NotImplementedError):
         nx.std(M)
     with pytest.raises(NotImplementedError):
         nx.linspace(0, 1, 50)
@@ -510,6 +512,10 @@ def test_func_backends(nx):
         A = nx.mean(Mb)
         lst_b.append(nx.to_numpy(A))
         lst_name.append('mean')
+
+        A = nx.median(Mb)
+        lst_b.append(nx.to_numpy(A))
+        lst_name.append('median')
 
         A = nx.std(Mb)
         lst_b.append(nx.to_numpy(A))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -270,25 +270,31 @@ def test_clean_zeros():
     assert len(b) == n - nz2
 
 
-def test_cost_normalization():
+def test_cost_normalization(nx):
 
     C = np.random.rand(10, 10)
+    C1 = nx.from_numpy(C)
 
     # does nothing
-    M0 = ot.utils.cost_normalization(C)
-    np.testing.assert_allclose(C, M0)
+    M0 = ot.utils.cost_normalization(C1)
+    M1 = nx.to_numpy(M0)
+    np.testing.assert_allclose(C, M1)
 
-    M = ot.utils.cost_normalization(C, 'median')
-    np.testing.assert_allclose(np.median(M), 1)
+    M = ot.utils.cost_normalization(C1, 'median')
+    M1 = nx.to_numpy(M)
+    np.testing.assert_allclose(np.median(M1), 1)
 
-    M = ot.utils.cost_normalization(C, 'max')
-    np.testing.assert_allclose(M.max(), 1)
+    M = ot.utils.cost_normalization(C1, 'max')
+    M1 = nx.to_numpy(M)
+    np.testing.assert_allclose(M1.max(), 1)
 
-    M = ot.utils.cost_normalization(C, 'log')
-    np.testing.assert_allclose(M.max(), np.log(1 + C).max())
+    M = ot.utils.cost_normalization(C1, 'log')
+    M1 = nx.to_numpy(M)
+    np.testing.assert_allclose(M1.max(), np.log(1 + C).max())
 
-    M = ot.utils.cost_normalization(C, 'loglog')
-    np.testing.assert_allclose(M.max(), np.log(1 + np.log(1 + C)).max())
+    M = ot.utils.cost_normalization(C1, 'loglog')
+    M1 = nx.to_numpy(M)
+    np.testing.assert_allclose(M1.max(), np.log(1 + np.log(1 + C)).max())
 
 
 def test_check_params():


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* The `utils.cost_normalization` function now uses backends in a general way.
* The  backends now implements the 'median' function, with exception of tensorflow backend.



## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The motivation for making this change is that currently, when using a backend other than Numpy (e.g. PyTorch), the program crashes when trying to use the `utils.cost_normalization` function. This function is also essential in the `ot.da.SinkhornTransport` class, for example.

This PR fix the issue #465


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

I modified the existing test `test_cost_normalization` to use the different types of backends, and then passed them back to Numpy again to keep the tests that existed before.

In addition, I added new cases to the backend tests, to include the new `median` function.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
