### PR TITLE
[MRG] Add LazyTensor for large scale OT

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@
 + New LP solvers from scipy used by default for LP barycenter (PR #537)
 + Update wheels to Python 3.12 and remove old i686 arch that do not have scipy wheels (PR #543)
 + Upgraded unbalanced OT solvers for more flexibility (PR #539)
++ Add LazyTensor for modeling plans and low rank tensor in large scale OT (PR #544)
 
 #### Closed issues
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)

--- a/ot/factored.py
+++ b/ot/factored.py
@@ -7,7 +7,7 @@ Factored OT solvers (low rank, cost or OT plan)
 # License: MIT License
 
 from .backend import get_backend
-from .utils import dist
+from .utils import dist, get_lowrank_lazytensor
 from .lp import emd
 from .bregman import sinkhorn
 
@@ -139,6 +139,7 @@ def factored_optimal_transport(Xa, Xb, a=None, b=None, reg=0.0, r=100, X0=None, 
                    'vb': logb['v'],
                    'costa': loga['cost'],
                    'costb': logb['cost'],
+                   'lazy_plan': get_lowrank_lazytensor(Ga, Gb.T, nx=nx),
                    }
         return Ga, Gb, X, log_dic
 

--- a/ot/factored.py
+++ b/ot/factored.py
@@ -139,7 +139,7 @@ def factored_optimal_transport(Xa, Xb, a=None, b=None, reg=0.0, r=100, X0=None, 
                    'vb': logb['v'],
                    'costa': loga['cost'],
                    'costb': logb['cost'],
-                   'lazy_plan': get_lowrank_lazytensor(Ga, Gb.T, nx=nx),
+                   'lazy_plan': get_lowrank_lazytensor(Ga * r, Gb.T, nx=nx),
                    }
         return Ga, Gb, X, log_dic
 

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -491,7 +491,7 @@ def get_coordinate_circle(x):
     x_t = (nx.atan2(-x[:, 1], -x[:, 0]) + np.pi) / (2 * np.pi)
     return x_t
 
-  
+
 def reduce_lazytensor(a, fun, axis=None, nx=None, batch_size=None):
     """ Reduce a LazyTensor along an axis with function fun using batches.
 
@@ -524,7 +524,7 @@ def reduce_lazytensor(a, fun, axis=None, nx=None, batch_size=None):
     """
 
     if nx is None:
-        nx = get_backend(a)
+        nx = get_backend(a[0])
 
     if batch_size is None:
         batch_size = 100
@@ -551,13 +551,11 @@ def reduce_lazytensor(a, fun, axis=None, nx=None, batch_size=None):
         else:
             shape = (a.shape[0], *a.shape[2:])
         res = nx.zeros(shape, type_as=a[0])
-        if nx.__name__ == "jax":
+        if nx.__name__ in ["jax", "tf"]:
             lst = []
             for i in range(0, a.shape[0], batch_size):
                 lst.append(fun(a[i:i + batch_size], 1))
             return nx.concatenate(lst, axis=0)
-        elif nx.__name__ == "tf":
-            raise (NotImplementedError("LazyTensor reduction not implemented for TF backend."))
         else:
             for i in range(0, a.shape[0], batch_size):
                 res[i:i + batch_size] = fun(a[i:i + batch_size], axis=1)
@@ -565,6 +563,7 @@ def reduce_lazytensor(a, fun, axis=None, nx=None, batch_size=None):
 
     else:
         raise (NotImplementedError("Only axis=None is implemented for now."))
+
 
 def get_parameter_pair(parameter):
     r"""Extract a pair of parameters from a given parameter

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -562,7 +562,7 @@ def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=100):
         return res
 
     else:
-        raise (NotImplementedError("Only axis=None is implemented for now."))
+        raise (NotImplementedError("Only axis=None, 0 or 1 is implemented for now."))
 
 
 def get_lowrank_lazytensor(Q, R, d=None, nx=None):

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -565,6 +565,31 @@ def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=100):
         raise (NotImplementedError("Only axis=None is implemented for now."))
 
 
+def get_lowrank_lazytensor(Q, R, d=None, nx=None):
+    """ Get a lowrank LazyTensor T=Q@R^T or T=Q@diag(d)@R^T"""
+
+    if nx is None:
+        nx = get_backend(Q, R, d)
+
+    shape = (Q.shape[0], R.shape[0])
+
+    if d is None:
+
+        def func(i, j, Q, R):
+            return nx.dot(Q[i], R[j].T)
+
+        T = LazyTensor(shape, func, Q=Q, R=R)
+
+    else:
+
+        def func(i, j, Q, R, d):
+            return nx.dot(Q[i] * d[None, :], R[j].T)
+
+        T = LazyTensor(shape, func, Q=Q, R=R, d=d)
+
+    return T
+
+
 def get_parameter_pair(parameter):
     r"""Extract a pair of parameters from a given parameter
     Used in unbalanced OT and COOT solvers

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -944,9 +944,14 @@ class OTResult:
         elif self._lazy_plan is not None:
             lp = self._lazy_plan
             bs = self._batch_size
-            res = self._backend.zeros(lp.shape[0])
-            for i in range(0, lp.shape[0], bs):
-                res[i:i + bs] = self._backend.sum(lp[i:i + bs], 1)
+            nx = self._backend
+            res = nx.zeros(lp.shape[0], type_as=lp[0])
+            if nx.__name__ == 'jax':
+                for i in range(0, lp.shape[0], bs):
+                    res = res.at[i:i + bs].set(nx.sum(lp[i:i + bs], 1))
+            else:
+                for i in range(0, lp.shape[0], bs):
+                    res[i:i + bs] = nx.sum(lp[i:i + bs], 1)
             return res
         else:
             raise NotImplementedError()
@@ -959,9 +964,14 @@ class OTResult:
         elif self._lazy_plan is not None:
             lp = self._lazy_plan
             bs = self._batch_size
-            res = self._backend.zeros(lp.shape[1])
-            for i in range(0, lp.shape[1], bs):
-                res[i:i + bs] = self._backend.sum(lp[:, i:i + bs], 0)
+            nx = self._backend
+            res = nx.zeros(lp.shape[1], type_as=lp[0])
+            if nx.__name__ == 'jax':
+                for i in range(0, lp.shape[1], bs):
+                    res = res.at[i:i + bs].set(nx.sum(lp[:, i:i + bs], 0))
+            else:
+                for i in range(0, lp.shape[1], bs):
+                    res[i:i + bs] = nx.sum(lp[:, i:i + bs], 0)
             return res
         else:
             raise NotImplementedError()

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -566,7 +566,23 @@ def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=100):
 
 
 def get_lowrank_lazytensor(Q, R, d=None, nx=None):
-    """ Get a lowrank LazyTensor T=Q@R^T or T=Q@diag(d)@R^T"""
+    """ Get a low rank LazyTensor T=Q@R^T or T=Q@diag(d)@R^T
+    
+    Parameters
+    ----------
+    Q : ndarray, shape (n, r)
+        First factor of the lowrank tensor
+    R : ndarray, shape (m, r)
+        Second factor of the lowrank tensor
+    d : ndarray, shape (r,), optional
+        Diagonal of the lowrank tensor
+    nx : Backend, optional
+        Backend to use for the reduction
+        
+    Returns
+    -------
+    T : LazyTensor
+        Lowrank tensor T=Q@R^T or T=Q@diag(d)@R^T    """
 
     if nx is None:
         nx = get_backend(Q, R, d)

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -492,7 +492,7 @@ def get_coordinate_circle(x):
     return x_t
 
 
-def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=None):
+def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=100):
     """ Reduce a LazyTensor along an axis with function fun using batches.
 
     When axis=None, reduce the LazyTensor to a scalar as a sum of fun over
@@ -528,9 +528,6 @@ def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=None):
 
     if nx is None:
         nx = get_backend(a[0])
-
-    if batch_size is None:
-        batch_size = 100
 
     if axis is None:
         res = 0.0

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -567,7 +567,7 @@ def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=100):
 
 def get_lowrank_lazytensor(Q, R, d=None, nx=None):
     """ Get a low rank LazyTensor T=Q@R^T or T=Q@diag(d)@R^T
