### PR TITLE
Validate `loss_fun` parameter in Gromov-Wasserstein utils

### DIFF
--- a/ot/gromov/_utils.py
+++ b/ot/gromov/_utils.py
@@ -405,9 +405,9 @@ def init_matrix_semirelaxed(C1, C2, p, loss_fun='square_loss', nx=None):
         Metric cost matrix in the source space
     C2 : array-like, shape (nt, nt)
         Metric cost matrix in the target space
-    T :  array-like, shape (ns, nt)
-        Coupling between source and target spaces
     p : array-like, shape (ns,)
+    loss_fun : str, optional
+        Name of loss function to use: either 'square_loss' or 'kl_loss' (default='square_loss')
     nx : backend, optional
         If let to its default value None, a backend test will be conducted.
 

--- a/ot/gromov/_utils.py
+++ b/ot/gromov/_utils.py
@@ -72,6 +72,7 @@ def init_matrix(C1, C2, p, q, loss_fun='square_loss', nx=None):
         Name of loss function to use: either 'square_loss' or 'kl_loss' (default='square_loss')
     nx : backend, optional
         If let to its default value None, a backend test will be conducted.
+
     Returns
     -------
     constC : array-like, shape (ns, nt)
@@ -118,6 +119,8 @@ def init_matrix(C1, C2, p, q, loss_fun='square_loss', nx=None):
 
         def h2(b):
             return nx.log(b + 1e-15)
+    else:
+        raise ValueError(f"Unknown `loss_fun='{loss_fun}'`. Use one of: {'square_loss', 'kl_loss'}.")
 
     constC1 = nx.dot(
         nx.dot(f1(C1), nx.reshape(p, (-1, 1))),
@@ -407,6 +410,7 @@ def init_matrix_semirelaxed(C1, C2, p, loss_fun='square_loss', nx=None):
     p : array-like, shape (ns,)
     nx : backend, optional
         If let to its default value None, a backend test will be conducted.
+
     Returns
     -------
     constC : array-like, shape (ns, nt)
@@ -446,6 +450,10 @@ def init_matrix_semirelaxed(C1, C2, p, loss_fun='square_loss', nx=None):
 
         def h2(b):
             return 2 * b
+    elif loss_fun == 'kl_loss':
+        raise NotImplementedError()
+    else:
+        raise ValueError(f"Unknown `loss_fun='{loss_fun}'`. Only 'square_loss' is supported.")
 
     constC = nx.dot(nx.dot(f1(C1), nx.reshape(p, (-1, 1))),
                     nx.ones((1, C2.shape[0]), type_as=p))

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -291,6 +291,24 @@ def test_gw_helper_backend(nx):
     np.testing.assert_allclose(res, Gb, atol=1e-06)
 
 
+@pytest.mark.parametrize('loss_fun', [
+    'square_loss',
+    'kl_loss',
+    pytest.param('unknown_loss', marks=pytest.mark.xfail(raises=ValueError)),
+])
+def test_gw_helper_validation(loss_fun):
+    n_samples = 20  # nb samples
+    mu = np.array([0, 0])
+    cov = np.array([[1, 0], [0, 1]])
+    xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=0)
+    xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=1)
+    p = ot.unif(n_samples)
+    q = ot.unif(n_samples)
+    C1 = ot.dist(xs, xs)
+    C2 = ot.dist(xt, xt)
+    ot.gromov.init_matrix(C1, C2, p, q, loss_fun=loss_fun)
+
+
 @pytest.skip_backend("jax", reason="test very slow with jax backend")
 @pytest.skip_backend("tf", reason="test very slow with tf backend")
 def test_entropic_gromov(nx):
@@ -2024,6 +2042,24 @@ def test_srgw_helper_backend(nx):
     res, log = ot.optim.semirelaxed_cg(pb, qb, 0., 1., f, df, Gb, line_search, log=True, numItermax=1e4, stopThr=1e-9, stopThr2=1e-9)
     # check constraints
     np.testing.assert_allclose(res, Gb, atol=1e-06)
+
+
+@pytest.mark.parametrize('loss_fun', [
+    'square_loss',
+    pytest.param('kl_loss', marks=pytest.mark.xfail(raises=NotImplementedError)),
+    pytest.param('unknown_loss', marks=pytest.mark.xfail(raises=ValueError)),
+])
+def test_gw_semirelaxed_helper_validation(loss_fun):
+    n_samples = 20  # nb samples
+    mu = np.array([0, 0])
+    cov = np.array([[1, 0], [0, 1]])
+    xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=0)
+    xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=1)
+    p = ot.unif(n_samples)
+    q = ot.unif(n_samples)
+    C1 = ot.dist(xs, xs)
+    C2 = ot.dist(xt, xt)
+    ot.gromov.init_matrix_semirelaxed(C1, C2, p, loss_fun=loss_fun)
 
 
 def test_semirelaxed_fgw(nx):

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -2056,7 +2056,6 @@ def test_gw_semirelaxed_helper_validation(loss_fun):
     xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=0)
     xt = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=1)
     p = ot.unif(n_samples)
-    q = ot.unif(n_samples)
     C1 = ot.dist(xs, xs)
     C2 = ot.dist(xt, xt)
     ot.gromov.init_matrix_semirelaxed(C1, C2, p, loss_fun=loss_fun)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
`ot.gromov._utils.init_matrix` raises `ValueError` when unknown `loss_fun` is given.
`ot.gromov._utils.init_matrix_semirelaxed` raises `NotImplementedError` for `loss_fun='kl_loss'`.
`ot.gromov._utils.init_matrix_semirelaxed` raises `ValueError` for unknown `loss_fun`.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Error message is rather hard to understand when unsupported loss_fun is used (as the code makes an attempt to call undefined function).


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
New test cases are provided.


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
