### PR TITLE
[MRG] Extend unbalanced OT solvers for more flexibility

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
 + The `convolutional_barycenter2d` and `convolutional_barycenter2d_debiased` functions now work with different devices.. (PR #533)
 + New API for Gromov-Wasserstein solvers with `ot.solve_gromov` function (PR #536)
 + New LP solvers from scipy used by default for LP barycenter (PR #537)
++ Upgraded unbalanced OT solvers for more flexibility (PR #539)
 
 #### Closed issues
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)
@@ -19,13 +20,13 @@
 ## 0.9.1
 *August 2023*
 
-This new release contains several new features and bug fixes. 
+This new release contains several new features and bug fixes.
 
 New features include a new submodule `ot.gnn` that contains two new Graph neural network layers (compatible with [Pytorch Geometric](https://pytorch-geometric.readthedocs.io/)) for template-based pooling of graphs with an example on [graph classification](https://pythonot.github.io/master/auto_examples/gromov/plot_gnn_TFGW.html). Related to this, we also now provide FGW and semi relaxed FGW solvers for which the resulting loss is differentiable w.r.t. the parameter `alpha`. Other contributions on the (F)GW front include a new solver for the Proximal Point algorithm [that can be used to solve entropic GW problems](https://pythonot.github.io/master/auto_examples/gromov/plot_fgw_solvers.html) (using the parameter `solver="PPA"`), new solvers for entropic FGW barycenters, novels Sinkhorn-based solvers for entropic semi-relaxed (F)GW, the possibility to provide a warm-start to the solvers, and optional marginal weights of the samples (uniform weights ar used by default). Finally we added in the submodule `ot.gaussian` and `ot.da` new loss and mapping estimators for the Gaussian Gromov-Wasserstein that can be used as a fast alternative to GW and estimates linear mappings between unregistered spaces that can potentially have different size (See the update [linear mapping example](https://pythonot.github.io/master/auto_examples/domain-adaptation/plot_otda_linear_mapping.html) for an illustration).
 
 We also provide a new solver for the [Entropic Wasserstein Component Analysis](https://pythonot.github.io/master/auto_examples/others/plot_EWCA.html) that is a generalization of the celebrated PCA taking into account the local neighborhood of the samples. We also now have a new solver in `ot.smooth` for the [sparsity-constrained OT (last plot)](https://pythonot.github.io/master/auto_examples/plot_OT_1D_smooth.html) that can be used to find regularized OT plans with sparsity constraints. Finally we have a first multi-marginal solver for regular 1D distributions with a Monge loss (see [here](https://pythonot.github.io/master/auto_examples/others/plot_dmmot.html)).
 
-The documentation and testings have also been updated. We now have nearly 95% code coverage with the tests. The documentation has been updated and some examples have been streamlined to build more quickly and avoid timeout problems with CircleCI. We also added an optional CI on GPU for the master branch and approved PRs that can be used when a GPU runner is online. 
+The documentation and testings have also been updated. We now have nearly 95% code coverage with the tests. The documentation has been updated and some examples have been streamlined to build more quickly and avoid timeout problems with CircleCI. We also added an optional CI on GPU for the master branch and approved PRs that can be used when a GPU runner is online.
 
 Many other bugs and issues have been fixed and we want to thank all the contributors, old and new, who made this release possible. More details below.
 
@@ -76,9 +77,9 @@ Many other bugs and issues have been fixed and we want to thank all the contribu
 *April 2023*
 
 This new release contains so many new features and bug fixes since 0.8.2 that we
-decided to make it a new minor release at 0.9.0. 
+decided to make it a new minor release at 0.9.0.
 
-The release contains many new features. First we did a major 
+The release contains many new features. First we did a major
 update of all Gromov-Wasserstein solvers that brings up to 30% gain in
 computation time (see PR #431) and allows the GW solvers to work on non symmetric
 matrices. It also brings novel solvers for the very
@@ -94,7 +95,7 @@ barycenter](https://pythonot.github.io/master/auto_examples/barycenters/plot_fre
 and the [Generalized Wasserstein
 barycenter](https://pythonot.github.io/master/auto_examples/barycenters/plot_generalized_free_support_barycenter.html#sphx-glr-auto-examples-barycenters-plot-generalized-free-support-barycenter-py).
 A new differentiable solver for OT across spaces that provides OT plans
-between samples and features simultaneously and 
+between samples and features simultaneously and
 called [Co-Optimal
 Transport](https://pythonot.github.io/master/auto_examples/others/plot_COOT.html)
 has also been implemented. Finally we began working on OT between Gaussian distributions and
@@ -147,7 +148,7 @@ when implementing new solvers but we encourage users to play with it.
 Finally, in addition to those many new  this release fixes 20 issues (some long
 standing) and we want to thank all the contributors who made this release so
 big. More details below.
-    
+
 
 #### New features
 - Added feature to (Fused) Gromov-Wasserstein solvers inherited from `ot.optim` to support relative and absolute loss variations as stopping criterions (PR #431)

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -1151,11 +1151,11 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
     >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 5, div='kl'), 2)
-    array([[0.45 , 0.  ],
-           [0.   , 0.34]])
+    array([[0.45, 0.  ],
+           [0.  , 0.34]])
     >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 5, div='l2'), 2)
-    array([[0.4 , 0. ],
-           [0.  , 0.1]])
+    array([[0.4, 0. ],
+           [0. , 0.1]])
 
 
     .. _references-regpath:
@@ -1475,11 +1475,11 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
     >>> np.round(ot.unbalanced.lbfgsb_unbalanced(a, b, M, reg=0, reg_m=5, reg_div='kl', regm_div='kl'), 2)
-    array([[0.45 , 0.  ],
-           [0.   , 0.34]])
+    array([[0.45, 0.  ],
+           [0.  , 0.34]])
     >>> np.round(ot.unbalanced.lbfgsb_unbalanced(a, b, M, reg=0, reg_m=5, reg_div='l2', regm_div='l2'), 2)
-    array([[0.4 , 0. ],
-           [0.  , 0.1]])
+    array([[0.4, 0. ],
+           [0. , 0.1]])
 
     References
     ----------

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -1319,7 +1319,7 @@ def mm_unbalanced2(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     ot.lp.emd2 : Unregularized OT loss
     ot.unbalanced.sinkhorn_unbalanced2 : Entropic regularized OT loss
     """
-    _, log_mm = mm_unbalanced(a, b, M, reg, reg_m, div=div, G0=G0,
+    _, log_mm = mm_unbalanced(a, b, M, reg_m, reg=reg, div=div, G0=G0,
                               numItermax=numItermax, stopThr=stopThr,
                               verbose=verbose, log=True)
 

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -15,8 +15,8 @@ import warnings
 import numpy as np
 from scipy.optimize import minimize, Bounds
 
-from ot.backend import get_backend
-from ot.utils import list_to_array
+from .backend import get_backend
+from .utils import list_to_array
 
 
 def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=1000,

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -128,7 +128,7 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=
     ot.unbalanced.sinkhorn_stabilized_unbalanced:
         Unbalanced Stabilized sinkhorn :ref:`[9, 10] <references-sinkhorn-unbalanced>`
     ot.unbalanced.sinkhorn_reg_scaling_unbalanced:
-        Unbalanced Sinkhorn with epslilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced>`
+        Unbalanced Sinkhorn with epsilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced>`
 
     """
 
@@ -253,7 +253,7 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m=None, method='sinkhorn',
     --------
     ot.unbalanced.sinkhorn_knopp : Unbalanced Classic Sinkhorn :ref:`[10] <references-sinkhorn-unbalanced2>`
     ot.unbalanced.sinkhorn_stabilized: Unbalanced Stabilized sinkhorn :ref:`[9, 10] <references-sinkhorn-unbalanced2>`
-    ot.unbalanced.sinkhorn_reg_scaling: Unbalanced Sinkhorn with epslilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced2>`
+    ot.unbalanced.sinkhorn_reg_scaling: Unbalanced Sinkhorn with epsilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced2>`
 
     """
     b = list_to_array(b)
@@ -528,7 +528,7 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
         For semi-relaxed case, use either
         (float("inf"), scalar) or (scalar, float("inf")).
     tau : float
-        thershold for max value in u or v for log scaling
+        threshold for max value in u or v for log scaling
     numItermax : int, optional
         Max number of iterations
     stopThr : float, optional
@@ -746,7 +746,7 @@ def barycenter_unbalanced_stabilized(A, M, reg, reg_m, weights=None, tau=1e3,
     tau : float
         Stabilization threshold for log domain absorption.
     weights : array-like (n_hists,) optional
-        Weight of each distribution (barycentric coodinates)
+        Weight of each distribution (barycentric coordinates)
         If None, uniform weights are used.
     numItermax : int, optional
         Max number of iterations

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -65,6 +65,7 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
         The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
         `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
+        If reg_m is an array, it must have the same backend as input arrays (a, b, M).
     method : str
         method used for the solver either 'sinkhorn',  'sinkhorn_stabilized' or
         'sinkhorn_reg_scaling', see those function for specific parameters
@@ -200,6 +201,7 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
         The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
         `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
+        If reg_m is an array, it must have the same backend as input arrays (a, b, M).
     method : str
         method used for the solver either 'sinkhorn',  'sinkhorn_stabilized' or
         'sinkhorn_reg_scaling', see those function for specific parameters
@@ -327,6 +329,7 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
         The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
         `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
+        If reg_m is an array, it must have the same backend as input arrays (a, b, M).
     numItermax : int, optional
         Max number of iterations
     stopThr : float, optional
@@ -519,6 +522,7 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
         The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
         `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
+        If reg_m is an array, it must have the same backend as input arrays (a, b, M).
     tau : float
         threshold for max value in u or v for log scaling
     numItermax : int, optional
@@ -1107,6 +1111,7 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
         Marginal relaxation term >= 0, but cannot be infinity.
         If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        If reg_m is an array, it must have the same backend as input arrays (a, b, M).
     reg : float, optional (default = 0)
         Entropy regularization term >= 0.
         By default, solve the unregularized problem
@@ -1255,6 +1260,7 @@ def mm_unbalanced2(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
         Marginal relaxation term >= 0, but cannot be infinity.
         If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        If reg_m is an array, it must have the same backend as input arrays (a, b, M).
     reg : float, optional (default = 0)
         Entropy regularization term >= 0.
         By default, solve the unregularized problem
@@ -1424,6 +1430,7 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
         Marginal relaxation term >= 0, but cannot be infinity.
         If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        If reg_m is an array, it must be a Numpy array.
     reg_div: string, optional
         Divergence used for regularization.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)
@@ -1477,7 +1484,7 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     nx = get_backend(M, a, b)
 
     M0 = M
-    # convert to humpy
+    # convert to numpy
     a, b, M = nx.to_numpy(a, b, M)
 
     reg_m1, reg_m2 = extract_parameters(reg_m, nx)

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -1150,10 +1150,10 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     >>> a=[.5, .5]
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
-    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 1, 'kl'), 2)
+    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 1, div='kl'), 2)
     array([[0.3 , 0.  ],
            [0.  , 0.07]])
-    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 1, 'l2'), 2)
+    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 1, div='l2'), 2)
     array([[0.25, 0.  ],
            [0.  , 0.  ]])
 
@@ -1304,9 +1304,9 @@ def mm_unbalanced2(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     >>> a=[.5, .5]
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, 'l2'),2)
+    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='l2'), 2)
     0.25
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, 'kl'),2)
+    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='kl'), 2)
     0.57
 
     References
@@ -1473,9 +1473,9 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     >>> a=[.5, .5]
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, 'l2'),2)
+    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='l2'),2)
     0.25
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, 'kl'),2)
+    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='kl'),2)
     0.57
 
     References

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -5,6 +5,8 @@ Regularized Unbalanced OT solvers
 
 # Author: Hicham Janati <hicham.janati@inria.fr>
 #         Laetitia Chapel <laetitia.chapel@univ-ubs.fr>
+#         Quang Huy Tran <quang-huy.tran@univ-ubs.fr>
+#
 # License: MIT License
 
 from __future__ import division
@@ -15,10 +17,9 @@ from scipy.optimize import minimize, Bounds
 
 from .backend import get_backend
 from .utils import list_to_array
-# from .utils import unif, dist
 
 
-def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
+def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=1000,
                         stopThr=1e-6, verbose=False, log=False, **kwargs):
     r"""
     Solve the unbalanced entropic regularization optimal transport problem
@@ -27,9 +28,10 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
     The function solves the following optimization problem:
 
     .. math::
-        W = \min_\gamma \ \langle \gamma, \mathbf{M} \rangle_F + \mathrm{reg}\cdot\Omega(\gamma) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
+        W = \min_\gamma \ \langle \gamma, \mathbf{M} \rangle_F +
+        \mathrm{reg} \cdot \Omega(\gamma) +
+        \mathrm{reg_{m1}} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
 
         s.t.
              \gamma \geq 0
@@ -56,8 +58,13 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float
-        Marginal relaxation term > 0
+    reg_m: float or indexable object of length 2, optional (default = None)
+        Marginal relaxation term.
+        By default, `reg_m=None` corresponds to solving an
+        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
+        For semi-relaxed case, use either
+        (float("inf"), scalar) or (scalar, float("inf")).
     method : str
         method used for the solver either 'sinkhorn',  'sinkhorn_stabilized' or
         'sinkhorn_reg_scaling', see those function for specific parameters
@@ -121,7 +128,7 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
     ot.unbalanced.sinkhorn_stabilized_unbalanced:
         Unbalanced Stabilized sinkhorn :ref:`[9, 10] <references-sinkhorn-unbalanced>`
     ot.unbalanced.sinkhorn_reg_scaling_unbalanced:
-        Unbalanced Sinkhorn with epsilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced>`
+        Unbalanced Sinkhorn with epslilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced>`
 
     """
 
@@ -147,7 +154,7 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
         raise ValueError("Unknown method '%s'." % method)
 
 
-def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
+def sinkhorn_unbalanced2(a, b, M, reg, reg_m=None, method='sinkhorn',
                          numItermax=1000, stopThr=1e-6, verbose=False,
                          log=False, **kwargs):
     r"""
@@ -157,13 +164,13 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
     The function solves the following optimization problem:
 
     .. math::
-        W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F + \mathrm{reg}\cdot\Omega(\gamma) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
+        W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F +
+        \mathrm{reg} \cdot \Omega(\gamma) +
+        \mathrm{reg_{m1}} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
 
         s.t.
              \gamma\geq 0
-
     where :
 
     - :math:`\mathbf{M}` is the (`dim_a`, `dim_b`) metric cost matrix
@@ -186,8 +193,13 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float
-        Marginal relaxation term > 0
+    reg_m: float or indexable object of length 2, optional (default = None)
+        Marginal relaxation term.
+        By default, `reg_m=None` corresponds to solving an
+        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
+        For semi-relaxed case, use either
+        (float("inf"), scalar) or (scalar, float("inf")).
     method : str
         method used for the solver either 'sinkhorn',  'sinkhorn_stabilized' or
         'sinkhorn_reg_scaling', see those function for specific parameters
@@ -241,7 +253,7 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
     --------
     ot.unbalanced.sinkhorn_knopp : Unbalanced Classic Sinkhorn :ref:`[10] <references-sinkhorn-unbalanced2>`
     ot.unbalanced.sinkhorn_stabilized: Unbalanced Stabilized sinkhorn :ref:`[9, 10] <references-sinkhorn-unbalanced2>`
-    ot.unbalanced.sinkhorn_reg_scaling: Unbalanced Sinkhorn with epsilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced2>`
+    ot.unbalanced.sinkhorn_reg_scaling: Unbalanced Sinkhorn with epslilon scaling :ref:`[9, 10] <references-sinkhorn-unbalanced2>`
 
     """
     b = list_to_array(b)
@@ -270,7 +282,7 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
         raise ValueError('Unknown method %s.' % method)
 
 
-def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
+def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m=None, numItermax=1000,
                               stopThr=1e-6, verbose=False, log=False, **kwargs):
     r"""
     Solve the entropic regularization unbalanced optimal transport problem and
@@ -279,9 +291,10 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
     The function solves the following optimization problem:
 
     .. math::
-        W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F + \mathrm{reg}\cdot\Omega(\gamma) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
+        W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F +
+        \mathrm{reg} \cdot \Omega(\gamma) +
+        \mathrm{reg_{m1}} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
 
         s.t.
              \gamma \geq 0
@@ -307,8 +320,13 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float
-        Marginal relaxation term > 0
+    reg_m: float or indexable object of length 2, optional (default = None)
+        Marginal relaxation term.
+        By default, `reg_m=None` corresponds to solving an
+        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
+        For semi-relaxed case, use either
+        (float("inf"), scalar) or (scalar, float("inf")).
     numItermax : int, optional
         Max number of iterations
     stopThr : float, optional
@@ -376,6 +394,16 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
     else:
         n_hists = 0
 
+    if isinstance(reg_m, float) or isinstance(reg_m, int):
+        reg_m1, reg_m2 = reg_m, reg_m
+    elif reg_m is None:
+        reg_m1, reg_m2 = float("inf"), float("inf")
+    else:
+        if len(reg_m) != 2:
+            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
+        else:
+            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+
     if log:
         log = {'err': []}
 
@@ -391,7 +419,8 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
 
     K = nx.exp(M / (-reg))
 
-    fi = reg_m / (reg_m + reg)
+    fi_1 = reg_m1 / (reg_m1 + reg) if reg_m1 != float("inf") else 1
+    fi_2 = reg_m2 / (reg_m2 + reg) if reg_m2 != float("inf") else 1
 
     err = 1.
 
@@ -400,9 +429,9 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
         vprev = v
 
         Kv = nx.dot(K, v)
-        u = (a / Kv) ** fi
+        u = (a / Kv) ** fi_1
         Ktu = nx.dot(K.T, u)
-        v = (b / Ktu) ** fi
+        v = (b / Ktu) ** fi_2
 
         if (nx.any(Ktu == 0.)
                 or nx.any(nx.isnan(u)) or nx.any(nx.isnan(v))
@@ -461,9 +490,10 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     stabilization as proposed in :ref:`[10] <references-sinkhorn-stabilized-unbalanced>`:
 
     .. math::
-        W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F + \mathrm{reg}\cdot\Omega(\gamma) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
+        W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F +
+        \mathrm{reg} \cdot \Omega(\gamma) +
+        \mathrm{reg_{m1}} \cdot \mathrm{KL}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{KL}(\gamma^T \mathbf{1}, \mathbf{b})
 
         s.t.
              \gamma \geq 0
@@ -490,10 +520,15 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float
-        Marginal relaxation term > 0
+    reg_m: float or indexable object of length 2, optional (default = None)
+        Marginal relaxation term.
+        By default, `reg_m=None` corresponds to solving an
+        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
+        For semi-relaxed case, use either
+        (float("inf"), scalar) or (scalar, float("inf")).
     tau : float
-        threshold for max value in u or v for log scaling
+        thershold for max value in u or v for log scaling
     numItermax : int, optional
         Max number of iterations
     stopThr : float, optional
@@ -559,6 +594,16 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     else:
         n_hists = 0
 
+    if isinstance(reg_m, float) or isinstance(reg_m, int):
+        reg_m1, reg_m2 = reg_m, reg_m
+    elif reg_m is None:
+        reg_m1, reg_m2 = float("inf"), float("inf")
+    else:
+        if len(reg_m) != 2:
+            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
+        else:
+            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+
     if log:
         log = {'err': []}
 
@@ -575,7 +620,8 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     # print(reg)
     K = nx.exp(-M / reg)
 
-    fi = reg_m / (reg_m + reg)
+    fi_1 = reg_m1 / (reg_m1 + reg) if reg_m1 != float("inf") else 1
+    fi_2 = reg_m2 / (reg_m2 + reg) if reg_m2 != float("inf") else 1
 
     cpt = 0
     err = 1.
@@ -586,15 +632,15 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
         vprev = v
 
         Kv = nx.dot(K, v)
-        f_alpha = nx.exp(- alpha / (reg + reg_m))
-        f_beta = nx.exp(- beta / (reg + reg_m))
+        f_alpha = nx.exp(- alpha / (reg + reg_m1)) if reg_m1 != float("inf") else 1
+        f_beta = nx.exp(- beta / (reg + reg_m2)) if reg_m2 != float("inf") else 1
 
         if n_hists:
             f_alpha = f_alpha[:, None]
             f_beta = f_beta[:, None]
-        u = ((a / (Kv + 1e-16)) ** fi) * f_alpha
+        u = ((a / (Kv + 1e-16)) ** fi_1) * f_alpha
         Ktu = nx.dot(K.T, u)
-        v = ((b / (Ktu + 1e-16)) ** fi) * f_beta
+        v = ((b / (Ktu + 1e-16)) ** fi_2) * f_beta
         absorbing = False
         if nx.any(u > tau) or nx.any(v > tau):
             absorbing = True
@@ -700,7 +746,7 @@ def barycenter_unbalanced_stabilized(A, M, reg, reg_m, weights=None, tau=1e3,
     tau : float
         Stabilization threshold for log domain absorption.
     weights : array-like (n_hists,) optional
-        Weight of each distribution (barycentric coordinates)
+        Weight of each distribution (barycentric coodinates)
         If None, uniform weights are used.
     numItermax : int, optional
         Max number of iterations
@@ -1037,7 +1083,7 @@ def barycenter_unbalanced(A, M, reg, reg_m, method="sinkhorn", weights=None,
         raise ValueError("Unknown method '%s'." % method)
 
 
-def mm_unbalanced(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
+def mm_unbalanced(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
                   stopThr=1e-15, verbose=False, log=False):
     r"""
     Solve the unbalanced optimal transport problem and return the OT plan.
@@ -1045,8 +1091,10 @@ def mm_unbalanced(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
 
     .. math::
         W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F +
-        \mathrm{reg_m} \cdot \mathrm{div}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{div}(\gamma^T \mathbf{1}, \mathbf{b})
+        \mathrm{reg_{m1}} \cdot \mathrm{div}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{div}(\gamma^T \mathbf{1}, \mathbf{b}) +
+        \mathrm{reg} \cdot \mathrm{div}(\gamma, \mathbf{a} \mathbf{b}^T)
+
         s.t.
              \gamma \geq 0
 
@@ -1068,8 +1116,12 @@ def mm_unbalanced(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
         Unnormalized histogram of dimension `dim_b`
     M : array-like (dim_a, dim_b)
         loss matrix
-    reg_m: float
-        Marginal relaxation term > 0
+    reg : float
+        Entropy regularization term >= 0
+    reg_m: float or indexable object of length 2
+        Marginal relaxation term >= 0.
+        If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
     div: string, optional
         Divergence to quantify the difference between the marginals.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)
@@ -1131,30 +1183,41 @@ def mm_unbalanced(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
     else:
         G = G0
 
+    if isinstance(reg_m, float) or isinstance(reg_m, int):
+        reg_m1, reg_m2 = reg_m, reg_m
+    else:
+        if len(reg_m) != 2:
+            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
+        else:
+            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+
     if log:
         log = {'err': [], 'G': []}
 
     if div == 'kl':
-        K = nx.exp(M / - reg_m / 2)
+        sum_r = reg + reg_m1 + reg_m2
+        r1, r2, r = reg_m1 / sum_r, reg_m2 / sum_r, reg / sum_r
+        K = a[:, None]**(r1 + r) * b[None, :]**(r2 + r) * nx.exp(- M / sum_r)
     elif div == 'l2':
-        K = nx.maximum(a[:, None] + b[None, :] - M / reg_m / 2,
-                       nx.zeros((dim_a, dim_b), type_as=M))
+        K = reg_m1 * a[:, None] + reg_m2 * b[None, :] + reg * a[:, None] * b[None, :] - M
+        K = nx.maximum(K, nx.zeros((dim_a, dim_b), type_as=M))
     else:
         warnings.warn("The div parameter should be either equal to 'kl' or \
                       'l2': it has been set to 'kl'.")
         div = 'kl'
-        K = nx.exp(M / - reg_m / 2)
+        sum_r = reg + reg_m1 + reg_m2
+        r1, r2, r = reg_m1 / sum_r, reg_m2 / sum_r, reg / sum_r
+        K = a[:, None]**(r1 + r) * b[None, :]**(r2 + r) * nx.exp(- M / sum_r)
 
     for i in range(numItermax):
         Gprev = G
 
         if div == 'kl':
-            u = nx.sqrt(a / (nx.sum(G, 1) + 1e-16))
-            v = nx.sqrt(b / (nx.sum(G, 0) + 1e-16))
-            G = G * K * u[:, None] * v[None, :]
+            G = K * G**(r1 + r2) / (nx.sum(G, 1, keepdims=True)**r1 * nx.sum(G, 0, keepdims=True)**r2 + 1e-16)
         elif div == 'l2':
-            Gd = nx.sum(G, 0, keepdims=True) + nx.sum(G, 1, keepdims=True) + 1e-16
-            G = G * K / Gd
+            Gd = reg_m1 * nx.sum(G, 1, keepdims=True) + \
+                reg_m2 * nx.sum(G, 0, keepdims=True) + reg * G + 1e-16
+            G = K * G / Gd
 
         err = nx.sqrt(nx.sum((G - Gprev) ** 2))
         if log:
@@ -1172,7 +1235,7 @@ def mm_unbalanced(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
         return G
 
 
-def mm_unbalanced2(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
+def mm_unbalanced2(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
                    stopThr=1e-15, verbose=False, log=False):
     r"""
     Solve the unbalanced optimal transport problem and return the OT plan.
@@ -1180,8 +1243,9 @@ def mm_unbalanced2(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
 
     .. math::
         W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F +
-        \mathrm{reg_m} \cdot \mathrm{div}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{div}(\gamma^T \mathbf{1}, \mathbf{b})
+        \mathrm{reg_{m1}} \cdot \mathrm{div}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{div}(\gamma^T \mathbf{1}, \mathbf{b}) +
+        \mathrm{reg} \cdot \mathrm{div}(\gamma, \mathbf{a} \mathbf{b}^T)
 
         s.t.
              \gamma \geq 0
@@ -1204,8 +1268,12 @@ def mm_unbalanced2(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
         Unnormalized histogram of dimension `dim_b`
     M : array-like (dim_a, dim_b)
         loss matrix
-    reg_m: float
-        Marginal relaxation term > 0
+    reg : float
+        Entropy regularization term >= 0
+    reg_m: float or indexable object of length 2
+        Marginal relaxation term >= 0.
+        If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
     div: string, optional
         Divergence to quantify the difference between the marginals.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)
@@ -1249,7 +1317,7 @@ def mm_unbalanced2(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
     ot.lp.emd2 : Unregularized OT loss
     ot.unbalanced.sinkhorn_unbalanced2 : Entropic regularized OT loss
     """
-    _, log_mm = mm_unbalanced(a, b, M, reg_m, div=div, G0=G0,
+    _, log_mm = mm_unbalanced(a, b, M, reg, reg_m, div=div, G0=G0,
                               numItermax=numItermax, stopThr=stopThr,
                               verbose=verbose, log=True)
 
@@ -1259,7 +1327,7 @@ def mm_unbalanced2(a, b, M, reg_m, div='kl', G0=None, numItermax=1000,
         return log_mm['cost']
 
 
-def _get_loss_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl'):
+def _get_loss_unbalanced(a, b, M, reg, reg_m1, reg_m2, reg_div='kl', regm_div='kl'):
     """
     return the loss function (scipy.optimize compatible) for regularized
     unbalanced OT
@@ -1268,7 +1336,7 @@ def _get_loss_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl'):
     m, n = M.shape
 
     def kl(p, q):
-        return np.sum(p * np.log(p / q + 1e-16))
+        return np.sum(p * np.log(p / q + 1e-16)) - p.sum() + q.sum()
 
     def reg_l2(G):
         return np.sum((G - a[:, None] * b[None, :])**2) / 2
@@ -1280,10 +1348,10 @@ def _get_loss_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl'):
         return kl(G, a[:, None] * b[None, :])
 
     def grad_kl(G):
-        return np.log(G / (a[:, None] * b[None, :]) + 1e-16) + 1
+        return np.log(G / (a[:, None] * b[None, :]) + 1e-16)
 
     def reg_entropy(G):
-        return kl(G, 1)
+        return np.sum(G * np.log(G + 1e-16))
 
     def grad_entropy(G):
         return np.log(G + 1e-16) + 1
@@ -1299,16 +1367,19 @@ def _get_loss_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl'):
         grad_reg_fun = grad_l2
 
     def marg_l2(G):
-        return 0.5 * np.sum((G.sum(1) - a)**2) + 0.5 * np.sum((G.sum(0) - b)**2)
+        return reg_m1 * 0.5 * np.sum((G.sum(1) - a)**2) + \
+            reg_m2 * 0.5 * np.sum((G.sum(0) - b)**2)
 
     def grad_marg_l2(G):
-        return np.outer((G.sum(1) - a), np.ones(n)) + np.outer(np.ones(m), (G.sum(0) - b))
+        return reg_m1 * np.outer((G.sum(1) - a), np.ones(n)) + \
+            reg_m2 * np.outer(np.ones(m), (G.sum(0) - b))
 
     def marg_kl(G):
-        return kl(G.sum(1), a) + kl(G.sum(0), b)
+        return reg_m1 * kl(G.sum(1), a) + reg_m2 * kl(G.sum(0), b)
 
     def grad_marg_kl(G):
-        return np.outer(np.log(G.sum(1) / a + 1e-16) + 1, np.ones(n)) + np.outer(np.ones(m), np.log(G.sum(0) / b + 1e-16) + 1)
+        return reg_m1 * np.outer(np.log(G.sum(1) / a + 1e-16), np.ones(n)) + \
+            reg_m2 * np.outer(np.ones(m), np.log(G.sum(0) / b + 1e-16))
 
     if regm_div == 'kl':
         regm_fun = marg_kl
@@ -1321,10 +1392,10 @@ def _get_loss_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl'):
         G = G.reshape((m, n))
 
         # compute loss
-        val = np.sum(G * M) + reg * reg_fun(G) + reg_m * regm_fun(G)
+        val = np.sum(G * M) + reg * reg_fun(G) + regm_fun(G)
 
         # compute gradient
-        grad = M + reg * grad_reg_fun(G) + reg_m * grad_regm_fun(G)
+        grad = M + reg * grad_reg_fun(G) + grad_regm_fun(G)
 
         return val, grad.ravel()
 
@@ -1339,9 +1410,9 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
 
     .. math::
         W = \min_\gamma \quad \langle \gamma, \mathbf{M} \rangle_F +
-        + \mathrm{reg} \mathrm{div}(\gamma,\mathbf{a}\mathbf{b}^T)
-        \mathrm{reg_m} \cdot \mathrm{div_m}(\gamma \mathbf{1}, \mathbf{a}) +
-        \mathrm{reg_m} \cdot \mathrm{div}(\gamma^T \mathbf{1}, \mathbf{b})
+        + \mathrm{reg} \mathrm{div}(\gamma, \mathbf{a} \mathbf{b}^T)
+        \mathrm{reg_{m1}} \cdot \mathrm{div_m}(\gamma \mathbf{1}, \mathbf{a}) +
+        \mathrm{reg_{m2}} \cdot \mathrm{div}(\gamma^T \mathbf{1}, \mathbf{b})
 
         s.t.
              \gamma \geq 0
@@ -1365,12 +1436,14 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
         loss matrix
     reg: float
         regularization term (>=0)
-    reg_m: float
-        Marginal relaxation term >= 0
+    reg_m: float or indexable object of length 2
+        Marginal relaxation term.
+        If reg_m is a scalar,
+        then the same reg_m is applied to both marginal relaxations.
     reg_div: string, optional
         Divergence used for regularization.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)
-    reg_div: string, optional
+    regm_div: string, optional
         Divergence to quantify the difference between the marginals.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)
     G0: array-like (dim_a, dim_b)
@@ -1413,18 +1486,27 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     ot.lp.emd2 : Unregularized OT loss
     ot.unbalanced.sinkhorn_unbalanced2 : Entropic regularized OT loss
     """
+
     nx = get_backend(M, a, b)
 
     M0 = M
     # convert to humpy
     a, b, M = nx.to_numpy(a, b, M)
 
+    if isinstance(reg_m, float) or isinstance(reg_m, int):
+        reg_m1, reg_m2 = reg_m, reg_m
+    else:
+        if len(reg_m) != 2:
+            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
+        else:
+            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+
     if G0 is not None:
         G0 = nx.to_numpy(G0)
     else:
         G0 = np.zeros(M.shape)
 
-    _func = _get_loss_unbalanced(a, b, M, reg, reg_m, reg_div, regm_div)
+    _func = _get_loss_unbalanced(a, b, M, reg, reg_m1, reg_m2, reg_div, regm_div)
 
     res = minimize(_func, G0.ravel(), method=method, jac=True, bounds=Bounds(0, np.inf),
                    tol=stopThr, options=dict(maxiter=numItermax, disp=verbose))

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -611,13 +611,16 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     err = 1.
     alpha = nx.zeros(dim_a, type_as=M)
     beta = nx.zeros(dim_b, type_as=M)
+    ones_a = nx.ones(dim_a, type_as=M)
+    ones_b = nx.ones(dim_b, type_as=M)
+
     while (err > stopThr and cpt < numItermax):
         uprev = u
         vprev = v
 
         Kv = nx.dot(K, v)
-        f_alpha = nx.exp(- alpha / (reg + reg_m1)) if reg_m1 != float("inf") else 1
-        f_beta = nx.exp(- beta / (reg + reg_m2)) if reg_m2 != float("inf") else 1
+        f_alpha = nx.exp(- alpha / (reg + reg_m1)) if reg_m1 != float("inf") else ones_a
+        f_beta = nx.exp(- beta / (reg + reg_m2)) if reg_m2 != float("inf") else ones_b
 
         if n_hists:
             f_alpha = f_alpha[:, None]

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -1151,11 +1151,11 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
     >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 5, div='kl'), 2)
-    array([[0.45 , 0.   ],
-           [0.   , 0.34 ]])
+    array([[0.45 , 0.  ],
+           [0.   , 0.34]])
     >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 5, div='l2'), 2)
-    array([[0.4 , 0.  ],
-           [0.  , 0.1 ]])
+    array([[0.4 , 0. ],
+           [0.  , 0.1]])
 
 
     .. _references-regpath:
@@ -1475,11 +1475,11 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
     >>> np.round(ot.unbalanced.lbfgsb_unbalanced(a, b, M, reg=0, reg_m=5, reg_div='kl', regm_div='kl'), 2)
-    array([[0.45 , 0.   ],
-           [0.   , 0.34 ]])
+    array([[0.45 , 0.  ],
+           [0.   , 0.34]])
     >>> np.round(ot.unbalanced.lbfgsb_unbalanced(a, b, M, reg=0, reg_m=5, reg_div='l2', regm_div='l2'), 2)
-    array([[0.4 , 0.  ],
-           [0.  , 0.1 ]])
+    array([[0.4 , 0. ],
+           [0.  , 0.1]])
 
     References
     ----------

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -16,7 +16,7 @@ import numpy as np
 from scipy.optimize import minimize, Bounds
 
 from .backend import get_backend
-from .utils import list_to_array, extract_parameters
+from .utils import list_to_array, get_parameter_pair
 
 
 def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
@@ -397,7 +397,7 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
     else:
         n_hists = 0
 
-    reg_m1, reg_m2 = extract_parameters(reg_m)
+    reg_m1, reg_m2 = get_parameter_pair(reg_m)
 
     if log:
         log = {'err': []}
@@ -590,7 +590,7 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     else:
         n_hists = 0
 
-    reg_m1, reg_m2 = extract_parameters(reg_m)
+    reg_m1, reg_m2 = get_parameter_pair(reg_m)
 
     if log:
         log = {'err': []}
@@ -1177,7 +1177,7 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     else:
         G = G0
 
-    reg_m1, reg_m2 = extract_parameters(reg_m)
+    reg_m1, reg_m2 = get_parameter_pair(reg_m)
 
     if log:
         log = {'err': [], 'G': []}
@@ -1487,7 +1487,7 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     # convert to numpy
     a, b, M = nx.to_numpy(a, b, M)
 
-    reg_m1, reg_m2 = extract_parameters(reg_m)
+    reg_m1, reg_m2 = get_parameter_pair(reg_m)
 
     if G0 is not None:
         G0 = nx.to_numpy(G0)

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -15,8 +15,8 @@ import warnings
 import numpy as np
 from scipy.optimize import minimize, Bounds
 
-from .backend import get_backend
-from .utils import list_to_array
+from ot.backend import get_backend
+from ot.utils import list_to_array
 
 
 def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=1000,
@@ -1150,12 +1150,12 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     >>> a=[.5, .5]
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
-    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 1, div='kl'), 2)
-    array([[0.3 , 0.  ],
-           [0.  , 0.07]])
-    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 1, div='l2'), 2)
-    array([[0.25, 0.  ],
-           [0.  , 0.  ]])
+    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 5, div='kl'), 2)
+    array([[0.45 , 0.   ],
+           [0.   , 0.34 ]])
+    >>> np.round(ot.unbalanced.mm_unbalanced(a, b, M, 5, div='l2'), 2)
+    array([[0.4 , 0.  ],
+           [0.  , 0.1 ]])
 
 
     .. _references-regpath:
@@ -1169,6 +1169,7 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     ot.lp.emd : Unregularized OT
     ot.unbalanced.sinkhorn_unbalanced : Entropic regularized OT
     """
+
     M, a, b = list_to_array(M, a, b)
     nx = get_backend(M, a, b)
 
@@ -1304,10 +1305,10 @@ def mm_unbalanced2(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     >>> a=[.5, .5]
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='l2'), 2)
-    0.25
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='kl'), 2)
-    0.57
+    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 5, div='l2'), 2)
+    0.8
+    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 5, div='kl'), 2)
+    1.79
 
     References
     ----------
@@ -1461,8 +1462,8 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
 
     Returns
     -------
-    ot_distance : array-like
-        the OT distance between :math:`\mathbf{a}` and :math:`\mathbf{b}`
+    gamma : (dim_a, dim_b) array-like
+            Optimal transportation matrix for the given parameters
     log : dict
         log dictionary returned only if `log` is `True`
 
@@ -1473,10 +1474,12 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     >>> a=[.5, .5]
     >>> b=[.5, .5]
     >>> M=[[1., 36.],[9., 4.]]
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='l2'),2)
-    0.25
-    >>> np.round(ot.unbalanced.mm_unbalanced2(a, b, M, 1, div='kl'),2)
-    0.57
+    >>> np.round(ot.unbalanced.lbfgsb_unbalanced(a, b, M, reg=0, reg_m=5, reg_div='kl', regm_div='kl'), 2)
+    array([[0.45 , 0.   ],
+           [0.   , 0.34 ]])
+    >>> np.round(ot.unbalanced.lbfgsb_unbalanced(a, b, M, reg=0, reg_m=5, reg_div='l2', regm_div='l2'), 2)
+    array([[0.4 , 0.  ],
+           [0.  , 0.1 ]])
 
     References
     ----------
@@ -1489,6 +1492,7 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     ot.unbalanced.sinkhorn_unbalanced2 : Entropic regularized OT loss
     """
 
+    M, a, b = list_to_array(M, a, b)
     nx = get_backend(M, a, b)
 
     M0 = M

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -1083,7 +1083,7 @@ def barycenter_unbalanced(A, M, reg, reg_m, method="sinkhorn", weights=None,
         raise ValueError("Unknown method '%s'." % method)
 
 
-def mm_unbalanced(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
+def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
                   stopThr=1e-15, verbose=False, log=False):
     r"""
     Solve the unbalanced optimal transport problem and return the OT plan.
@@ -1116,12 +1116,13 @@ def mm_unbalanced(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
         Unnormalized histogram of dimension `dim_b`
     M : array-like (dim_a, dim_b)
         loss matrix
-    reg : float
-        Entropy regularization term >= 0
     reg_m: float or indexable object of length 2
         Marginal relaxation term >= 0.
         If reg_m is a scalar,
         then the same reg_m is applied to both marginal relaxations.
+    reg : float, optional (default = 0)
+        Entropy regularization term >= 0.
+        By default, solve the unregularized problem
     div: string, optional
         Divergence to quantify the difference between the marginals.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)
@@ -1235,7 +1236,7 @@ def mm_unbalanced(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
         return G
 
 
-def mm_unbalanced2(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
+def mm_unbalanced2(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
                    stopThr=1e-15, verbose=False, log=False):
     r"""
     Solve the unbalanced optimal transport problem and return the OT plan.
@@ -1268,12 +1269,13 @@ def mm_unbalanced2(a, b, M, reg, reg_m, div='kl', G0=None, numItermax=1000,
         Unnormalized histogram of dimension `dim_b`
     M : array-like (dim_a, dim_b)
         loss matrix
-    reg : float
-        Entropy regularization term >= 0
     reg_m: float or indexable object of length 2
         Marginal relaxation term >= 0.
         If reg_m is a scalar,
         then the same reg_m is applied to both marginal relaxations.
+    reg : float, optional (default = 0)
+        Entropy regularization term >= 0.
+        By default, solve the unregularized problem
     div: string, optional
         Divergence to quantify the difference between the marginals.
         Can take two values: 'kl' (Kullback-Leibler) or 'l2' (quadratic)

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -16,10 +16,10 @@ import numpy as np
 from scipy.optimize import minimize, Bounds
 
 from .backend import get_backend
-from .utils import list_to_array
+from .utils import list_to_array, extract_parameters
 
 
-def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=1000,
+def sinkhorn_unbalanced(a, b, M, reg, reg_m, method='sinkhorn', numItermax=1000,
                         stopThr=1e-6, verbose=False, log=False, **kwargs):
     r"""
     Solve the unbalanced entropic regularization optimal transport problem
@@ -58,13 +58,13 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float or indexable object of length 2, optional (default = None)
+    reg_m: float or indexable object of length 1 or 2
         Marginal relaxation term.
-        By default, `reg_m=None` corresponds to solving an
-        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
-        (float("inf"), scalar) or (scalar, float("inf")).
+        `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
     method : str
         method used for the solver either 'sinkhorn',  'sinkhorn_stabilized' or
         'sinkhorn_reg_scaling', see those function for specific parameters
@@ -154,7 +154,7 @@ def sinkhorn_unbalanced(a, b, M, reg, reg_m=None, method='sinkhorn', numItermax=
         raise ValueError("Unknown method '%s'." % method)
 
 
-def sinkhorn_unbalanced2(a, b, M, reg, reg_m=None, method='sinkhorn',
+def sinkhorn_unbalanced2(a, b, M, reg, reg_m, method='sinkhorn',
                          numItermax=1000, stopThr=1e-6, verbose=False,
                          log=False, **kwargs):
     r"""
@@ -193,13 +193,13 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m=None, method='sinkhorn',
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float or indexable object of length 2, optional (default = None)
+    reg_m: float or indexable object of length 1 or 2
         Marginal relaxation term.
-        By default, `reg_m=None` corresponds to solving an
-        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
-        (float("inf"), scalar) or (scalar, float("inf")).
+        `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
     method : str
         method used for the solver either 'sinkhorn',  'sinkhorn_stabilized' or
         'sinkhorn_reg_scaling', see those function for specific parameters
@@ -282,7 +282,7 @@ def sinkhorn_unbalanced2(a, b, M, reg, reg_m=None, method='sinkhorn',
         raise ValueError('Unknown method %s.' % method)
 
 
-def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m=None, numItermax=1000,
+def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
                               stopThr=1e-6, verbose=False, log=False, **kwargs):
     r"""
     Solve the entropic regularization unbalanced optimal transport problem and
@@ -320,13 +320,13 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m=None, numItermax=1000,
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float or indexable object of length 2, optional (default = None)
+    reg_m: float or indexable object of length 1 or 2
         Marginal relaxation term.
-        By default, `reg_m=None` corresponds to solving an
-        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
-        (float("inf"), scalar) or (scalar, float("inf")).
+        `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
     numItermax : int, optional
         Max number of iterations
     stopThr : float, optional
@@ -394,15 +394,7 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m=None, numItermax=1000,
     else:
         n_hists = 0
 
-    if isinstance(reg_m, float) or isinstance(reg_m, int):
-        reg_m1, reg_m2 = reg_m, reg_m
-    elif reg_m is None:
-        reg_m1, reg_m2 = float("inf"), float("inf")
-    else:
-        if len(reg_m) != 2:
-            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
-        else:
-            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
 
     if log:
         log = {'err': []}
@@ -520,13 +512,13 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
         loss matrix
     reg : float
         Entropy regularization term > 0
-    reg_m: float or indexable object of length 2, optional (default = None)
+    reg_m: float or indexable object of length 1 or 2
         Marginal relaxation term.
-        By default, `reg_m=None` corresponds to solving an
-        entropic **balanced** OT (i.e. `reg_m=float("inf")`). If reg_m is a scalar,
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
+        The entropic balanced OT can be recovered using `reg_m=float("inf")`.
         For semi-relaxed case, use either
-        (float("inf"), scalar) or (scalar, float("inf")).
+        `reg_m=(float("inf"), scalar)` or `reg_m=(scalar, float("inf"))`.
     tau : float
         threshold for max value in u or v for log scaling
     numItermax : int, optional
@@ -594,15 +586,7 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     else:
         n_hists = 0
 
-    if isinstance(reg_m, float) or isinstance(reg_m, int):
-        reg_m1, reg_m2 = reg_m, reg_m
-    elif reg_m is None:
-        reg_m1, reg_m2 = float("inf"), float("inf")
-    else:
-        if len(reg_m) != 2:
-            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
-        else:
-            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
 
     if log:
         log = {'err': []}
@@ -1116,9 +1100,9 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
         Unnormalized histogram of dimension `dim_b`
     M : array-like (dim_a, dim_b)
         loss matrix
-    reg_m: float or indexable object of length 2
-        Marginal relaxation term >= 0.
-        If reg_m is a scalar,
+    reg_m: float or indexable object of length 1 or 2
+        Marginal relaxation term >= 0, but cannot be infinity.
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
     reg : float, optional (default = 0)
         Entropy regularization term >= 0.
@@ -1185,13 +1169,7 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     else:
         G = G0
 
-    if isinstance(reg_m, float) or isinstance(reg_m, int):
-        reg_m1, reg_m2 = reg_m, reg_m
-    else:
-        if len(reg_m) != 2:
-            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
-        else:
-            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
 
     if log:
         log = {'err': [], 'G': []}
@@ -1270,9 +1248,9 @@ def mm_unbalanced2(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
         Unnormalized histogram of dimension `dim_b`
     M : array-like (dim_a, dim_b)
         loss matrix
-    reg_m: float or indexable object of length 2
-        Marginal relaxation term >= 0.
-        If reg_m is a scalar,
+    reg_m: float or indexable object of length 1 or 2
+        Marginal relaxation term >= 0, but cannot be infinity.
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
     reg : float, optional (default = 0)
         Entropy regularization term >= 0.
@@ -1438,10 +1416,10 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     M : array-like (dim_a, dim_b)
         loss matrix
     reg: float
-        regularization term (>=0)
-    reg_m: float or indexable object of length 2
-        Marginal relaxation term.
-        If reg_m is a scalar,
+        regularization term >=0
+    reg_m: float or indexable object of length 1 or 2
+        Marginal relaxation term >= 0, but cannot be infinity.
+        If reg_m is a scalar or an indexable object of length 1,
         then the same reg_m is applied to both marginal relaxations.
     reg_div: string, optional
         Divergence used for regularization.
@@ -1499,13 +1477,7 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     # convert to humpy
     a, b, M = nx.to_numpy(a, b, M)
 
-    if isinstance(reg_m, float) or isinstance(reg_m, int):
-        reg_m1, reg_m2 = reg_m, reg_m
-    else:
-        if len(reg_m) != 2:
-            raise ValueError("Epsilon must be either a scalar or an indexable object of length 2.")
-        else:
-            reg_m1, reg_m2 = reg_m[0], reg_m[1]
+    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
 
     if G0 is not None:
         G0 = nx.to_numpy(G0)

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -397,7 +397,7 @@ def sinkhorn_knopp_unbalanced(a, b, M, reg, reg_m, numItermax=1000,
     else:
         n_hists = 0
 
-    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
+    reg_m1, reg_m2 = extract_parameters(reg_m)
 
     if log:
         log = {'err': []}
@@ -590,7 +590,7 @@ def sinkhorn_stabilized_unbalanced(a, b, M, reg, reg_m, tau=1e5, numItermax=1000
     else:
         n_hists = 0
 
-    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
+    reg_m1, reg_m2 = extract_parameters(reg_m)
 
     if log:
         log = {'err': []}
@@ -1177,7 +1177,7 @@ def mm_unbalanced(a, b, M, reg_m, reg=0, div='kl', G0=None, numItermax=1000,
     else:
         G = G0
 
-    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
+    reg_m1, reg_m2 = extract_parameters(reg_m)
 
     if log:
         log = {'err': [], 'G': []}
@@ -1487,7 +1487,7 @@ def lbfgsb_unbalanced(a, b, M, reg, reg_m, reg_div='kl', regm_div='kl', G0=None,
     # convert to numpy
     a, b, M = nx.to_numpy(a, b, M)
 
-    reg_m1, reg_m2 = extract_parameters(reg_m, nx)
+    reg_m1, reg_m2 = extract_parameters(reg_m)
 
     if G0 is not None:
         G0 = nx.to_numpy(G0)

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -492,7 +492,7 @@ def get_coordinate_circle(x):
     return x_t
 
 
-def extract_parameters(parameter, nx):
+def extract_parameters(parameter):
     r"""Extract parameters from a given parameter
     Used in unbalanced OT and COOT solvers
     to handle marginal regularization and entropic regularization.
@@ -508,7 +508,7 @@ def extract_parameters(parameter, nx):
     param_2 : float
     """
 
-    if isinstance(parameter, float) or isinstance(parameter, int) or parameter == float("inf"):
+    if isinstance(parameter, float) or isinstance(parameter, int):
         param_1, param_2 = parameter, parameter
     elif len(parameter) == 1:
         param_1, param_2 = parameter[0], parameter[0]

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -492,8 +492,8 @@ def get_coordinate_circle(x):
     return x_t
 
 
-def extract_parameters(parameter):
-    r"""Extract parameters from a given parameter
+def get_parameter_pair(parameter):
+    r"""Extract a pair of parameters from a given parameter
     Used in unbalanced OT and COOT solvers
     to handle marginal regularization and entropic regularization.
 

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -511,8 +511,7 @@ def extract_parameters(parameter, nx):
     if isinstance(parameter, float) or isinstance(parameter, int) or parameter == float("inf"):
         param_1, param_2 = parameter, parameter
     elif len(parameter) == 1:
-        parameter = parameter * nx.ones(2)
-        param_1, param_2 = parameter[0], parameter[1]
+        param_1, param_2 = parameter[0], parameter[0]
     else:
         if len(parameter) > 2:
             raise ValueError("Parameter must be either a scalar, \

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -492,6 +492,37 @@ def get_coordinate_circle(x):
     return x_t
 
 
+def extract_parameters(parameter, nx):
+    r"""Extract parameters from a given parameter
+    Used in unbalanced OT and COOT solvers
+    to handle marginal regularization and entropic regularization.
+
+    Parameters
+    ----------
+    parameter : float or indexable object
+    nx : backend object
+
+    Returns
+    -------
+    param_1 : float
+    param_2 : float
+    """
+
+    if isinstance(parameter, float) or isinstance(parameter, int) or parameter == float("inf"):
+        param_1, param_2 = parameter, parameter
+    elif len(parameter) == 1:
+        parameter = parameter * nx.ones(2)
+        param_1, param_2 = parameter[0], parameter[1]
+    else:
+        if len(parameter) > 2:
+            raise ValueError("Parameter must be either a scalar, \
+                             or an indexable object of length 1 or 2.")
+        else:
+            param_1, param_2 = parameter[0], parameter[1]
+
+    return param_1, param_2
+
+
 class deprecated(object):
     r"""Decorator to mark a function or class as deprecated.
 

--- a/test/test_unbalanced.py
+++ b/test/test_unbalanced.py
@@ -369,12 +369,16 @@ def test_lbfgsb_unbalanced_relaxation_parameters(nx, reg_div, regm_div):
     a = ot.unif(5)
     b = ot.unif(6)
 
+    a, b, M = nx.from_numpy(a, b, M)
+
     reg_m = 10
     full_list_reg_m = [reg_m, reg_m]
     full_tuple_reg_m = (reg_m, reg_m)
     tuple_reg_m, list_reg_m = (reg_m), [reg_m]
-    nx_reg_m = reg_m * nx.ones(1)
-    list_options = [nx_reg_m, full_tuple_reg_m,
+    np1_reg_m = reg_m * np.ones(1)
+    np2_reg_m = reg_m * np.ones(2)
+
+    list_options = [np1_reg_m, np2_reg_m, full_tuple_reg_m,
                     tuple_reg_m, full_list_reg_m, list_reg_m]
 
     G = ot.unbalanced.lbfgsb_unbalanced(a, b, M, 1, reg_m=reg_m,
@@ -453,8 +457,10 @@ def test_mm_relaxation_parameters(nx, div):
     full_list_reg_m = [reg_m, reg_m]
     full_tuple_reg_m = (reg_m, reg_m)
     tuple_reg_m, list_reg_m = (reg_m), [reg_m]
-    nx_reg_m = reg_m * nx.ones(1)
-    list_options = [nx_reg_m, full_tuple_reg_m,
+    nx1_reg_m = reg_m * nx.ones(1)
+    nx2_reg_m = reg_m * nx.ones(2)
+
+    list_options = [nx1_reg_m, nx2_reg_m, full_tuple_reg_m,
                     tuple_reg_m, full_list_reg_m, list_reg_m]
 
     G0, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, reg=reg,
@@ -474,7 +480,7 @@ def test_mm_relaxation_parameters(nx, div):
         )
 
         np.testing.assert_allclose(nx.to_numpy(G0), nx.to_numpy(G1), atol=1e-05)
-        assert loss_0 == loss_1
+        np.testing.assert_allclose(loss_0, loss_1, atol=1e-5)
 
 
 def test_mm_wrong_divergence(nx):
@@ -509,4 +515,4 @@ def test_mm_wrong_divergence(nx):
     )
 
     np.testing.assert_allclose(nx.to_numpy(G0), nx.to_numpy(G1), atol=1e-05)
-    assert loss_0 == loss_1
+    np.testing.assert_allclose(loss_0, loss_1, atol=1e-5)

--- a/test/test_unbalanced.py
+++ b/test/test_unbalanced.py
@@ -388,13 +388,12 @@ def test_mm_convergence(nx, div):
     M = ot.dist(x, y)
     M = M / M.max()
     reg_m = 100
-    reg = 0
     a, b, M = nx.from_numpy(a_np, b_np, M)
 
-    G, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg, reg_m=reg_m, div=div,
+    G, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, div=div,
                                        verbose=False, log=True)
     loss = nx.to_numpy(
-        ot.unbalanced.mm_unbalanced2(a, b, M, reg, reg_m, div=div, verbose=True)
+        ot.unbalanced.mm_unbalanced2(a, b, M, reg_m, div=div, verbose=True)
     )
 
     # check if the marginals come close to the true ones when large reg
@@ -408,14 +407,14 @@ def test_mm_convergence(nx, div):
     a_np, b_np = np.array([]), np.array([])
     a, b = nx.from_numpy(a_np, b_np)
 
-    G_null = ot.unbalanced.mm_unbalanced(a, b, M, reg, reg_m=reg_m, div=div, verbose=False)
+    G_null = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, div=div, verbose=False)
     np.testing.assert_allclose(nx.to_numpy(G_null), nx.to_numpy(G))
 
     # test when G0 is given
     G0 = ot.emd(a, b, M)
     G0_np = nx.to_numpy(G0)
     reg_m = 10000
-    G = ot.unbalanced.mm_unbalanced(a, b, M, reg, reg_m=reg_m, div=div, G0=G0, verbose=False)
+    G = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, div=div, G0=G0, verbose=False)
     np.testing.assert_allclose(G0_np, nx.to_numpy(G), atol=1e-05)
 
 
@@ -436,20 +435,19 @@ def test_mm_relaxation_parameters(nx, div):
 
     a, b, M = nx.from_numpy(a_np, b_np, M)
 
-    G0, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg=reg, reg_m=reg_m, div=div,
+    G0, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, reg=reg, div=div,
                                         verbose=False, log=True)
     loss_0 = nx.to_numpy(
-        ot.unbalanced.mm_unbalanced2(a, b, M, reg=reg, reg_m=reg_m,
+        ot.unbalanced.mm_unbalanced2(a, b, M, reg_m=reg_m, reg=reg,
                                      div=div, verbose=True)
     )
 
-    G1, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg=reg,
-                                        reg_m=(reg_m, reg_m), div=div,
+    G1, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=(reg_m, reg_m),
+                                        reg=reg, div=div,
                                         verbose=False, log=True)
     loss_1 = nx.to_numpy(
-        ot.unbalanced.mm_unbalanced2(a, b, M, reg=reg,
-                                     reg_m=(reg_m, reg_m),
-                                     div=div, verbose=True)
+        ot.unbalanced.mm_unbalanced2(a, b, M, reg_m=(reg_m, reg_m),
+                                     reg=reg, div=div, verbose=True)
     )
 
     np.testing.assert_allclose(nx.to_numpy(G0), nx.to_numpy(G1), atol=1e-05)

--- a/test/test_unbalanced.py
+++ b/test/test_unbalanced.py
@@ -388,12 +388,13 @@ def test_mm_convergence(nx, div):
     M = ot.dist(x, y)
     M = M / M.max()
     reg_m = 100
+    reg = 0
     a, b, M = nx.from_numpy(a_np, b_np, M)
 
-    G, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, div=div,
+    G, _ = ot.unbalanced.mm_unbalanced(a, b, M, reg, reg_m=reg_m, div=div,
                                        verbose=False, log=True)
     loss = nx.to_numpy(
-        ot.unbalanced.mm_unbalanced2(a, b, M, reg_m, div=div, verbose=True)
+        ot.unbalanced.mm_unbalanced2(a, b, M, reg, reg_m, div=div, verbose=True)
     )
 
     # check if the marginals come close to the true ones when large reg
@@ -407,14 +408,14 @@ def test_mm_convergence(nx, div):
     a_np, b_np = np.array([]), np.array([])
     a, b = nx.from_numpy(a_np, b_np)
 
-    G_null = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, div=div, verbose=False)
+    G_null = ot.unbalanced.mm_unbalanced(a, b, M, reg, reg_m=reg_m, div=div, verbose=False)
     np.testing.assert_allclose(nx.to_numpy(G_null), nx.to_numpy(G))
 
     # test when G0 is given
     G0 = ot.emd(a, b, M)
     G0_np = nx.to_numpy(G0)
     reg_m = 10000
-    G = ot.unbalanced.mm_unbalanced(a, b, M, reg_m=reg_m, div=div, G0=G0, verbose=False)
+    G = ot.unbalanced.mm_unbalanced(a, b, M, reg, reg_m=reg_m, div=div, G0=G0, verbose=False)
     np.testing.assert_allclose(G0_np, nx.to_numpy(G), atol=1e-05)
 
 

--- a/test/test_unbalanced.py
+++ b/test/test_unbalanced.py
@@ -101,13 +101,13 @@ def test_unbalanced_relaxation_parameters(nx, method, reg_m):
     loss, log = ot.unbalanced.sinkhorn_unbalanced(
         a, b, M, reg=epsilon, reg_m=reg_m,
         method=method, log=True, verbose=True
-        )
+    )
 
     for opt in list_options:
         loss_opt, log_opt = ot.unbalanced.sinkhorn_unbalanced(
             a, b, M, reg=epsilon, reg_m=opt,
             method=method, log=True, verbose=True
-            )
+        )
 
         np.testing.assert_allclose(
             nx.to_numpy(log["logu"]), nx.to_numpy(log_opt["logu"]), atol=1e-05)
@@ -385,7 +385,7 @@ def test_lbfgsb_unbalanced_relaxation_parameters(nx, reg_div, regm_div):
         G0 = ot.unbalanced.lbfgsb_unbalanced(
             a, b, M, 1, reg_m=opt, reg_div=reg_div,
             regm_div=regm_div, log=False, verbose=False
-            )
+        )
 
         np.testing.assert_allclose(nx.to_numpy(G), nx.to_numpy(G0), atol=1e-06)
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Modify all unbalanced solvers in `unbalanced.py ` (except for barycenter), so that the argument `reg_m` can take either a scalar, or an indexable object of length 1 or 2. 
- Edit `mm_unbalanced` method so that it can be used for both unregularized and regularized problems (previously supported unregularized only). Also, fix an implementation error of matrix $K$ in the $L_2$ case.
- Fix the KL formula and the corresponding gradient for L-BFGS-B solver.
- Add corresponding tests to `test_unbalanced.py`.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
1. The current solvers for unbalanced OT have some limitations, which may restrict their usage in practice.
- The `sinkhorn_unbalanced` and `lbfgsb_unbalanced` methods only allow for `reg_m` to be a scalar, thus impose the same penalization on both marginals.
- The `mm_unbalanced` method has the same limitation and restrict only to the unregularized problem.
2.  The `_get_loss_unbalanced` method uses incorrect formula of KL divergence, since we are working with unnormalized measures. As a result, the calculation of the gradient is also incorrect.

This PR fixes all of these issues. Moreover, as a byproduct, the new version of `sinkhorn_unbalanced` method also allows to solve the entropic balanced and semi-relaxed problems.

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

Tested when `reg_m` is a scalar, indexable objects of length 1 and 2 (tuple, list, array/tensor).


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
