### PR TITLE
[MTN] more permissive check_backend

### DIFF
--- a/ot/backend.py
+++ b/ot/backend.py
@@ -165,7 +165,7 @@ def get_backend(*args):
 
     for backend in _BACKENDS:
         if _check_args_backend(backend, args):
-            return backend()
+            return backend
 
     raise ValueError("Unknown type of non implemented backend.")
 
@@ -1312,7 +1312,7 @@ class NumpyBackend(Backend):
         return np.matmul(a, b)
 
 
-register_backend(NumpyBackend)
+register_backend(NumpyBackend())
 
 
 class JaxBackend(Backend):
@@ -1675,7 +1675,7 @@ class JaxBackend(Backend):
 
 if jax:
     # Only register jax backend if it is installed
-    register_backend(JaxBackend)
+    register_backend(JaxBackend())
 
 
 class TorchBackend(Backend):
@@ -2152,7 +2152,7 @@ class TorchBackend(Backend):
 
 if torch:
     # Only register torch backend if it is installed
-    register_backend(TorchBackend)
+    register_backend(TorchBackend())
 
 
 class CupyBackend(Backend):  # pragma: no cover
@@ -2539,7 +2539,7 @@ class CupyBackend(Backend):  # pragma: no cover
 
 if cp:
     # Only register cp backend if it is installed
-    register_backend(CupyBackend)
+    register_backend(CupyBackend())
 
 
 class TensorflowBackend(Backend):
@@ -2946,4 +2946,4 @@ class TensorflowBackend(Backend):
 
 if tf:
     # Only register tensorflow backend if it is installed
-    register_backend(TensorflowBackend)
+    register_backend(TensorflowBackend())

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -131,23 +131,27 @@ except ImportError:
 str_type_error = "All array should be from the same type/backend. Current types are : {}"
 
 
+# Mapping between argument types and the existing backend
+_BACKENDS = []
+
+
+def register_backend(backend):
+    _BACKENDS.append(backend)
+
+
 def get_backend_list():
     """Returns the list of available backends"""
-    lst = [NumpyBackend(), ]
+    return _BACKENDS
 
-    if torch:
-        lst.append(TorchBackend())
 
-    if jax:
-        lst.append(JaxBackend())
+def _check_args_backend(backend, args):
+    is_instance = set(isinstance(a, backend.__type__) for a in args)
+    # check that all arguments matched or not the type
+    if len(is_instance) == 1:
+        return is_instance.pop()
 
-    if cp:  # pragma: no cover
-        lst.append(CupyBackend())
-
-    if tf:
-        lst.append(TensorflowBackend())
-
-    return lst
+    # Oterwise return an error
+    raise ValueError(str_type_error.format([type(a) for a in args]))
 
 
 def get_backend(*args):
@@ -158,22 +162,12 @@ def get_backend(*args):
     # check that some arrays given
     if not len(args) > 0:
         raise ValueError(" The function takes at least one parameter")
-    # check all same type
-    if not len(set(type(a) for a in args)) == 1:
-        raise ValueError(str_type_error.format([type(a) for a in args]))
 
-    if isinstance(args[0], np.ndarray):
-        return NumpyBackend()
-    elif isinstance(args[0], torch_type):
-        return TorchBackend()
-    elif isinstance(args[0], jax_type):
-        return JaxBackend()
-    elif isinstance(args[0], cp_type):  # pragma: no cover
-        return CupyBackend()
-    elif isinstance(args[0], tf_type):
-        return TensorflowBackend()
-    else:
-        raise ValueError("Unknown type of non implemented backend.")
+    for backend in _BACKENDS:
+        if _check_args_backend(backend, args):
+            return backend()
+
+    raise ValueError("Unknown type of non implemented backend.")
 
 
 def to_numpy(*args):
@@ -1318,6 +1312,9 @@ class NumpyBackend(Backend):
         return np.matmul(a, b)
 
 
+register_backend(NumpyBackend)
+
+
 class JaxBackend(Backend):
     """
     JAX implementation of the backend
@@ -1674,6 +1671,11 @@ class JaxBackend(Backend):
 
     def matmul(self, a, b):
         return jnp.matmul(a, b)
+
+
+if jax:
+    # Only register jax backend if it is installed
+    register_backend(JaxBackend)
 
 
 class TorchBackend(Backend):
@@ -2148,6 +2150,11 @@ class TorchBackend(Backend):
         return torch.matmul(a, b)
 
 
+if torch:
+    # Only register torch backend if it is installed
+    register_backend(TorchBackend)
+
+
 class CupyBackend(Backend):  # pragma: no cover
     """
     CuPy implementation of the backend
@@ -2528,6 +2535,11 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def matmul(self, a, b):
         return cp.matmul(a, b)
+
+
+if cp:
+    # Only register cp backend if it is installed
+    register_backend(CupyBackend)
 
 
 class TensorflowBackend(Backend):
@@ -2930,3 +2942,8 @@ class TensorflowBackend(Backend):
 
     def matmul(self, a, b):
         return tnp.matmul(a, b)
+
+
+if tf:
+    # Only register tensorflow backend if it is installed
+    register_backend(TensorflowBackend)

--- a/ot/partial.py
+++ b/ot/partial.py
@@ -873,7 +873,7 @@ def entropic_partial_wasserstein(a, b, M, reg, m=None, numItermax=1000,
 
     log_e = {'err': []}
 
-    if type(a) == type(b) == type(M) == np.ndarray:
+    if nx.__name__ == "numpy":
         # Next 3 lines equivalent to K=nx.exp(-M/reg), but faster to compute
         K = np.empty(M.shape, dtype=M.dtype)
         np.divide(M, -reg, out=K)

--- a/ot/stochastic.py
+++ b/ot/stochastic.py
@@ -258,7 +258,7 @@ def c_transform_entropic(b, M, reg, beta):
 
 
 def solve_semi_dual_entropic(a, b, M, reg, method, numItermax=10000, lr=None,
-                                log=False):
+                             log=False):
     r'''
     Compute the transportation matrix to solve the regularized discrete measures optimal transport max problem
 

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -7,7 +7,7 @@
 
 import ot
 import ot.backend
-from ot.backend import torch, jax, cp, tf
+from ot.backend import torch, jax, tf
 
 import pytest
 


### PR DESCRIPTION
With the current behavior, the `check_backend` helper fails when one of the arguments is a subtype of the base type of the backend. For instance, if one argument is a `memmap`, while it is still a `ndarray`, the `check_backend` raises a `ValueError`.

This PR makes the helper check the type of all arguments with `isinstance`. It also refactors the API to ease the backend management. 