### PR TITLE
Prevent line search from evaluating cost outside of the interpolation range

### DIFF
--- a/ot/optim.py
+++ b/ot/optim.py
@@ -27,7 +27,7 @@ with warnings.catch_warnings():
 
 def line_search_armijo(
     f, xk, pk, gfk, old_fval, args=(), c1=1e-4,
-    alpha0=0.99, alpha_min=None, alpha_max=None, nx=None, **kwargs
+    alpha0=0.99, alpha_min=0., alpha_max=None, nx=None, **kwargs
 ):
     r"""
     Armijo linesearch function that works with matrices
@@ -56,7 +56,7 @@ def line_search_armijo(
         :math:`c_1` const in armijo rule (>0)
     alpha0 : float, optional
         initial step (>0)
-    alpha_min : float, optional
+    alpha_min : float, default=0.
         minimum value for alpha
     alpha_max : float, optional
         maximum value for alpha
@@ -89,6 +89,14 @@ def line_search_armijo(
     fc = [0]
 
     def phi(alpha1):
+        # it's necessary to check boundary condition here for the coefficient
+        # as the callback could be evaluated for negative value of alpha by
+        # `scalar_search_armijo` function here:
+        #
+        # https://github.com/scipy/scipy/blob/11509c4a98edded6c59423ac44ca1b7f28fba1fd/scipy/optimize/linesearch.py#L686
+        #
+        # see more details https://github.com/PythonOT/POT/issues/502
+        alpha1 = np.clip(alpha1, alpha_min, alpha_max)
         # The callable function operates on nx backend
         fc[0] += 1
         alpha10 = nx.from_numpy(alpha1)
@@ -109,13 +117,12 @@ def line_search_armijo(
 
     derphi0 = np.sum(pk * gfk)  # Quickfix for matrices
     alpha, phi1 = scalar_search_armijo(
-        phi, phi0, derphi0, c1=c1, alpha0=alpha0)
+        phi, phi0, derphi0, c1=c1, alpha0=alpha0, amin=alpha_min)
 
     if alpha is None:
         return 0., fc[0], nx.from_numpy(phi0, type_as=xk0)
     else:
-        if alpha_min is not None or alpha_max is not None:
-            alpha = np.clip(alpha, alpha_min, alpha_max)
+        alpha = np.clip(alpha, alpha_min, alpha_max)
         return nx.from_numpy(alpha, type_as=xk0), fc[0], nx.from_numpy(phi1, type_as=xk0)
 
 

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -7,6 +7,7 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pytest
+import warnings
 
 import ot
 from ot.datasets import make_data_classif
@@ -166,7 +167,9 @@ def test_sinkhorn_l1l2_transport_class(nx):
     otda = ot.da.SinkhornL1l2Transport()
 
     # test its computed
-    otda.fit(Xs=Xs, ys=ys, Xt=Xt)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        otda.fit(Xs=Xs, ys=ys, Xt=Xt)
     assert hasattr(otda, "cost_")
     assert hasattr(otda, "coupling_")
     assert hasattr(otda, "log_")


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
`alpha_min` parameter for `ot.optim.line_search_armijo` now has default value 0. Additional boundary condition check is introduce inside of line search callback.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
PR closes #502, you can find detailed analysis of the problem there.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
Existing `test_sinkhorn_l1l2_transport_class` test case now has explicit check for "no warnings".


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
