### PR TITLE
[WIP] update LP barycenter with new scipy solvers

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
 + The `linspace` method of the backends now has the `type_as` argument to convert to the same dtype and device. (PR #533)
 + The `convolutional_barycenter2d` and `convolutional_barycenter2d_debiased` functions now work with different devices.. (PR #533)
 + New API for Gromov-Wasserstein solvers with `ot.solve_gromov` function (PR #536)
++ New LP solvers from scipy used by default for LP barycenter (PR #537)
 
 #### Closed issues
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)

--- a/examples/barycenters/plot_barycenter_lp_vs_entropic.py
+++ b/examples/barycenters/plot_barycenter_lp_vs_entropic.py
@@ -83,7 +83,7 @@ ot.toc()
 
 
 ot.tic()
-bary_wass2 = ot.lp.barycenter(A, M, weights, solver='interior-point', verbose=True)
+bary_wass2 = ot.lp.barycenter(A, M, weights, solver='highs-ipm', verbose=True)
 ot.toc()
 
 pl.figure(2)

--- a/examples/barycenters/plot_barycenter_lp_vs_entropic.py
+++ b/examples/barycenters/plot_barycenter_lp_vs_entropic.py
@@ -83,7 +83,7 @@ ot.toc()
 
 
 ot.tic()
-bary_wass2 = ot.lp.barycenter(A, M, weights, solver='highs-ipm', verbose=True)
+bary_wass2 = ot.lp.barycenter(A, M, weights)
 ot.toc()
 
 pl.figure(2)
@@ -149,7 +149,7 @@ ot.toc()
 
 
 ot.tic()
-bary_wass2 = ot.lp.barycenter(A, M, weights, solver='interior-point', verbose=True)
+bary_wass2 = ot.lp.barycenter(A, M, weights)
 ot.toc()
 
 
@@ -223,7 +223,7 @@ ot.toc()
 
 
 ot.tic()
-bary_wass2 = ot.lp.barycenter(A, M, weights, solver='interior-point', verbose=True)
+bary_wass2 = ot.lp.barycenter(A, M, weights)
 ot.toc()
 
 

--- a/ot/lp/cvx.py
+++ b/ot/lp/cvx.py
@@ -25,7 +25,7 @@ def scipy_sparse_to_spmatrix(A):
     return SP
 
 
-def barycenter(A, M, weights=None, verbose=False, log=False, solver='interior-point'):
+def barycenter(A, M, weights=None, verbose=False, log=False, solver='highs-ipm'):
     r"""Compute the Wasserstein barycenter of distributions A
 
      The function solves the following optimization problem [16]:
@@ -115,13 +115,13 @@ def barycenter(A, M, weights=None, verbose=False, log=False, solver='interior-po
     A_eq = sps.vstack((A_eq1, A_eq2))
     b_eq = np.concatenate((b_eq1, b_eq2))
 
-    if not cvxopt or solver in ['interior-point']:
+    if not cvxopt or solver in ['interior-point', 'highs', 'highs-ipm', 'highs-ds']:
         # cvxopt not installed or interior point
 
         if solver is None:
             solver = 'interior-point'
 
-        options = {'sparse': True, 'disp': verbose}
+        options = {'disp': verbose}
         sol = sp.optimize.linprog(c, A_eq=A_eq, b_eq=b_eq, method=solver,
                                   options=options)
         x = sol.x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.20
-scipy>=1.3
+scipy>=1.6
 matplotlib
 autograd
 pymanopt

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     scripts=[],
     data_files=[],
     setup_requires=["oldest-supported-numpy", "cython>=0.23"],
-    install_requires=["numpy>=1.16", "scipy>=1.0"],
+    install_requires=["numpy>=1.16", "scipy>=1.6"],
     python_requires=">=3.6",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Scipy has since 1.6 new C++ LP solvers that can handle very well sparse matrices and lead to better solutions. 

This PR bump the scipy requirement and use now as default solver for LP barycenter the new "highs-ipm" solver that is more than 10 times faster on the example in the documentation

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
