### PR TITLE
[MRG] get_backend compatibility with None entries

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 0.9.2dev
+
+Tweaked `get_backend` to ignore `None` inputs (PR # 525)
+
 ## 0.9.1
 *August 2023*
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,11 @@
 
 ## 0.9.2dev
 
-Tweaked `get_backend` to ignore `None` inputs (PR # 525)
+#### New features
++ Tweaked `get_backend` to ignore `None` inputs (PR # 525)
+
+#### Closed issues
+
 
 ## 0.9.1
 *August 2023*

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -157,11 +157,15 @@ def _check_args_backend(backend, args):
 def get_backend(*args):
     """Returns the proper backend for a list of input arrays
 
+        Accepts None entries in the arguments, and ignores them
+
         Also raises TypeError if all arrays are not from the same backend
     """
+    args = [arg for arg in args if arg is not None]  # exclude None entries
+
     # check that some arrays given
     if not len(args) > 0:
-        raise ValueError(" The function takes at least one parameter")
+        raise ValueError(" The function takes at least one (non-None) parameter")
 
     for backend in _BACKENDS:
         if _check_args_backend(backend, args):

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -3,6 +3,7 @@
 # Author: Remi Flamary <remi.flamary@polytechnique.edu>
 #         Nicolas Courty <ncourty@irisa.fr>
 #
+#
 # License: MIT License
 
 import ot
@@ -753,3 +754,11 @@ def test_gradients_backends():
             [dl_dw, dl_db] = tape.gradient(manipulated_loss, [w, b])
             assert nx.allclose(dl_dw, w)
             assert nx.allclose(dl_db, b)
+
+
+def test_get_backend_none():
+    a, b = np.zeros((2, 3)), None
+    nx = get_backend(a, b)
+    assert str(nx) == 'numpy'
+    with pytest.raises(ValueError):
+        get_backend(None, None)


### PR DESCRIPTION
## Types of changes
Tweaked the code for get_backend so as to ignore None entries



## Motivation and context / Related issue
This is a convenience addition for optional arguments:
```python
def f(a, b=None):
     nx = get_backend(a, b)
```
will be nicer that
```python
def f(a,b=None):
     if b is None:
          nx = get_backend(a)
     else:
          nx = get_backend(a, b)
```
especially in the case where there are a lot of optional arrays, where the amount of required `if` statements is combinatorial.


## How has this been tested (if it applies)
Added a test in `test/test_backend.py`. Ran and passed the test workflow. 



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
