### PR TITLE
Add EWCA in to ot.dr

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,5 @@ Dictionary Learning](https://arxiv.org/pdf/2102.06555.pdf), International Confer
 [50] Liu, T., Puigcerver, J., & Blondel, M. (2023). [Sparsity-constrained optimal transport](https://openreview.net/forum?id=yHY9NbQJ5BP). Proceedings of the Eleventh International Conference on Learning Representations (ICLR).
 
 [51] Xu, H., Luo, D., Zha, H., & Duke, L. C. (2019). [Gromov-wasserstein learning for graph matching and node embedding](http://proceedings.mlr.press/v97/xu19b.html). In International Conference on Machine Learning (ICML), 2019.
+
+[52] Collas, A., Vayer, T., Flamary, F., & Breloy, A. (2023). [Entropic Wasserstein Component Analysis](https://arxiv.org/abs/2303.05119). ArXiv.

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -385,13 +385,13 @@ def projection_robust_wasserstein(X, Y, a, b, tau, U0=None, reg=0.1, k=2, stopTh
 
 def ewca(X, U0=None, reg=1, k=2, method='BCD', sinkhorn_method='sinkhorn', stopThr=1e-6, maxiter=100, maxiter_sink=1000, maxiter_MM=10, verbose=0):
     r"""
-    Entropic Wasserstein Component Analysis :ref:`[52] <references-entropic-wasserstein-component_analysis>`
+    Entropic Wasserstein Component Analysis :ref:`[52] <references-entropic-wasserstein-component_analysis>`.
 
     The function solves the following optimization problem:
 
     .. math::
         \mathbf{U} = \mathop{\arg \min}_\mathbf{U} \quad
-        W(\mathbf{X}, \mathbf{U}\mathbf{U}^T \\mathbf{X})
+        W(\mathbf{X}, \mathbf{U}\mathbf{U}^T \mathbf{X})
 
     where :
 
@@ -402,33 +402,33 @@ def ewca(X, U0=None, reg=1, k=2, method='BCD', sinkhorn_method='sinkhorn', stopT
     Parameters
     ----------
     X : ndarray, shape (n, d)
-        Samples from measure :math:`\mu`
+        Samples from measure :math:`\mu`.
     U0 : ndarray, shape (d, k), optional
         Initial starting point for projection.
     reg : float, optional
-        Regularization term >0 (entropic regularization)
+        Regularization term >0 (entropic regularization).
     k : int, optional
-        Subspace dimension
+        Subspace dimension.
     method : str, optional
-        Eather 'BCD' or 'MM' (Block Coordinate Descent or Majorization-Minimization)
+        Eather 'BCD' or 'MM' (Block Coordinate Descent or Majorization-Minimization).
         Prefer MM when d is large.
     sinkhorn_method : str
         Method used for the Sinkhorn solver, see :ref:`ot.bregman.sinkhorn` for more details.
     stopThr : float, optional
-        Stop threshold on error (>0)
+        Stop threshold on error (>0).
     maxiter : int, optional
-        Maximum number of iterations of the BCD/MM
+        Maximum number of iterations of the BCD/MM.
     maxiter_sink : int, optional
-        Maximum number of iterations of the Sinkhorn solver
+        Maximum number of iterations of the Sinkhorn solver.
     maxiter_MM : int, optional
-        Maximum number of iterations of the MM (only used when method='MM')
+        Maximum number of iterations of the MM (only used when method='MM').
     verbose : int, optional
         Print information along iterations.
 
     Returns
     -------
     pi : ndarray, shape (n, n)
-        Optimal transportation matrix for the given parameters
+        Optimal transportation matrix for the given parameters.
     U : ndarray, shape (d, k)
         Matrix Stiefel manifold.
 
@@ -437,7 +437,7 @@ def ewca(X, U0=None, reg=1, k=2, method='BCD', sinkhorn_method='sinkhorn', stopT
     References
     ----------
     .. [52] Collas, A., Vayer, T., Flamary, F., & Breloy, A. (2023).
-            Entropic Wasserstein Component Analysis
+            Entropic Wasserstein Component Analysis.
     """  # noqa
     n, d = X.shape
     X = X - X.mean(0)

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -383,7 +383,7 @@ def projection_robust_wasserstein(X, Y, a, b, tau, U0=None, reg=0.1, k=2, stopTh
     return pi, U
 
 
-def ewca(X, U0=None, reg=1, k=2, method='BCD', sinkhorn_method='sinkhorn', stopThr=1e-3, maxiter=100, maxiter_sink=100, maxiter_MM=10, verbose=0):
+def ewca(X, U0=None, reg=1, k=2, method='BCD', sinkhorn_method='sinkhorn', stopThr=1e-6, maxiter=100, maxiter_sink=1000, maxiter_MM=10, verbose=0):
     r"""
     Entropic Wasserstein Component Analysis :ref:`[52] <references-entropic-wasserstein-component_analysis>`
 


### PR DESCRIPTION
## Types of changes
Add function `ewca` into `ot.dr` module.


## Motivation and context / Related issue
Add dimensionality reduction method called Entropic Wasserstein Component Analysis from the paper https://arxiv.org/abs/2303.05119.


## How has this been tested (if it applies)
Add a test in `test/test_dr.py` that checks that the `ewca` function estimates the first and last principle components when its regularisation parameter is low and high, respectively. 



## PR checklist

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
