### PR TITLE
[DOC] Fix references to JAX and numpy functions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -199,4 +199,4 @@ method does to the data and a figure (coming from an example)
 illustrating it.
 
 
-This Contribution guide is strongly inpired by the one of the [scikit-learn](https://github.com/scikit-learn/scikit-learn) team.
+This Contribution guide is strongly inspired by the one of the [scikit-learn](https://github.com/scikit-learn/scikit-learn) team.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,7 +11,7 @@
 
 - Fix circleci-redirector action and codecov (PR #460)
 - Fix issues with cuda for ot.binary_search_circle and with gradients for ot.sliced_wasserstein_sphere (PR #457)
-- Major documentation cleanup (PR #462, #467)
+- Major documentation cleanup (PR #462, #467, #475)
 - Fix gradients for "Wasserstein2 Minibatch GAN" example (PR #466)
 - Faster Bures-Wasserstein distance with NumPy backend (PR #468)
 - Fix issue backend for ot.sliced_wasserstein_sphere ot.sliced_wasserstein_sphere_unif (PR #471)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -351,7 +351,8 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
                        'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
                        'matplotlib': ('http://matplotlib.org/', None),
-                       'torch': ('https://pytorch.org/docs/stable/', None)}
+                       'torch': ('https://pytorch.org/docs/stable/', None),
+                       'jax': ('https://jax.readthedocs.io/en/latest/', None)}
 
 sphinx_gallery_conf = {
     'examples_dirs': ['../../examples', '../../examples/da'],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -348,7 +348,7 @@ autodoc_default_options = {'autosummary': True,
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
-                       'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'numpy': ('https://numpy.org/doc/stable/', None),
                        'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
                        'matplotlib': ('http://matplotlib.org/', None),
                        'torch': ('https://pytorch.org/docs/stable/', None),

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -670,7 +670,7 @@ class Backend():
 
         This function follows the api from :any:`numpy.random.seed`
 
-        See: https://numpy.org/doc/stable/reference/generated/numpy.random.seed.html
+        See: https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html
         """
         raise NotImplementedError()
 
@@ -680,7 +680,7 @@ class Backend():
 
         This function follows the api from :any:`numpy.random.rand`
 
-        See: https://numpy.org/doc/stable/reference/generated/numpy.random.rand.html
+        See: https://numpy.org/doc/stable/reference/random/generated/numpy.random.rand.html
         """
         raise NotImplementedError()
 
@@ -690,7 +690,7 @@ class Backend():
 
         This function follows the api from :any:`numpy.random.rand`
 
-        See: https://numpy.org/doc/stable/reference/generated/numpy.random.rand.html
+        See: https://numpy.org/doc/stable/reference/random/generated/numpy.random.rand.html
         """
         raise NotImplementedError()
 

--- a/ot/factored.py
+++ b/ot/factored.py
@@ -81,8 +81,8 @@ def factored_optimal_transport(Xa, Xb, a=None, b=None, reg=0.0, r=100, X0=None, 
 
     See Also
     --------
-    ot.bregman.sinkhorn : Entropic regularized OT ot.optim.cg : General
-    regularized OT
+    ot.bregman.sinkhorn : Entropic regularized OT
+    ot.optim.cg : General regularized OT
     """
 
     nx = get_backend(Xa, Xb)

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -28,10 +28,10 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
         \lambda_u U(\mathbf{T}\mathbf{1},\mathbf{a}) +
         \lambda_u U(\mathbf{T}^T\mathbf{1},\mathbf{b})
 
-    The regularization is selected with ``reg`` (:math:`\lambda_r`) and ``reg_type``. By
+    The regularization is selected with `reg` (:math:`\lambda_r`) and `reg_type`. By
     default ``reg=None`` and there is no regularization. The unbalanced marginal
-    penalization can be selected with ``unbalanced`` (:math:`\lambda_u`) and
-    ``unbalanced_type``. By default ``unbalanced=None`` and the function
+    penalization can be selected with `unbalanced` (:math:`\lambda_u`) and
+    `unbalanced_type`. By default ``unbalanced=None`` and the function
     solves the exact optimal transport problem (respecting the marginals).
 
     Parameters
@@ -46,12 +46,12 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
         Regularization weight :math:`\lambda_r`, by default None (no reg., exact
         OT)
     reg_type : str, optional
-        Type of regularization :math:`R`  either "KL", "L2", 'entropy', by default "KL"
+        Type of regularization :math:`R`  either "KL", "L2", "entropy", by default "KL"
     unbalanced : float, optional
         Unbalanced penalization weight :math:`\lambda_u`, by default None
         (balanced OT)
     unbalanced_type : str, optional
-        Type of unbalanced penalization unction :math:`U`  either "KL", "L2", 'TV', by default 'KL'
+        Type of unbalanced penalization unction :math:`U`  either "KL", "L2", "TV", by default "KL"
     n_threads : int, optional
         Number of OMP threads for exact OT solver, by default 1
     max_iter : int, optional

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -28,10 +28,10 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
         \lambda_u U(\mathbf{T}\mathbf{1},\mathbf{a}) +
         \lambda_u U(\mathbf{T}^T\mathbf{1},\mathbf{b})
 
-    The regularization is selected with :any:`reg` (:math:`\lambda_r`) and :any:`reg_type`. By
+    The regularization is selected with ``reg`` (:math:`\lambda_r`) and ``reg_type``. By
     default ``reg=None`` and there is no regularization. The unbalanced marginal
-    penalization can be selected with :any:`unbalanced` (:math:`\lambda_u`) and
-    :any:`unbalanced_type`. By default ``unbalanced=None`` and the function
+    penalization can be selected with ``unbalanced`` (:math:`\lambda_u`) and
+    ``unbalanced_type``. By default ``unbalanced=None`` and the function
     solves the exact optimal transport problem (respecting the marginals).
 
     Parameters


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Fix references to `jax` and `numpy` functions.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
* added `jax` to the list of mappings (there's `:any:` reference onto `jax.numpy.array` from Quickstart)
* fixed manual references for `np.random.*` functions from backend docstrings (previous links were broken)
* removed `:any:` references from docstrings onto function parameters (`ot.solver`) to avoid warnings when building docs
* fixed markup for `ot.factored` so the references to other modules are working correctly


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
