### PR TITLE
[MRG] Issue warning when numerical error happens in `empirical_bures_wasserstein_mapping`

### DIFF
--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -8,9 +8,10 @@ Optimal transport for Gaussian distributions
 #
 # License: MIT License
 
+import warnings
+
 from .backend import get_backend
-from .utils import dots
-from .utils import list_to_array
+from .utils import dots, is_all_finite, list_to_array
 
 
 def bures_wasserstein_mapping(ms, mt, Cs, Ct, log=False):
@@ -72,6 +73,7 @@ def bures_wasserstein_mapping(ms, mt, Cs, Ct, log=False):
     """
     ms, mt, Cs, Ct = list_to_array(ms, mt, Cs, Ct)
     nx = get_backend(ms, mt, Cs, Ct)
+    is_input_finite = is_all_finite(ms, mt, Cs, Ct)
 
     Cs12 = nx.sqrtm(Cs)
     Cs12inv = nx.inv(Cs12)
@@ -81,6 +83,9 @@ def bures_wasserstein_mapping(ms, mt, Cs, Ct, log=False):
     A = dots(Cs12inv, M0, Cs12inv)
 
     b = mt - nx.dot(ms, A)
+
+    if is_input_finite and not is_all_finite(A, b):
+        warnings.warn("Warning: 'bures_wasserstein_mapping' caused numerical errors.")
 
     if log:
         log = {}
@@ -235,11 +240,16 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     """
     ms, mt, Cs, Ct = list_to_array(ms, mt, Cs, Ct)
     nx = get_backend(ms, mt, Cs, Ct)
+    is_input_finite = is_all_finite(ms, mt, Cs, Ct)
 
     Cs12 = nx.sqrtm(Cs)
 
     B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
     W = nx.sqrt(nx.norm(ms - mt)**2 + B)
+
+    if is_input_finite and not is_all_finite(W):
+        warnings.warn("Warning: 'bures_wasserstein_distance' caused numerical errors.")
+
     if log:
         log = {}
         log['Cs12'] = Cs12

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -85,7 +85,7 @@ def bures_wasserstein_mapping(ms, mt, Cs, Ct, log=False):
     b = mt - nx.dot(ms, A)
 
     if is_input_finite and not is_all_finite(A, b):
-        warnings.warn("Warning: 'bures_wasserstein_mapping' caused numerical errors.")
+        warnings.warn("Numerical errors encountered in ot.gaussian.bures_wasserstein_mapping")
 
     if log:
         log = {}
@@ -248,7 +248,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     W = nx.sqrt(nx.norm(ms - mt)**2 + B)
 
     if is_input_finite and not nx.isfinite(W):
-        warnings.warn("Warning: 'bures_wasserstein_distance' caused numerical errors.")
+        warnings.warn("Numerical errors encountered in ot.gaussian.bures_wasserstein_distance")
 
     if log:
         log = {}

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -247,7 +247,7 @@ def bures_wasserstein_distance(ms, mt, Cs, Ct, log=False):
     B = nx.trace(Cs + Ct - 2 * nx.sqrtm(dots(Cs12, Ct, Cs12)))
     W = nx.sqrt(nx.norm(ms - mt)**2 + B)
 
-    if is_input_finite and not is_all_finite(W):
+    if is_input_finite and not nx.isfinite(W):
         warnings.warn("Warning: 'bures_wasserstein_distance' caused numerical errors.")
 
     if log:

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -387,7 +387,7 @@ def dots(*args):
 def is_all_finite(*args):
     r"""Tests element-wise for finiteness in all arguments."""
     nx = get_backend(*args)
-    return reduce(lambda f: nx.all(nx.isfinite(f)), args)
+    return all(not nx.any(~nx.isfinite(arg)) for arg in args)
 
 
 def label_normalization(y, start=0):

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -384,6 +384,12 @@ def dots(*args):
     return reduce(nx.dot, args)
 
 
+def is_all_finite(*args):
+    r"""Tests element-wise for finiteness in all arguments."""
+    nx = get_backend(*args)
+    return reduce(lambda f: nx.all(nx.isfinite(f)), args)
+
+
 def label_normalization(y, start=0):
     r""" Transform labels to start at a given value
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -71,11 +71,12 @@ def test_empirical_bures_wasserstein_mapping(nx, bias):
     np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
 
 
-def test_empirical_bures_wasserstein_mapping_instabilities_warning():
-    Xs = np.random.rand(2000, 1000)
-    Xt = np.random.rand(2000, 1000)
+def test_empirical_bures_wasserstein_mapping_numerical_error_warning():
+    rng = np.random.RandomState(42)
+    Xs = rng.rand(766, 800) * 5
+    Xt = rng.rand(295, 800) * 2
     with pytest.warns():
-        A, b = ot.gaussian.empirical_bures_wasserstein_mapping(Xs, Xt)
+        A, b = ot.gaussian.empirical_bures_wasserstein_mapping(Xs, Xt, reg=1e-8)
         assert not is_all_finite(A, b)
 
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -72,8 +72,8 @@ def test_empirical_bures_wasserstein_mapping(nx, bias):
 
 
 def test_empirical_bures_wasserstein_mapping_instabilities_warning():
-    Xs = np.random.rand(10, 1000)
-    Xt = np.random.rand(10, 1000)
+    Xs = np.random.rand(2000, 1000)
+    Xt = np.random.rand(2000, 1000)
     with pytest.warns():
         A, b = ot.gaussian.empirical_bures_wasserstein_mapping(Xs, Xt)
         assert not is_all_finite(A, b)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -11,6 +11,7 @@ import pytest
 
 import ot
 from ot.datasets import make_data_classif
+from ot.utils import is_all_finite
 
 
 def test_bures_wasserstein_mapping(nx):
@@ -68,6 +69,14 @@ def test_empirical_bures_wasserstein_mapping(nx, bias):
 
     np.testing.assert_allclose(Cst_log, Cst, rtol=1e-2, atol=1e-2)
     np.testing.assert_allclose(Ct, Cst, rtol=1e-2, atol=1e-2)
+
+
+def test_empirical_bures_wasserstein_mapping_instabilities_warning():
+    Xs = np.random.rand(10, 1000)
+    Xt = np.random.rand(10, 1000)
+    with pytest.warns():
+        A, b = ot.gaussian.empirical_bures_wasserstein_mapping(Xs, Xt)
+        assert not is_all_finite(A, b)
 
 
 def test_bures_wasserstein_distance(nx):


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Issue `UserWarning` when `ot.gaussian.empirical_bures_wasserstein_mapping` returns matrix of NaNs. This happens when min eigenvalue turns out to be negative in `sqrtm`, typically requires `reg` parameter to be increased.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
New test case with a simple reproducer is added.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