-    
+
     Parameters
     ----------
     Q : ndarray, shape (n, r)
@@ -578,11 +578,12 @@ def get_lowrank_lazytensor(Q, R, d=None, nx=None):
         Diagonal of the lowrank tensor
     nx : Backend, optional
         Backend to use for the reduction
-        
+
     Returns
     -------
     T : LazyTensor
-        Lowrank tensor T=Q@R^T or T=Q@diag(d)@R^T    """
+        Lowrank tensor T=Q@R^T or T=Q@diag(d)@R^T
+    """
 
     if nx is None:
         nx = get_backend(Q, R, d)

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -498,7 +498,7 @@ def reduce_lazytensor(a, func, axis=None, nx=None, batch_size=None):
     When axis=None, reduce the LazyTensor to a scalar as a sum of fun over
     batches taken along dim.
 
-    .. warning:: 
+    .. warning::
         This function works for tensor of any order but the reduction can be done
         only along the first two axis (or global). Also, in order to work, it requires that the slice of size `batch_size` along the axis to reduce (or axis 0 if `axis=None`) is can be computed and fits in memory.
 

--- a/test/test_factored.py
+++ b/test/test_factored.py
@@ -28,6 +28,7 @@ def test_factored_ot():
     # check constraints
     np.testing.assert_allclose(u, Ga.sum(1))
     np.testing.assert_allclose(u, Gb.sum(0))
