### PR TITLE
Remove debug print statement from entropic FBG

### DIFF
--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -1004,7 +1004,6 @@ def entropic_fused_gromov_barycenters(
                 print('{:5d}|{:8e}|'.format(cpt, err_feature))
 
         cpt += 1
-        print('Y type:', type(Y))
     if log:
         log_['T'] = T  # from target to Ys
         log_['p'] = p


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Remove `print` statement about input datatype.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Seems like this is a debugging leftover. This information is not really helpful as it doesn't change, and it makes harder to read output when `verbose` is set to `True`.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
n/a


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
