### PR TITLE
Use local random state in `ot.datasets.make_data_classif`

### DIFF
--- a/ot/datasets.py
+++ b/ot/datasets.py
@@ -155,7 +155,7 @@ def make_data_classif(dataset, n, nz=.5, theta=0, p=.5, random_state=None, **kwa
     elif dataset.lower() == '2gauss_prop':
 
         y = np.concatenate((np.ones(int(p * n)), np.zeros(int((1 - p) * n))))
-        x = np.hstack((0 * y[:, None] - 0, 1 - 2 * y[:, None])) + nz * np.random.randn(len(y), 2)
+        x = np.hstack((0 * y[:, None] - 0, 1 - 2 * y[:, None])) + nz * generator.randn(len(y), 2)
 
         if ('bias' not in kwargs) and ('b' not in kwargs):
             kwargs['bias'] = np.array([0, 2])


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Switch from `np.random.randn` to `rng.randn` when generating `make_data_classif` dataset with `dataset='2gauss_prop'`.

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
It's not desirable to change global state. And it's already done for other datasets in the same function.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
n/a


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