+    np.testing.assert_allclose(1, log['lazy_plan'][:].sum())
 
 
 def test_factored_ot_backends(nx):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -408,6 +408,7 @@ def test_LazyTensor(nx):
 
     n1 = 100
     n2 = 200
+    shape = (n1, n2)
 
     rng = np.random.RandomState(42)
     x1 = rng.randn(n1, 2)
@@ -429,16 +430,16 @@ def test_LazyTensor(nx):
     assert T.x2 is x2
 
     # get the full tensor (not lazy)
-    T[:]
+    assert T[:].shape == shape
 
     # get one component
-    T[1, 1]
+    assert T[1, 1] == nx.dot(x1[1], x2[1].T)
 
     # get one row
-    T[1]
+    assert T[1].shape == (n2,)
 
     # get one column with slices
-    T[::10, 5]
+    assert T[::10, 5].shape == (10,)
 
 
 def test_OTResult_LazyTensor(nx):
@@ -448,9 +449,9 @@ def test_OTResult_LazyTensor(nx):
 
     rng = np.random.RandomState(42)
     a = rng.rand(n1)
-    a = a / a.sum()
+    a /= a.sum()
     b = rng.rand(n2)
-    b = b / b.sum()
+    b /= b.sum()
 
     a, b = nx.from_numpy(a, b)
 
@@ -473,9 +474,9 @@ def test_LazyTensor_reduce(nx):
 
     rng = np.random.RandomState(42)
     a = rng.rand(n1)
-    a = a / a.sum()
+    a /= a.sum()
     b = rng.rand(n2)
-    b = b / b.sum()
+    b /= b.sum()
 
     a, b = nx.from_numpy(a, b)
 
@@ -485,9 +486,13 @@ def test_LazyTensor_reduce(nx):
     # create a lazy tensor
     T = ot.utils.LazyTensor((n1, n2), getitem, a=a, b=b)
 
+    T0 = T[:]
+    s0 = nx.sum(T0)
+
     # total sum
     s = ot.utils.reduce_lazytensor(T, nx.sum, nx=nx)
     np.testing.assert_allclose(nx.to_numpy(s), 1)
+    np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(s0))
 
     s2 = ot.utils.reduce_lazytensor(T, nx.sum)
     np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(s2))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -460,7 +460,7 @@ def test_OTResult_LazyTensor(nx):
     # create a lazy tensor
     T = ot.utils.LazyTensor((n1, n2), getitem, a=a, b=b)
 
