### PR TITLE
[MRG] Add exact line-search for (f)gw solvers with kl_loss

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,7 @@
 + Update wheels to Python 3.12 and remove old i686 arch that do not have scipy wheels (PR #543)
 + Upgraded unbalanced OT solvers for more flexibility (PR #539)
 + Add LazyTensor for modeling plans and low rank tensor in large scale OT (PR #544)
++ Add exact line-search for `gromov_wasserstein` and `fused_gromov_wasserstein` with KL loss (PR #556)
 
 #### Closed issues
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- Add exact line-search for `ot.gromov.gromov_wasserstein` and `ot.gromov.fused_gromov_wasserstein` when `loss_fun = 'kl_loss'` which can be called by setting `armijo=False`(default for the method). Note that these solvers ignored the provided `armijo` parameter with this loss enforcing `armijo=True`.
- Extend `ot.gromov.solve_gromov_linesearch` to any loss with common decomposition.
- Adapt the behavior of dependent solvers that also enforced `armijo=True`: `ot.gromov.gromov_barycenters` and `ot.gromov.fgw_barycenters`
- Add gradients in this setting for `ot.gromov.gromov_wasserstein2` and `ot.gromov.fused_gromov_wasserstein2`

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

- Extended existing test for `ot.gromov.gromov_wasserstein` and `ot.gromov.fused_gromov_wasserstein` with kl loss, looping over armijo values.

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
