### PR TITLE
[MRG] Gracefully handle cost = 0 in `generic_conditional_gradient`

### DIFF
--- a/ot/optim.py
+++ b/ot/optim.py
@@ -290,7 +290,7 @@ def generic_conditional_gradient(a, b, M, f, df, reg1, reg2, lp_solver, line_sea
             loop = 0
 
         abs_delta_cost_G = abs(cost_G - old_cost_G)
-        relative_delta_cost_G = abs_delta_cost_G / abs(cost_G)
+        relative_delta_cost_G = abs_delta_cost_G / abs(cost_G) if cost_G != 0. else np.nan
         if relative_delta_cost_G < stopThr or abs_delta_cost_G < stopThr2:
             loop = 0
 

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -8,10 +8,12 @@
 # License: MIT License
 
 import numpy as np
+import pytest
+import warnings
+
 import ot
 from ot.backend import NumpyBackend
 from ot.backend import torch, tf
-import pytest
 
 
 def test_gromov(nx):
@@ -146,8 +148,10 @@ def test_gromov_dtype_device(nx):
 
         C1b, C2b, pb, qb, G0b = nx.from_numpy(C1, C2, p, q, G0, type_as=tp)
 
-        Gb = ot.gromov.gromov_wasserstein(C1b, C2b, pb, qb, 'square_loss', G0=G0b, verbose=True)
-        gw_valb = ot.gromov.gromov_wasserstein2(C1b, C2b, pb, qb, 'kl_loss', armijo=True, G0=G0b, log=False)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            Gb = ot.gromov.gromov_wasserstein(C1b, C2b, pb, qb, 'square_loss', G0=G0b, verbose=True)
+            gw_valb = ot.gromov.gromov_wasserstein2(C1b, C2b, pb, qb, 'kl_loss', armijo=True, G0=G0b, log=False)
 
         nx.assert_same_dtype_device(C1b, Gb)
         nx.assert_same_dtype_device(C1b, gw_valb)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
`relative_delta_cost_G` in `generic_conditional_gradient` is only computed when the cost != 0.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
As the contract for cost evaluation in `generic_conditional_gradient` is rather generic, it could be the case it's set to 0. In this case computing `relative_delta_cost_G` fails because of zero division. As we only need the value of `relative_delta_cost_G` for early stopping condition, it doesn't hurt to skip the computation when cost is 0.

The code to reproduce the issue:

```python
import numpy as np
import ot
import ot.datasets

n_samples = 50
mu_s = np.array([0, 0])
cov_s = np.array([[1, 0], [0, 1]])
xs = ot.datasets.make_2D_samples_gauss(n_samples, mu_s, cov_s, random_state=4)
xt = xs[::-1].copy()
p = ot.unif(n_samples)
q = ot.unif(n_samples)
G0 = p[:, None] * q[None, :]
C1 = ot.dist(xs, xs)
C2 = ot.dist(xt, xt)
C1 /= C1.max()
C2 /= C2.max()
ot.gromov.gromov_wasserstein(C1, C2, p, q, 'square_loss', G0=G0, verbose=True)
```

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
This actually happens in `test_gromov_dtype_device` test case. The test case is not modified to ensure we don't have warnings when computing `ot.gromov.gromov_wasserstein`.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