-    res = ot.utils.OTResult(lazy_plan=T, batch_size=10, backend=nx)
+    res = ot.utils.OTResult(lazy_plan=T, batch_size=9, backend=nx)
 
     np.testing.assert_allclose(nx.to_numpy(a), nx.to_numpy(res.marginal_a))
     np.testing.assert_allclose(nx.to_numpy(b), nx.to_numpy(res.marginal_b))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,6 +10,27 @@ import sys
 import pytest
 
 
+def get_LazyTensor(nx):
+    n1 = 100
+    n2 = 200
+
+    rng = np.random.RandomState(42)
+    a = rng.rand(n1)
+    a /= a.sum()
+    b = rng.rand(n2)
+    b /= b.sum()
+
+    a, b = nx.from_numpy(a, b)
+
+    def getitem(i, j, a, b):
+        return a[i, None] * b[None, j]
+
+    # create a lazy tensor
+    T = ot.utils.LazyTensor((n1, n2), getitem, a=a, b=b)
+
+    return T
+
+
 def test_proj_simplex(nx):
     n = 10
     rng = np.random.RandomState(0)
@@ -444,22 +465,7 @@ def test_LazyTensor(nx):
 
 def test_OTResult_LazyTensor(nx):
 
-    n1 = 100
-    n2 = 200
-
-    rng = np.random.RandomState(42)
-    a = rng.rand(n1)
-    a /= a.sum()
-    b = rng.rand(n2)
-    b /= b.sum()
-
-    a, b = nx.from_numpy(a, b)
-
-    def getitem(i, j, a, b):
-        return a[i, None] * b[None, j]
-
-    # create a lazy tensor
-    T = ot.utils.LazyTensor((n1, n2), getitem, a=a, b=b)
+    T = get_LazyTensor(nx)
 
     res = ot.utils.OTResult(lazy_plan=T, batch_size=9, backend=nx)
 
@@ -469,22 +475,7 @@ def test_OTResult_LazyTensor(nx):
 
 def test_LazyTensor_reduce(nx):
 
-    n1 = 100
-    n2 = 200
-
-    rng = np.random.RandomState(42)
-    a = rng.rand(n1)
-    a /= a.sum()
-    b = rng.rand(n2)
-    b /= b.sum()
-
-    a, b = nx.from_numpy(a, b)
-
-    def getitem(i, j, a, b):
-        return a[i, None] * b[None, j]
-
-    # create a lazy tensor
-    T = ot.utils.LazyTensor((n1, n2), getitem, a=a, b=b)
+    T = get_LazyTensor(nx)
 
     T0 = T[:]
     s0 = nx.sum(T0)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -462,6 +462,9 @@ def test_LazyTensor(nx):
     # get one column with slices
     assert T[::10, 5].shape == (10,)
 
+    with pytest.raises(NotImplementedError):
+        T["error"]
+
 
 def test_OTResult_LazyTensor(nx):
 
@@ -506,6 +509,23 @@ def test_LazyTensor_reduce(nx):
     s = ot.utils.reduce_lazytensor(T, nx.logsumexp, axis=1, nx=nx)
     s2 = nx.logsumexp(T[:], axis=1)
     np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(s2))
+
+    # test 3D tensors
+    def getitem(i, j, k, a, b, c):
+        return a[i, None, None] * b[None, j, None] * c[None, None, k]
+
+    # create a lazy tensor
+    n = a.shape[0]
+    T = ot.utils.LazyTensor((n, n, n), getitem, a=a, b=a, c=a)
+
+    # total sum
+    s1 = ot.utils.reduce_lazytensor(T, nx.sum, axis=0, nx=nx)
+    s2 = ot.utils.reduce_lazytensor(T, nx.sum, axis=1, nx=nx)
+
+    np.testing.assert_allclose(nx.to_numpy(s1), nx.to_numpy(s2))
+
+    with pytest.raises(NotImplementedError):
+        ot.utils.reduce_lazytensor(T, nx.sum, axis=2, nx=nx, batch_size=10)
 
 
 def test_lowrank_LazyTensor(nx):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -489,6 +489,15 @@ def test_LazyTensor_reduce(nx):
     s = ot.utils.reduce_lazytensor(T, nx.sum, nx=nx)
     np.testing.assert_allclose(nx.to_numpy(s), 1)
 
