### PR TITLE
[FEAT] Alpha differentiability in semirelaxed_gromov_wasserstein2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,7 @@
 ## 0.9.1dev
 
 #### New features
+- Make alpha parameter in semi-relaxed Fused Gromov Wasserstein differentiable (PR #483)
 - Make alpha parameter in Fused Gromov Wasserstein differentiable (PR #463)
 - Added the sparsity-constrained OT solver to `ot.smooth` and added ` projection_sparse_simplex` to `ot.utils` (PR #459)
 - Add tests on GPU for master branch and approved PR (PR #473)

--- a/ot/gromov/_semirelaxed.py
+++ b/ot/gromov/_semirelaxed.py
@@ -467,8 +467,15 @@ def semirelaxed_fused_gromov_wasserstein2(M, C1, C2, p, loss_fun='square_loss', 
     if loss_fun == 'square_loss':
         gC1 = 2 * C1 * nx.outer(p, p) - 2 * nx.dot(T, nx.dot(C2, T.T))
         gC2 = 2 * C2 * nx.outer(q, q) - 2 * nx.dot(T.T, nx.dot(C1, T))
-        srfgw_dist = nx.set_gradients(srfgw_dist, (C1, C2, M),
-                                      (alpha * gC1, alpha * gC2, (1 - alpha) * T))
+        if isinstance(alpha, int) or isinstance(alpha, float):
+            srfgw_dist = nx.set_gradients(srfgw_dist, (C1, C2, M),
+                                        (alpha * gC1, alpha * gC2, (1 - alpha) * T))
+        else:
+            lin_term = nx.sum(T * M)
+            srgw_term = (srfgw_dist - (1 - alpha) * lin_term) / alpha
+            srfgw_dist = nx.set_gradients(srfgw_dist, (C1, C2, M, alpha),
+                                        (alpha * gC1, alpha * gC2, (1 - alpha) * T,
+                                         srgw_term - lin_term))
 
     if log:
         return srfgw_dist, log_fgw

--- a/ot/gromov/_semirelaxed.py
+++ b/ot/gromov/_semirelaxed.py
@@ -469,13 +469,13 @@ def semirelaxed_fused_gromov_wasserstein2(M, C1, C2, p, loss_fun='square_loss', 
         gC2 = 2 * C2 * nx.outer(q, q) - 2 * nx.dot(T.T, nx.dot(C1, T))
         if isinstance(alpha, int) or isinstance(alpha, float):
             srfgw_dist = nx.set_gradients(srfgw_dist, (C1, C2, M),
-                                        (alpha * gC1, alpha * gC2, (1 - alpha) * T))
+                                          (alpha * gC1, alpha * gC2, (1 - alpha) * T))
         else:
             lin_term = nx.sum(T * M)
             srgw_term = (srfgw_dist - (1 - alpha) * lin_term) / alpha
             srfgw_dist = nx.set_gradients(srfgw_dist, (C1, C2, M, alpha),
-                                        (alpha * gC1, alpha * gC2, (1 - alpha) * T,
-                                         srgw_term - lin_term))
+                                          (alpha * gC1, alpha * gC2, (1 - alpha) * T,
+                                           srgw_term - lin_term))
 
     if log:
         return srfgw_dist, log_fgw

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -1753,7 +1753,7 @@ def test_semirelaxed_fgw2_gradients():
             assert M1.shape == M1.grad.shape
 
             # full gradients with alpha
-            p1 = torch.tensor(p, requires_grad=True, device=device)
+            p1 = torch.tensor(p, requires_grad=False, device=device)
             C11 = torch.tensor(C1, requires_grad=True, device=device)
             C12 = torch.tensor(C2, requires_grad=True, device=device)
             M1 = torch.tensor(M, requires_grad=True, device=device)
@@ -1764,7 +1764,7 @@ def test_semirelaxed_fgw2_gradients():
             val.backward()
 
             assert val.device == p1.device
-            assert p1.shape == p1.grad.shape
+            assert p1.grad is None
             assert C11.shape == C11.grad.shape
             assert C12.shape == C12.grad.shape
             assert alpha.shape == alpha.grad.shape

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -1752,6 +1752,23 @@ def test_semirelaxed_fgw2_gradients():
             assert C12.shape == C12.grad.shape
             assert M1.shape == M1.grad.shape
 
+            # full gradients with alpha
+            p1 = torch.tensor(p, requires_grad=True, device=device)
+            C11 = torch.tensor(C1, requires_grad=True, device=device)
+            C12 = torch.tensor(C2, requires_grad=True, device=device)
+            M1 = torch.tensor(M, requires_grad=True, device=device)
+            alpha = torch.tensor(0.5, requires_grad=True, device=device)
+
+            val = ot.gromov.semirelaxed_fused_gromov_wasserstein2(M1, C11, C12, p1, alpha=alpha)
+
+            val.backward()
+
+            assert val.device == p1.device
+            assert p1.shape == p1.grad.shape
+            assert C11.shape == C11.grad.shape
+            assert C12.shape == C12.grad.shape
+            assert alpha.shape == alpha.grad.shape
+
 
 def test_srfgw_helper_backend(nx):
     n_samples = 20  # nb samples


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Addition of differentiability over the trade-off parameter $\alpha$ in the `semirelaxed_gromov_wasserstein2` function in `ot/gromov/_semirelaxed.py`.

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
