### PR TITLE
[MRG] New API for gromov solvers

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@
 + Callbacks for generalized conditional gradient in `ot.da.sinkhorn_l1l2_gl` are now vectorized to improve performance (PR #507)
 + The `linspace` method of the backends now has the `type_as` argument to convert to the same dtype and device. (PR #533)
 + The `convolutional_barycenter2d` and `convolutional_barycenter2d_debiased` functions now work with different devices.. (PR #533)
++ New API for Gromov-Wasserstein solvers with `ot.solve_gromov` function (PR #536)
 
 #### Closed issues
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -50,7 +50,7 @@ from .gromov import (gromov_wasserstein, gromov_wasserstein2,
                      gromov_barycenters, fused_gromov_wasserstein, fused_gromov_wasserstein2)
 from .weak import weak_optimal_transport
 from .factored import factored_optimal_transport
-from .solvers import solve
+from .solvers import solve, solve_gromov
 
 # utils functions
 from .utils import dist, unif, tic, toc, toq

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -65,7 +65,7 @@ __all__ = ['emd', 'emd2', 'emd_1d', 'sinkhorn', 'sinkhorn2', 'utils',
            'sinkhorn_unbalanced2', 'sliced_wasserstein_distance', 'sliced_wasserstein_sphere',
            'gromov_wasserstein', 'gromov_wasserstein2', 'gromov_barycenters', 'fused_gromov_wasserstein',
            'fused_gromov_wasserstein2', 'max_sliced_wasserstein_distance', 'weak_optimal_transport',
-           'factored_optimal_transport', 'solve',
+           'factored_optimal_transport', 'solve', 'solve_gromov',
            'smooth', 'stochastic', 'unbalanced', 'partial', 'regpath', 'solvers',
            'binary_search_circle', 'wasserstein_circle',
            'semidiscrete_wasserstein2_unif_circle', 'sliced_wasserstein_sphere_unif']

--- a/ot/da.py
+++ b/ot/da.py
@@ -2274,6 +2274,7 @@ class NearestBrenierPotential(BaseTransport):
     ot.mapping.nearest_brenier_potential_fit : Fitting the SSNB on source and target data
     ot.mapping.nearest_brenier_potential_predict_bounds : Predicting SSNB images on new source data
     """
+
     def __init__(self, strongly_convex_constant=0.6, gradient_lipschitz_constant=1.4, log=False, its=100, seed=None):
         self.strongly_convex_constant = strongly_convex_constant
         self.gradient_lipschitz_constant = gradient_lipschitz_constant

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -330,6 +330,7 @@ def entropic_gromov_wasserstein2(
         learning for graph matching and node embedding. In International
         Conference on Machine Learning (ICML), 2019.
     """
+
     T, logv = entropic_gromov_wasserstein(
         C1, C2, p, q, loss_fun, epsilon, symmetric, G0, max_iter,
         tol, solver, warmstart, verbose, log=True, **kwargs)
@@ -815,11 +816,20 @@ def entropic_fused_gromov_wasserstein2(
         (ICML). 2019.
 
     """
+
+    nx = get_backend(M, C1, C2)
+
     T, logv = entropic_fused_gromov_wasserstein(
         M, C1, C2, p, q, loss_fun, epsilon, symmetric, alpha, G0, max_iter,
         tol, solver, warmstart, verbose, log=True, **kwargs)
 
     logv['T'] = T
+
+    lin_term = nx.sum(T * M)
+    gw_term = (logv['gw_dist'] - (1 - alpha) * lin_term) / alpha
+
+    log_fgw['quad_loss'] = gw_term * alpha
+    log_fgw['lin_loss'] = lin_term * (1 - alpha)
 
     if log:
         return logv['fgw_dist'], logv

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -826,10 +826,10 @@ def entropic_fused_gromov_wasserstein2(
     logv['T'] = T
 
     lin_term = nx.sum(T * M)
-    gw_term = (logv['gw_dist'] - (1 - alpha) * lin_term) / alpha
+    gw_term = (logv['fgw_dist'] - (1 - alpha) * lin_term) / alpha
 
-    log_fgw['quad_loss'] = gw_term * alpha
-    log_fgw['lin_loss'] = lin_term * (1 - alpha)
+    logv['quad_loss'] = gw_term * alpha
+    logv['lin_loss'] = lin_term * (1 - alpha)
 
     if log:
         return logv['fgw_dist'], logv

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -826,9 +826,7 @@ def entropic_fused_gromov_wasserstein2(
     logv['T'] = T
 
     lin_term = nx.sum(T * M)
-    gw_term = (logv['fgw_dist'] - (1 - alpha) * lin_term) / alpha
-
-    logv['quad_loss'] = gw_term * alpha
+    logv['quad_loss'] = (logv['fgw_dist'] - (1 - alpha) * lin_term)
     logv['lin_loss'] = lin_term * (1 - alpha)
 
     if log:

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -584,9 +584,7 @@ def fused_gromov_wasserstein2(M, C1, C2, p=None, q=None, loss_fun='square_loss',
 
     # compute separate terms for gradients and log
     lin_term = nx.sum(T * M)
-    gw_term = (fgw_dist - (1 - alpha) * lin_term) / alpha
-
-    log_fgw['quad_loss'] = gw_term * alpha
+    log_fgw['quad_loss'] = (fgw_dist - (1 - alpha) * lin_term)
     log_fgw['lin_loss'] = lin_term * (1 - alpha)
 
     if loss_fun == 'square_loss':

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -586,6 +586,7 @@ def fused_gromov_wasserstein2(M, C1, C2, p=None, q=None, loss_fun='square_loss',
     lin_term = nx.sum(T * M)
     log_fgw['quad_loss'] = (fgw_dist - (1 - alpha) * lin_term)
     log_fgw['lin_loss'] = lin_term * (1 - alpha)
+    gw_term = log_fgw['quad_loss'] / alpha
 
     if loss_fun == 'square_loss':
         gC1 = 2 * C1 * nx.outer(p, p) - 2 * nx.dot(T, nx.dot(C2, T.T))

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -582,6 +582,13 @@ def fused_gromov_wasserstein2(M, C1, C2, p=None, q=None, loss_fun='square_loss',
     fgw_dist = log_fgw['fgw_dist']
     log_fgw['T'] = T
 
+    # compute separate terms for gradients and log
+    lin_term = nx.sum(T * M)
+    gw_term = (fgw_dist - (1 - alpha) * lin_term) / alpha
+
+    log_fgw['quad_loss'] = gw_term * alpha
+    log_fgw['lin_loss'] = lin_term * (1 - alpha)
+
     if loss_fun == 'square_loss':
         gC1 = 2 * C1 * nx.outer(p, p) - 2 * nx.dot(T, nx.dot(C2, T.T))
         gC2 = 2 * C2 * nx.outer(q, q) - 2 * nx.dot(T.T, nx.dot(C1, T))
@@ -591,8 +598,7 @@ def fused_gromov_wasserstein2(M, C1, C2, p=None, q=None, loss_fun='square_loss',
                                          log_fgw['v'] - nx.mean(log_fgw['v']),
                                          alpha * gC1, alpha * gC2, (1 - alpha) * T))
         else:
-            lin_term = nx.sum(T * M)
-            gw_term = (fgw_dist - (1 - alpha) * lin_term) / alpha
+
             fgw_dist = nx.set_gradients(fgw_dist, (p, q, C1, C2, M, alpha),
                                         (log_fgw['u'] - nx.mean(log_fgw['u']),
                                          log_fgw['v'] - nx.mean(log_fgw['v']),

--- a/ot/gromov/_semirelaxed.py
+++ b/ot/gromov/_semirelaxed.py
@@ -488,6 +488,8 @@ def semirelaxed_fused_gromov_wasserstein2(M, C1, C2, p=None, loss_fun='square_lo
     q = nx.sum(T, 0)
     srfgw_dist = log_fgw['srfgw_dist']
     log_fgw['T'] = T
+    log_fgw['lin_loss'] = nx.sum(M * T) * (1 - alpha)
+    log_fgw['quad_loss'] = srfgw_dist - log_fgw['lin_loss']
 
     if loss_fun == 'square_loss':
         gC1 = 2 * C1 * nx.outer(p, p) - 2 * nx.dot(T, nx.dot(C2, T.T))
@@ -979,7 +981,9 @@ def entropic_semirelaxed_fused_gromov_wasserstein(
     if log:
         qG = nx.sum(G, 0)
         marginal_product = nx.outer(ones_p, nx.dot(qG, fC2t))
-        log['srfgw_dist'] = alpha * gwloss(constC + marginal_product, hC1, hC2, G, nx) + (1 - alpha) * nx.sum(M * G)
+        log['lin_loss'] = nx.sum(M * G) * (1 - alpha)
+        log['quad_loss'] = alpha * gwloss(constC + marginal_product, hC1, hC2, G, nx)
+        log['srfgw_dist'] = log['lin_loss'] + log['quad_loss']
         return G, log
     else:
         return G

--- a/ot/optim.py
+++ b/ot/optim.py
@@ -297,7 +297,7 @@ def generic_conditional_gradient(a, b, M, f, df, reg1, reg2, lp_solver, line_sea
             loop = 0
 
         abs_delta_cost_G = abs(cost_G - old_cost_G)
-        relative_delta_cost_G = abs_delta_cost_G / abs(cost_G)
+        relative_delta_cost_G = abs_delta_cost_G / abs(cost_G) if cost_G != 0. else np.nan
         if relative_delta_cost_G < stopThr or abs_delta_cost_G < stopThr2:
             loop = 0
 

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -461,6 +461,10 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
 
     loss_dict = {'l2': 'square_loss', 'kl': 'kl_loss'}
 
+    if loss.lower() not in loss_dict.keys():
+        raise (ValueError('Unknown GW loss="{}"'.format(loss)))
+    loss_fun = loss_dict[loss.lower()]
+
     if reg is None or reg == 0:  # exact OT
 
         if unbalanced is None and unbalanced_type.lower() not in ['semirelaxed']:  # Exact balanced OT
@@ -473,7 +477,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if tol is None:
                     tol = 1e-9
 
-                value, log = gromov_wasserstein2(Ca, Cb, a, b, loss_fun=loss_dict[loss.lower()], log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value, log = gromov_wasserstein2(Ca, Cb, a, b, loss_fun=loss_fun, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 value_quad = value
                 if alpha == 1:  # set to 0 for FGW with alpha=1
@@ -503,7 +507,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if tol is None:
                     tol = 1e-9
 
-                value, log = fused_gromov_wasserstein2(M, Ca, Cb, a, b, loss_fun=loss_dict[loss.lower()], alpha=alpha, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value, log = fused_gromov_wasserstein2(M, Ca, Cb, a, b, loss_fun=loss_fun, alpha=alpha, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 value_linear = log['lin_loss']
                 value_quad = log['quad_loss']
@@ -520,7 +524,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if tol is None:
                     tol = 1e-9
 
-                value, log = semirelaxed_gromov_wasserstein2(Ca, Cb, a, loss_fun=loss_dict[loss.lower()], log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value, log = semirelaxed_gromov_wasserstein2(Ca, Cb, a, loss_fun=loss_fun, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 value_quad = value
                 if alpha == 1:  # set to 0 for FGW with alpha=1
@@ -536,7 +540,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if tol is None:
                     tol = 1e-9
 
-                value, log = semirelaxed_fused_gromov_wasserstein2(M, Ca, Cb, a, loss_fun=loss_dict[loss.lower()], alpha=alpha, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value, log = semirelaxed_fused_gromov_wasserstein2(M, Ca, Cb, a, loss_fun=loss_fun, alpha=alpha, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 value_linear = log['lin_loss']
                 value_quad = log['quad_loss']
@@ -564,7 +568,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if method is None:
                     method = 'PGD'
 
-                value_quad, log = entropic_gromov_wasserstein2(Ca, Cb, a, b, epsilon=reg, loss_fun=loss_dict[loss.lower()], log=True, symmetric=symmetric, solver=method, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value_quad, log = entropic_gromov_wasserstein2(Ca, Cb, a, b, epsilon=reg, loss_fun=loss_fun, log=True, symmetric=symmetric, solver=method, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 plan = log['T']
                 value_linear = 0
@@ -597,7 +601,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if method is None:
                     method = 'PGD'
 
-                value_noreg, log = entropic_fused_gromov_wasserstein2(M, Ca, Cb, a, b, loss_fun=loss_dict[loss.lower()], alpha=alpha, log=True, symmetric=symmetric, solver=method, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value_noreg, log = entropic_fused_gromov_wasserstein2(M, Ca, Cb, a, b, loss_fun=loss_fun, alpha=alpha, log=True, symmetric=symmetric, solver=method, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 value_linear = log['lin_loss']
                 value_quad = log['quad_loss']
@@ -618,7 +622,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if tol is None:
                     tol = 1e-9
 
-                value_quad, log = entropic_semirelaxed_gromov_wasserstein2(Ca, Cb, a, epsilon=reg, loss_fun=loss_dict[loss.lower()], log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value_quad, log = entropic_semirelaxed_gromov_wasserstein2(Ca, Cb, a, epsilon=reg, loss_fun=loss_fun, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 plan = log['T']
                 value_linear = 0
@@ -632,7 +636,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
                 if tol is None:
                     tol = 1e-9
 
-                value_noreg, log = entropic_semirelaxed_fused_gromov_wasserstein2(M, Ca, Cb, a, loss_fun=loss_dict[loss.lower()], alpha=alpha, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
+                value_noreg, log = entropic_semirelaxed_fused_gromov_wasserstein2(M, Ca, Cb, a, loss_fun=loss_fun, alpha=alpha, log=True, symmetric=symmetric, max_iter=max_iter, G0=plan_init, tol_rel=tol, tol_abs=tol, verbose=verbose)
 
                 value_linear = log['lin_loss']
                 value_quad = log['quad_loss']
@@ -642,37 +646,6 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
         else:  # unbalanced AND regularized OT
 
             raise (NotImplementedError('Not implemented reg_type="{}" and unbalanced_type="{}"'.format(reg_type, unbalanced_type)))
-
-            # if reg_type.lower() in ['kl'] and unbalanced_type.lower() == 'kl':
-
-            #     if max_iter is None:
-            #         max_iter = 1000
-            #     if tol is None:
-            #         tol = 1e-9
-
-            #     plan, log = sinkhorn_knopp_unbalanced(a, b, M, reg=reg, reg_m=unbalanced, numItermax=max_iter, stopThr=tol, verbose=verbose, log=True)
-
-            #     value_linear = nx.sum(M * plan)
-
-            #     value = value_linear + reg * nx.kl_div(plan, a[:, None] * b[None, :]) + unbalanced * (nx.kl_div(nx.sum(plan, 1), a) + nx.kl_div(nx.sum(plan, 0), b))
-
-            #     potentials = (log['logu'], log['logv'])
-
-            # elif reg_type.lower() in ['kl', 'l2', 'entropy'] and unbalanced_type.lower() in ['kl', 'l2']:
-
-            #     if max_iter is None:
-            #         max_iter = 1000
-            #     if tol is None:
-            #         tol = 1e-12
-
-            #     plan, log = lbfgsb_unbalanced(a, b, M, reg=reg, reg_m=unbalanced, reg_div=reg_type.lower(), regm_div=unbalanced_type.lower(), numItermax=max_iter, stopThr=tol, verbose=verbose, log=True)
-
-            #     value_linear = nx.sum(M * plan)
-
-            #     value = log['loss']
-
-            # else:
-            #     raise (NotImplementedError('Not implemented reg_type="{}" and unbalanced_type="{}"'.format(reg_type, unbalanced_type)))
 
     res = OTResult(potentials=potentials, value=value,
                    value_linear=value_linear, value_quad=value_quad, plan=plan, status=status, backend=nx)

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -402,7 +402,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
         Weight the quadratic term (alpha*Gromov) and the linear term
         ((1-alpha)*Wass) in the Fused Gromov-Wasserstein problem. Not used for
         Gromov problem (when M is not provided). By default ``alpha=None``
-        corresponds to to 
+        corresponds to to
         ``alpha=1`` for Gromov problem (``M==None``) and ``alpha=0.5`` for Fused
         Gromov-Wasserstein problem (``M!=None``)
     unbalanced : float, optional

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -602,7 +602,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
     loss_dict = {'l2': 'square_loss', 'kl': 'kl_loss'}
 
     if loss.lower() not in loss_dict.keys():
-        raise (ValueError('Unknown GW loss="{}"'.format(loss)))
+        raise (NotImplementedError('Not implemented GW loss="{}"'.format(loss)))
     loss_fun = loss_dict[loss.lower()]
 
     if reg is None or reg == 0:  # exact OT

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -440,6 +440,115 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
     The following methods are available for solving the Gromov-Wasserstein
     problem:
 
+    - **Classical Gromov-Wasserstein (GW) problem :ref:`[3] <references-solve-gromov>`** (default parameters):
+
+    .. math::
+        \min_{\mathbf{T}\geq 0} \sum_{i,j,k,l} L(\mathbf{C_1}_{i,k}, \mathbf{C_2}_{j,l}) \mathbf{T}_{i,j}
+
+        s.t. \ \mathbf{T} \mathbf{1} = \mathbf{a}
+
+             \mathbf{T}^T \mathbf{1} = \mathbf{b}
+
+             \mathbf{T} \geq 0
+
+    can be solved with the following code:
+
+    .. code-block:: python
+        res = ot.solve_gromov(Ca, Cb) # uniform weights
+        res = ot.solve_gromov(Ca, Cb, a=a, b=) # given weights
+        res = ot.solve_gromov(Ca, Cb, loss='KL') # KL loss
+
+        plan = res.plan # GW plan
+        value = res.value # GW value
+
+    - **Fused Gromov-Wasserstein (FGW) problem ref:`[24] <references-solve-gromov>`** (when ``M!=None``):
+
+    .. math::
+        \min_{\mathbf{T}\geq 0} \quad (1 - \alpha) \langle \mathbf{T}, \mathbf{M} \rangle_F +
+        \alpha \sum_{i,j,k,l} L(\mathbf{C_1}_{i,k}, \mathbf{C_2}_{j,l}) \mathbf{T}_{i,j}
+
+        s.t. \ \mathbf{T} \mathbf{1} = \mathbf{a}
+
+             \mathbf{T}^T \mathbf{1} = \mathbf{b}
+
+             \mathbf{T} \geq 0
+
+    can be solved with the following code:
+
+    .. code-block:: python
+        res = ot.solve_gromov(Ca, Cb, M) # uniform weights, alpha=0.5 (default)
+        res = ot.solve_gromov(Ca, Cb, M, a=a, b=b, alpha=0.1) # given weights and alpha
+
+        plan = res.plan # FGW plan
+        loss_linear_term = res.value_linear # Wasserstein part of the loss
+        loss_quad_term = res.value_quad # Gromov part of the loss
+        loss = res.value # FGW value
+
+    - **Regularized (Fused) Gromov-Wasserstein (GW) problem ref:`[12] <references-solve-gromov>`** (when  ``reg!=None``):
+
+    .. math::
+        \min_{\mathbf{T}\geq 0} \quad (1 - \alpha) \langle \mathbf{T}, \mathbf{M} \rangle_F +
+        \alpha \sum_{i,j,k,l} L(\mathbf{C_1}_{i,k}, \mathbf{C_2}_{j,l}) \mathbf{T}_{i,j} + \lambda_r R(\mathbf{T})
+
+        s.t. \ \mathbf{T} \mathbf{1} = \mathbf{a}
+
+             \mathbf{T}^T \mathbf{1} = \mathbf{b}
+
+             \mathbf{T} \geq 0
+
+    can be solved with the following code:
+
+    .. code-block:: python
+        res = ot.solve_gromov(Ca, Cb, reg=1.0) # GW entropy regularization (default)
+        res = ot.solve_gromov(Ca, Cb, M, a=a, b=b, reg=10, alpha=0.1) # FGW with entropy
+
+        plan = res.plan # FGW plan
+        loss_linear_term = res.value_linear # Wasserstein part of the loss
+        loss_quad_term = res.value_quad # Gromov part of the loss
+        loss = res.value # FGW value (including regularization)
+
+    - **Semi-relaxed (Fused) Gromov-Wasserstein (GW) problemref:`[48] <references-solve-gromov>`** (when  ``unbalanced='semirelaxed'``):
+
+    .. math::
+        \min_{\mathbf{T}\geq 0} \quad (1 - \alpha) \langle \mathbf{T}, \mathbf{M} \rangle_F +
+        \alpha \sum_{i,j,k,l} L(\mathbf{C_1}_{i,k}, \mathbf{C_2}_{j,l}) \mathbf{T}_{i,j}
+
+        s.t. \ \mathbf{T} \mathbf{1} = \mathbf{a}
+
+             \mathbf{T} \geq 0
+
+    can be solved with the following code:
+
+    .. code-block:: python
+        res = ot.solve_gromov(Ca, Cb, unbalanced='semirelaxed') # semirelaxed GW
+        res = ot.solve_gromov(Ca, Cb, unbalanced='semirelaxed', reg=1) # entropic semirelaxed GW
+        res = ot.solve_gromov(Ca, Cb, M, unbalanced='semirelaxed', alpha=0.1) # semirelaxed FGW
+
+        plan = res.plan # FGW plan
+        right_marginal = res.marginal_b # right marginal of the plan
+
+    .. _references-solve-gromov:
+    References
+    ----------
+
+    .. [3] Mémoli, F. (2011). Gromov–Wasserstein distances and the metric
+        approach to object matching. Foundations of computational mathematics,
+        11(4), 417-487.
+
+    .. [12] Gabriel Peyré, Marco Cuturi, and Justin Solomon (2016),
+        Gromov-Wasserstein averaging of kernel and distance matrices
+        International Conference on Machine Learning (ICML).
+
+    .. [24] Vayer, T., Chapel, L., Flamary, R., Tavenard, R. and Courty, N.
+        (2019). Optimal Transport for structured data with application on graphs
+        Proceedings of the 36th International Conference on Machine Learning
+        (ICML).
+
+    .. [48] Cédric Vincent-Cuaz, Rémi Flamary, Marco Corneli, Titouan Vayer,
+        Nicolas Courty (2022). Semi-relaxed Gromov-Wasserstein divergence and
+        applications on graphs. International Conference on Learning
+        Representations (ICLR), 2022.
+
     """
 
     # detect backend

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -542,8 +542,8 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None, alph
                     tol = 1e-9
 
                 plan, log = sinkhorn_log(a, b, M, reg=reg, numItermax=max_iter,
-                                            stopThr=tol, log=True,
-                                            verbose=verbose)
+                                         stopThr=tol, log=True,
+                                         verbose=verbose)
 
                 value_linear = nx.sum(M * plan)
                 value = value_linear + reg * nx.sum(plan * nx.log(plan + 1e-16))

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -59,11 +59,11 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
         Unbalanced penalization weight :math:`\lambda_u`, by default None
         (balanced OT)
     unbalanced_type : str, optional
-        Type of unbalanced penalization unction :math:`U`  either "KL", "L2", "TV", by default "KL"
+        Type of unbalanced penalization function :math:`U`  either "KL", "L2", "TV", by default "KL"
     n_threads : int, optional
         Number of OMP threads for exact OT solver, by default 1
     max_iter : int, optional
-        Maximum number of iteration, by default None (default values in each solvers)
+        Maximum number of iterations, by default None (default values in each solvers)
     plan_init : array_like, shape (dim_a, dim_b), optional
         Initialization of the OT plan for iterative methods, by default None
     potentials_init : (array_like(dim_a,),array_like(dim_b,)), optional
@@ -391,30 +391,29 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
         Type of loss function, either ``"L2"`` or ``"KL"``, by default ``"L2"``
     symmetric : bool, optional
         Use symmetric version of the Gromov-Wasserstein problem, by default None
-        tests wether the matrices are symmetric or True/False to avoid the test.
+        tests whether the matrices are symmetric or True/False to avoid the test.
     reg : float, optional
         Regularization weight :math:`\lambda_r`, by default None (no reg., exact
         OT)
     reg_type : str, optional
-        Type of regularization :math:`R`, by default "entropic" (only used when
+        Type of regularization :math:`R`, by default "entropy" (only used when
         ``reg!=None``)
     alpha : float, optional
         Weight the quadratic term (alpha*Gromov) and the linear term
         ((1-alpha)*Wass) in the Fused Gromov-Wasserstein problem. Not used for
         Gromov problem (when M is not provided). By default ``alpha=None``
-        corresponds to to
-        ``alpha=1`` for Gromov problem (``M==None``) and ``alpha=0.5`` for Fused
-        Gromov-Wasserstein problem (``M!=None``)
+        corresponds to ``alpha=1`` for Gromov problem (``M==None``) and
+        ``alpha=0.5`` for Fused Gromov-Wasserstein problem (``M!=None``)
     unbalanced : float, optional
         Unbalanced penalization weight :math:`\lambda_u`, by default None
         (balanced OT), Not implemented yet
     unbalanced_type : str, optional
-        Type of unbalanced penalization unction :math:`U`  either "KL", "semirelaxed",
-        "partial", by default "KL" , Not implemented yet
+        Type of unbalanced penalization function :math:`U` either "KL", "semirelaxed",
+        "partial", by default "KL" but note that it is not implemented yet.
     n_threads : int, optional
         Number of OMP threads for exact OT solver, by default 1
     max_iter : int, optional
-        Maximum number of iteration, by default None (default values in each
+        Maximum number of iterations, by default None (default values in each
         solvers)
     plan_init : array_like, shape (dim_a, dim_b), optional
         Initialization of the OT plan for iterative methods, by default None

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -412,6 +412,10 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
         "partial", by default "KL" but note that it is not implemented yet.
     n_threads : int, optional
         Number of OMP threads for exact OT solver, by default 1
+    method : str, optional
+        Method for solving the problem, for entropic problems "PGD" is projected
+        gradient descent and "PPA" for proximal point, default None for
+        automatic selection ("PGD").
     max_iter : int, optional
         Maximum number of iterations, by default None (default values in each
         solvers)
@@ -457,7 +461,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
     .. code-block:: python
 
         res = ot.solve_gromov(Ca, Cb) # uniform weights
-        res = ot.solve_gromov(Ca, Cb, a=a, b=) # given weights
+        res = ot.solve_gromov(Ca, Cb, a=a, b=b) # given weights
         res = ot.solve_gromov(Ca, Cb, loss='KL') # KL loss
 
         plan = res.plan # GW plan

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -712,7 +712,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
 
             else:  # partial FGW
 
-                raise(NotImplementedError('Partial FGW not implemented yet'))
+                raise (NotImplementedError('Partial FGW not implemented yet'))
 
         elif unbalanced_type.lower() in ['kl', 'l2']:  # unbalanced exact OT
 
@@ -835,7 +835,7 @@ def solve_gromov(Ca, Cb, M=None, a=None, b=None, loss='L2', symmetric=None,
 
             else:  # partial FGW
 
-                raise(NotImplementedError('Partial entropic FGW not implemented yet'))
+                raise (NotImplementedError('Partial entropic FGW not implemented yet'))
 
         else:  # unbalanced AND regularized OT
 

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -731,11 +731,12 @@ class UndefinedParameter(Exception):
 
 
 class OTResult:
-    def __init__(self, potentials=None, value=None, value_linear=None, plan=None, log=None, backend=None, sparse_plan=None, lazy_plan=None, status=None):
+    def __init__(self, potentials=None, value=None, value_linear=None, value_quad=None, plan=None, log=None, backend=None, sparse_plan=None, lazy_plan=None, status=None):
 
         self._potentials = potentials
         self._value = value
         self._value_linear = value_linear
+        self._value_quad = value_quad
         self._plan = plan
         self._log = log
         self._sparse_plan = sparse_plan
@@ -828,7 +829,8 @@ class OTResult:
 
     @property
     def value(self):
-        """Full transport cost, including possible regularization terms."""
+        """Full transport cost, including possible regularization terms and
+        quadratic term for Gromov Wasserstein solutions."""
         if self._value is not None:
             return self._value
         else:
@@ -839,6 +841,14 @@ class OTResult:
         """The "minimal" transport cost, i.e. the product between the transport plan and the cost."""
         if self._value_linear is not None:
             return self._value_linear
+        else:
+            raise NotImplementedError()
+
+    @property
+    def value_quad(self):
+        """The quadratic part of the transport cost for Gromov-Wasserstein solutions."""
+        if self._value_quad is not None:
+            return self._value_quad
         else:
             raise NotImplementedError()
 

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -8,10 +8,12 @@
 # License: MIT License
 
 import numpy as np
+import pytest
+import warnings
+
 import ot
 from ot.backend import NumpyBackend
 from ot.backend import torch, tf
-import pytest
 
 
 def test_gromov(nx):
@@ -146,8 +148,10 @@ def test_gromov_dtype_device(nx):
 
         C1b, C2b, pb, qb, G0b = nx.from_numpy(C1, C2, p, q, G0, type_as=tp)
 
-        Gb = ot.gromov.gromov_wasserstein(C1b, C2b, pb, qb, 'square_loss', G0=G0b, verbose=True)
-        gw_valb = ot.gromov.gromov_wasserstein2(C1b, C2b, pb, qb, 'kl_loss', armijo=True, G0=G0b, log=False)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            Gb = ot.gromov.gromov_wasserstein(C1b, C2b, pb, qb, 'square_loss', G0=G0b, verbose=True)
+            gw_valb = ot.gromov.gromov_wasserstein2(C1b, C2b, pb, qb, 'kl_loss', armijo=True, G0=G0b, log=False)
 
         nx.assert_same_dtype_device(C1b, Gb)
         nx.assert_same_dtype_device(C1b, gw_valb)

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -17,7 +17,7 @@ from ot.backend import torch, tf
 
 
 def test_gromov(nx):
-    n_samples = 50  # nb samples
+    n_samples = 20  # nb samples
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
 
@@ -80,7 +80,7 @@ def test_gromov(nx):
 
 
 def test_asymmetric_gromov(nx):
-    n_samples = 30  # nb samples
+    n_samples = 20  # nb samples
     rng = np.random.RandomState(0)
     C1 = rng.uniform(low=0., high=10, size=(n_samples, n_samples))
     idx = np.arange(n_samples)
@@ -124,7 +124,7 @@ def test_asymmetric_gromov(nx):
 
 def test_gromov_dtype_device(nx):
     # setup
-    n_samples = 50  # nb samples
+    n_samples = 20  # nb samples
 
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
@@ -160,7 +160,7 @@ def test_gromov_dtype_device(nx):
 @pytest.mark.skipif(not tf, reason="tf not installed")
 def test_gromov_device_tf():
     nx = ot.backend.TensorflowBackend()
-    n_samples = 50  # nb samples
+    n_samples = 20  # nb samples
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
     xs = ot.datasets.make_2D_samples_gauss(n_samples, mu_s, cov_s, random_state=4)
@@ -192,7 +192,7 @@ def test_gromov_device_tf():
 
 
 def test_gromov2_gradients():
-    n_samples = 50  # nb samples
+    n_samples = 20  # nb samples
 
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
@@ -257,7 +257,7 @@ def test_gromov2_gradients():
 
 
 def test_gw_helper_backend(nx):
-    n_samples = 20  # nb samples
+    n_samples = 10  # nb samples
 
     mu = np.array([0, 0])
     cov = np.array([[1, 0], [0, 1]])
@@ -301,7 +301,7 @@ def test_gw_helper_backend(nx):
     pytest.param('unknown_loss', marks=pytest.mark.xfail(raises=ValueError)),
 ])
 def test_gw_helper_validation(loss_fun):
-    n_samples = 20  # nb samples
+    n_samples = 10  # nb samples
     mu = np.array([0, 0])
     cov = np.array([[1, 0], [0, 1]])
     xs = ot.datasets.make_2D_samples_gauss(n_samples, mu, cov, random_state=0)
@@ -548,7 +548,7 @@ def test_entropic_gromov_dtype_device(nx):
 
 @pytest.skip_backend("tf", reason="test very slow with tf backend")
 def test_entropic_fgw(nx):
-    n_samples = 10  # nb samples
+    n_samples = 5  # nb samples
 
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
@@ -613,7 +613,7 @@ def test_entropic_fgw(nx):
 
 
 def test_entropic_proximal_fgw(nx):
-    n_samples = 10  # nb samples
+    n_samples = 5  # nb samples
 
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
@@ -678,7 +678,7 @@ def test_entropic_proximal_fgw(nx):
 
 
 def test_asymmetric_entropic_fgw(nx):
-    n_samples = 10  # nb samples
+    n_samples = 5  # nb samples
     rng = np.random.RandomState(0)
     C1 = rng.uniform(low=0., high=10, size=(n_samples, n_samples))
     idx = np.arange(n_samples)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -207,8 +207,51 @@ def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha
         solx = ot.solve_gromov(Cax, Cbx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, loss=loss)  # GW
         solx_fgw = ot.solve_gromov(Cax, Cbx, Mx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha, loss=loss)  # FGW
 
+        solx.value_quad
+
         assert_allclose_sol(sol0, solx)
         assert_allclose_sol(sol0_fgw, solx_fgw)
 
     except NotImplementedError:
         pytest.skip("Not implemented")
+
+
+def test_solve_gromov_not_implemented(nx):
+
+    np.random.seed(0)
+
+    n_samples_s = 3
+    n_samples_t = 5
+
+    Ca = np.random.rand(n_samples_s, n_samples_s)
+    Ca = (Ca + Ca.T) / 2
+
+    Cb = np.random.rand(n_samples_t, n_samples_t)
+    Cb = (Cb + Cb.T) / 2
+
+    a = ot.utils.unif(n_samples_s)
+    b = ot.utils.unif(n_samples_t)
+
+    M = np.random.rand(n_samples_s, n_samples_t)
+
+    Ca, Cb, M, a, b = nx.from_numpy(Ca, Cb, M, a, b)
+
+    # test not implemented and check raise
+    with pytest.raises(NotImplementedError):
+        ot.solve_gromov(Ca, Cb, loss='weird loss')
+    with pytest.raises(NotImplementedError):
+        ot.solve_gromov(Ca, Cb, unbalanced=1, unbalanced_type='cryptic divergence')
+    with pytest.raises(NotImplementedError):
+        ot.solve_gromov(Ca, Cb, reg=1, reg_type='cryptic divergence')
+
+    # detect partial not implemented and error detect in value
+    with pytest.raises(ValueError):
+        ot.solve_gromov(Ca, Cb, unbalanced_type='partial', unbalanced=1.5)
+    with pytest.raises(NotImplementedError):
+        ot.solve_gromov(Ca, Cb, unbalanced_type='partial', unbalanced=0.5, symmetric=False)
+    with pytest.raises(NotImplementedError):
+        ot.solve_gromov(Ca, Cb, M, unbalanced_type='partial', unbalanced=0.5)
+    with pytest.raises(ValueError):
+        ot.solve_gromov(Ca, Cb, reg=1, unbalanced_type='partial', unbalanced=1.5)
+    with pytest.raises(NotImplementedError):
+        ot.solve_gromov(Ca, Cb, reg=1, unbalanced_type='partial', unbalanced=0.5, symmetric=False)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -18,7 +18,7 @@ lst_unbalanced = [None, 0.9]
 lst_unbalanced_type = ['KL', 'L2', 'TV']
 
 lst_reg_type_gromov = ['entropy']
-lst_unbalanced_type_gromov = ['KL']
+lst_unbalanced_type_gromov = ['semirelaxed']
 lst_unbalanced_gromov = [None, 0.9]
 lst_alpha = [0, 0.4, 0.9, 1]
 
@@ -112,7 +112,7 @@ def test_solve_grid(nx, reg, reg_type, unbalanced, unbalanced_type):
 
         assert_allclose_sol(sol, solb)
     except NotImplementedError:
-        pass
+        pytest.skip("Not implemented")
 
 
 def test_solve_not_implemented(nx):
@@ -142,8 +142,8 @@ def test_solve_gromov(nx):
 
     np.random.seed(0)
 
-    n_samples_s = 5
-    n_samples_t = 10
+    n_samples_s = 3
+    n_samples_t = 5
 
     Ca = np.random.rand(n_samples_s, n_samples_s)
     Ca = (Ca + Ca.T) / 2
@@ -181,8 +181,8 @@ def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha
 
     np.random.seed(0)
 
-    n_samples_s = 5
-    n_samples_t = 10
+    n_samples_s = 3
+    n_samples_t = 5
 
     Ca = np.random.rand(n_samples_s, n_samples_s)
     Ca = (Ca + Ca.T) / 2
@@ -210,4 +210,4 @@ def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha
         assert_allclose_sol(sol0_fgw, solx_fgw)
 
     except NotImplementedError:
-        pass
+        pytest.skip("Not implemented")

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -18,7 +18,8 @@ lst_unbalanced = [None, 0.9]
 lst_unbalanced_type = ['KL', 'L2', 'TV']
 
 lst_reg_type_gromov = ['entropy']
-lst_unbalanced_type_gromov = ['semirelaxed']
+lst_gw_losses = ['L2', 'KL']
+lst_unbalanced_type_gromov = ['KL', 'semirelaxed']
 lst_unbalanced_gromov = [None, 0.9]
 lst_alpha = [0, 0.4, 0.9, 1]
 
@@ -176,8 +177,8 @@ def test_solve_gromov(nx):
     assert_allclose_sol(sol0_fgw, solx_fgw)
 
 
-@pytest.mark.parametrize("reg,reg_type,unbalanced,unbalanced_type,alpha", itertools.product(lst_reg, lst_reg_type_gromov, lst_unbalanced_gromov, lst_unbalanced_type_gromov, lst_alpha))
-def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha):
+@pytest.mark.parametrize("reg,reg_type,unbalanced,unbalanced_type,alpha,loss", itertools.product(lst_reg, lst_reg_type_gromov, lst_unbalanced_gromov, lst_unbalanced_type_gromov, lst_alpha, lst_gw_losses))
+def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha, loss):
 
     np.random.seed(0)
 
@@ -197,14 +198,14 @@ def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha
 
     try:
 
-        sol0 = ot.solve_gromov(Ca, Cb, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type)  # GW
-        sol0_fgw = ot.solve_gromov(Ca, Cb, M, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha)  # FGW
+        sol0 = ot.solve_gromov(Ca, Cb, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, loss=loss)  # GW
+        sol0_fgw = ot.solve_gromov(Ca, Cb, M, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha, loss=loss)  # FGW
 
         # solve in backend
         ax, bx, Mx, Cax, Cbx = nx.from_numpy(a, b, M, Ca, Cb)
 
-        solx = ot.solve_gromov(Cax, Cbx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type)  # GW
-        solx_fgw = ot.solve_gromov(Cax, Cbx, Mx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha)  # FGW
+        solx = ot.solve_gromov(Cax, Cbx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, loss=loss)  # GW
+        solx_fgw = ot.solve_gromov(Cax, Cbx, Mx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha, loss=loss)  # FGW
 
         assert_allclose_sol(sol0, solx)
         assert_allclose_sol(sol0_fgw, solx_fgw)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -12,14 +12,14 @@ import pytest
 import ot
 
 
-lst_reg = [None, 1.0]
+lst_reg = [None, 1]
 lst_reg_type = ['KL', 'entropy', 'L2']
 lst_unbalanced = [None, 0.9]
 lst_unbalanced_type = ['KL', 'L2', 'TV']
 
 lst_reg_type_gromov = ['entropy']
 lst_gw_losses = ['L2', 'KL']
-lst_unbalanced_type_gromov = ['KL', 'semirelaxed']
+lst_unbalanced_type_gromov = ['KL', 'semirelaxed', 'partial']
 lst_unbalanced_gromov = [None, 0.9]
 lst_alpha = [0, 0.4, 0.9, 1]
 

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -17,6 +17,11 @@ lst_reg_type = ['KL', 'entropy', 'L2']
 lst_unbalanced = [None, 0.9]
 lst_unbalanced_type = ['KL', 'L2', 'TV']
 
+lst_reg_type_gromov = ['entropy']
+lst_unbalanced_type_gromov = ['KL']
+lst_unbalanced_gromov = [None, 0.9]
+lst_alpha = [0, 0.4, 0.9, 1]
+
 
 def assert_allclose_sol(sol1, sol2):
 
@@ -131,3 +136,78 @@ def test_solve_not_implemented(nx):
     # pairs of incompatible divergences
     with pytest.raises(NotImplementedError):
         ot.solve(M, reg=1.0, reg_type='kl', unbalanced=1.0, unbalanced_type='tv')
+
+
+def test_solve_gromov(nx):
+
+    np.random.seed(0)
+
+    n_samples_s = 5
+    n_samples_t = 10
+
+    Ca = np.random.rand(n_samples_s, n_samples_s)
+    Ca = (Ca + Ca.T) / 2
+
+    Cb = np.random.rand(n_samples_t, n_samples_t)
+    Cb = (Cb + Cb.T) / 2
+
+    a = ot.utils.unif(n_samples_s)
+    b = ot.utils.unif(n_samples_t)
+
+    M = np.random.rand(n_samples_s, n_samples_t)
+
+    sol0 = ot.solve_gromov(Ca, Cb)  # GW
+    sol = ot.solve_gromov(Ca, Cb, a=a, b=b)  # GW
+    sol0_fgw = ot.solve_gromov(Ca, Cb, M)  # FGW
+
+    # check some attributes
+    sol.potentials
+    sol.marginals
+
+    assert_allclose_sol(sol0, sol)
+
+    # solve in backend
+    ax, bx, Mx, Cax, Cbx = nx.from_numpy(a, b, M, Ca, Cb)
+
+    solx = ot.solve_gromov(Cax, Cbx, a=ax, b=bx)  # GW
+    solx_fgw = ot.solve_gromov(Cax, Cbx, Mx)  # FGW
+
+    assert_allclose_sol(sol, solx)
+    assert_allclose_sol(sol0_fgw, solx_fgw)
+
+
+@pytest.mark.parametrize("reg,reg_type,unbalanced,unbalanced_type,alpha", itertools.product(lst_reg, lst_reg_type_gromov, lst_unbalanced_gromov, lst_unbalanced_type_gromov, lst_alpha))
+def test_solve_gromov_grid(nx, reg, reg_type, unbalanced, unbalanced_type, alpha):
+
+    np.random.seed(0)
+
+    n_samples_s = 5
+    n_samples_t = 10
+
+    Ca = np.random.rand(n_samples_s, n_samples_s)
+    Ca = (Ca + Ca.T) / 2
+
+    Cb = np.random.rand(n_samples_t, n_samples_t)
+    Cb = (Cb + Cb.T) / 2
+
+    a = ot.utils.unif(n_samples_s)
+    b = ot.utils.unif(n_samples_t)
+
+    M = np.random.rand(n_samples_s, n_samples_t)
+
+    try:
+
+        sol0 = ot.solve_gromov(Ca, Cb, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type)  # GW
+        sol0_fgw = ot.solve_gromov(Ca, Cb, M, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha)  # FGW
+
+        # solve in backend
+        ax, bx, Mx, Cax, Cbx = nx.from_numpy(a, b, M, Ca, Cb)
+
+        solx = ot.solve_gromov(Cax, Cbx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type)  # GW
+        solx_fgw = ot.solve_gromov(Cax, Cbx, Mx, reg=reg, reg_type=reg_type, unbalanced=unbalanced, unbalanced_type=unbalanced_type, alpha=alpha)  # FGW
+
+        assert_allclose_sol(sol0, solx)
+        assert_allclose_sol(sol0_fgw, solx_fgw)
+
+    except NotImplementedError:
+        pass

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -386,7 +386,8 @@ def test_OTResult():
                       'sparse_plan',
                       'status',
                       'value',
-                      'value_linear']
+                      'value_linear',
+                      'value_quad']
     for at in lst_attributes:
         with pytest.raises(NotImplementedError):
             getattr(res, at)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

in this PR I propose the implementation of the new API for Gromov-Wasserstsein solvers. Similarly to `ot.solve` we now have a function `ot.solve_gromov` that can be used as follows

```python

# Gromov Wassrerstein (GW) wity L2 loss
res = ot.solve_gromov(Ca, Cb) # uniform weights
res = ot.solve_gromov(Ca, Cb, a=a, b=b) # given weights

# GW with KL loss
res = ot.solve_gromov(Ca, Cb, loss='KL') # uniform weights

# Fused Gromov-Wassertsein (FGW)
res = ot.solve_gromov(Ca, Cb, M, alpha=0.5) # uniform weights
res = ot.solve_gromov(Ca, Cb, M, a=a, b=b, alpha=0.1) # given weights

# GW and FGW with entropy reg
res = ot.solve_gromov(Ca, Cb, reg=1) # GW
res = ot.solve_gromov(Ca, Cb, M, reg=1, alpha=0.5) # FGW

# Semirelaxed GW and FGW
res=ot.solve_gromov(Ca, Cb, unbalanced_type='semirelaxed') # GW
res=ot.solve_gromov(Ca, Cb, M, unbalanced_type='semirelaxed') # FGW

# partial GW
res=ot.solve_gromov(Ca, Cb,unbalanced=0.8, unbalanced_type='partial') # partial GW with m=0.8 of mass transported

#results can be obtained from OTResult() as
res.plan # OT plan
res.value # optimal loss (all objective with regularization is present)
res.value_quad # quadratic (GW) part of the loss
res.value_linear # linear (W) part of the loss for FGW

```



## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