+    s2 = ot.utils.reduce_lazytensor(T, nx.sum)
+    np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(s2))
+
+    s2 = ot.utils.reduce_lazytensor(T, nx.sum, batch_size=500)
+    np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(s2))
+
+    s2 = ot.utils.reduce_lazytensor(T, nx.sum, batch_size=11)
+    np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(s2))
+
     # sum over axis 0
     s = ot.utils.reduce_lazytensor(T, nx.sum, axis=0, nx=nx)
     np.testing.assert_allclose(nx.to_numpy(s), nx.to_numpy(b))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -389,6 +389,7 @@ def test_OTResult():
                       'value_linear',
                       'value_quad']
     for at in lst_attributes:
+        print(at)
         with pytest.raises(NotImplementedError):
             getattr(res, at)
 
@@ -401,3 +402,38 @@ def test_get_coordinate_circle():
     x_p = ot.utils.get_coordinate_circle(x)
 
     np.testing.assert_allclose(u[0], x_p)
+
+
+def test_LazyTensor(nx):
+
+    n1 = 100
+    n2 = 200
+    x1 = np.random.randn(n1, 2)
+    x2 = np.random.randn(n2, 2)
+
+    x1, x2 = nx.from_numpy(x1, x2)
+
+    # i,j can be integers or slices, x1,x2 have to be passed as keyword arguments
+    def getitem(i, j, x1, x2):
+        return nx.dot(x1[i], x2[j].T)
+
+    # create a lazy tensor
+    T = ot.utils.LazyTensor((n1, n2), getitem, x1=x1, x2=x2)
+
+    assert T.shape == (n1, n2)
+    assert str(T) == "LazyTensor(shape=(100, 200),attributes=(x1,x2))"
+
+    assert T.x1 is x1
+    assert T.x2 is x2
+
+    # get the full tensor (not lazy)
+    full_T = T[:]
+
+    # get one component
+    T11 = T[1, 1]
+
+    # get one row
+    T1 = T[1]
+
+    # get one column with slices
+    Tsliced = T[::10, 5]


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

This PR adds a very simple LazyTensor class that can implement large scale matrices and tensors that are computed only lazily when getting slices of the tensor.

This class will be very interesting when implementing large scale OT problems such as factored OT, low rank OT and lazy implementation of sinkhorn. The objective is to be very simple with a storage of all necessary data and a function that compute the values on sliced (without computing the full tensor).

Exemple of use

```python
import numpy as np
from ot.utils import LazyTensor, 

n1=100
n2=200
x1 = np.random.randn(n1,2)
x2 = np.random.randn(n2,2)

# i,j can be integers or slices, x1,x2 have to be passed as keyword arguments
def getitem(i,j, x1, x2):
    return np.dot(x1[i], x2[j].T)

# create a lazy tensor (giv data as arguments)
T = LazyTensor((n1,n2),getitem, x1=x1, x2=x2)

print(T.shape)
# (100, 200)
print(T)
# LazyTensor(shape=(100, 200),attributes=(x1,x2))

# get the full tensor (not lazy)
full_T = T[:]

# get one component
T11 = T[1,1]

# get one row
T1 = T[1]

# get one column with slices
Tsliced = T[::10,5]

# get the data as attributes
x1_0 = T.x1
x2_0 = T.x2

# create a LazyTensor from another one : exp(T)
T2 = ot.utils.LazyTensor(T.shape,lambda i,j,T: np.exp(T[i,j]) , T=T)

# compute sum
s = reduce_lazytensor(T, np.sum) 

# compute marginals
c = reduce_lazytensor(T, np.sum, axis=1) 
r = reduce_lazytensor(T, np.sum, axis=0, batch_size=50) 

```


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
