### PR TITLE
[MRG] correct independence of fgw barycenters to init

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,6 +21,7 @@
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)
 - Lazily instantiate backends to avoid unnecessary GPU memory pre-allocations on package import (Issue #516, PR #520)
 - Handle documentation and warnings when integers are provided to (f)gw solvers based on cg (Issue #530, PR #559)
+- Correct independence of `fgw_barycenters` to `init_C` and `init_X` (Issue #547, PR #564)
 
 ## 0.9.1
 *August 2023*

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,7 +21,7 @@
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)
 - Lazily instantiate backends to avoid unnecessary GPU memory pre-allocations on package import (Issue #516, PR #520)
 - Handle documentation and warnings when integers are provided to (f)gw solvers based on cg (Issue #530, PR #559)
-- Correct independence of `fgw_barycenters` to `init_C` and `init_X` (Issue #547, PR #564)
+- Correct independence of `fgw_barycenters` to `init_C` and `init_X` (Issue #547, PR #566)
 
 ## 0.9.1
 *August 2023*

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -167,7 +167,7 @@ def gromov_wasserstein(C1, C2, p=None, q=None, loss_fun='square_loss', symmetric
             return 0.5 * (gwggrad(constC, hC1, hC2, G, np_) + gwggrad(constCt, hC1t, hC2t, G, np_))
 
     # removed since 0.9.2
-    #if loss_fun == 'kl_loss':
+    # if loss_fun == 'kl_loss':
     #    armijo = True # there is no closed form line-search with KL
 
     if armijo:
@@ -479,7 +479,7 @@ def fused_gromov_wasserstein(M, C1, C2, p=None, q=None, loss_fun='square_loss', 
             return 0.5 * (gwggrad(constC, hC1, hC2, G, np_) + gwggrad(constCt, hC1t, hC2t, G, np_))
 
     # removed since 0.9.2
-    #if loss_fun == 'kl_loss':
+    # if loss_fun == 'kl_loss':
     #    armijo = True  # there is no closed form line-search with KL
 
     if armijo:
@@ -828,7 +828,7 @@ def gromov_barycenters(
         C = init_C
 
     # removed since 0.9.2
-    #if loss_fun == 'kl_loss':
+    # if loss_fun == 'kl_loss':
     #    armijo = True
 
     cpt = 0
@@ -1015,7 +1015,7 @@ def fgw_barycenters(
         T = [nx.outer(p, q) for q in ps]
 
     # removed since 0.9.2
-    #if loss_fun == 'kl_loss':
+    # if loss_fun == 'kl_loss':
     #    armijo = True
 
     cpt = 0

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -166,10 +166,6 @@ def gromov_wasserstein(C1, C2, p=None, q=None, loss_fun='square_loss', symmetric
         def df(G):
             return 0.5 * (gwggrad(constC, hC1, hC2, G, np_) + gwggrad(constCt, hC1t, hC2t, G, np_))
 
-    # removed since 0.9.2
-    # if loss_fun == 'kl_loss':
-    #    armijo = True # there is no closed form line-search with KL
-
     if armijo:
         def line_search(cost, G, deltaG, Mi, cost_G, **kwargs):
             return line_search_armijo(cost, G, deltaG, Mi, cost_G, nx=np_, **kwargs)
@@ -477,10 +473,6 @@ def fused_gromov_wasserstein(M, C1, C2, p=None, q=None, loss_fun='square_loss', 
 
         def df(G):
             return 0.5 * (gwggrad(constC, hC1, hC2, G, np_) + gwggrad(constCt, hC1t, hC2t, G, np_))
-
-    # removed since 0.9.2
-    # if loss_fun == 'kl_loss':
-    #    armijo = True  # there is no closed form line-search with KL
 
     if armijo:
         def line_search(cost, G, deltaG, Mi, cost_G, **kwargs):
@@ -827,10 +819,6 @@ def gromov_barycenters(
     else:
         C = init_C
 
-    # removed since 0.9.2
-    # if loss_fun == 'kl_loss':
-    #    armijo = True
-
     cpt = 0
     err = 1
 
@@ -1013,10 +1001,6 @@ def fgw_barycenters(
 
     if warmstartT:
         T = [nx.outer(p, q) for q in ps]
-
-    # removed since 0.9.2
-    # if loss_fun == 'kl_loss':
-    #    armijo = True
 
     cpt = 0
     err_feature = 1

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -1425,11 +1425,18 @@ def test_fgw_barycenter(nx):
     init_C /= init_C.max()
     init_Cb = nx.from_numpy(init_C)
 
-    Xb, Cb = ot.gromov.fgw_barycenters(
-        n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
-        alpha=0.5, fixed_structure=True, init_C=init_Cb, fixed_features=False,
-        p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
-    )
+    try:  # to raise warning when `fixed_structure=True`and `init_C=None`
+        Xb, Cb = ot.gromov.fgw_barycenters(
+            n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
+            alpha=0.5, fixed_structure=True, init_C=None, fixed_features=False,
+            p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
+        )
+    except:
+        Xb, Cb = ot.gromov.fgw_barycenters(
+            n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
+            alpha=0.5, fixed_structure=True, init_C=init_Cb, fixed_features=False,
+            p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
+        )
     Xb, Cb = nx.to_numpy(Xb), nx.to_numpy(Cb)
     np.testing.assert_allclose(Cb.shape, (n_samples, n_samples))
     np.testing.assert_allclose(Xb.shape, (n_samples, ys.shape[1]))
@@ -1437,12 +1444,21 @@ def test_fgw_barycenter(nx):
     init_X = rng.randn(n_samples, ys.shape[1])
     init_Xb = nx.from_numpy(init_X)
 
-    Xb, Cb, logb = ot.gromov.fgw_barycenters(
-        n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
-        fixed_structure=False, fixed_features=True, init_X=init_Xb,
-        p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
-        warmstartT=True, log=True, random_state=98765, verbose=True
-    )
+    try:  # to raise warning when `fixed_features=True`and `init_X=None`
+        Xb, Cb, logb = ot.gromov.fgw_barycenters(
+            n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
+            fixed_structure=False, fixed_features=True, init_X=None,
+            p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
+            warmstartT=True, log=True, random_state=98765, verbose=True
+        )
+    except:
+        Xb, Cb, logb = ot.gromov.fgw_barycenters(
+            n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
+            fixed_structure=False, fixed_features=True, init_X=init_Xb,
+            p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
+            warmstartT=True, log=True, random_state=98765, verbose=True
+        )
+
     X, C = nx.to_numpy(Xb), nx.to_numpy(Cb)
     np.testing.assert_allclose(C.shape, (n_samples, n_samples))
     np.testing.assert_allclose(X.shape, (n_samples, ys.shape[1]))

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -1425,18 +1425,18 @@ def test_fgw_barycenter(nx):
     init_C /= init_C.max()
     init_Cb = nx.from_numpy(init_C)
 
-    try:  # to raise warning when `fixed_structure=True`and `init_C=None`
+    with pytest.raises(ot.utils.UndefinedParameter):  # to raise warning when `fixed_structure=True`and `init_C=None`
         Xb, Cb = ot.gromov.fgw_barycenters(
             n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
             alpha=0.5, fixed_structure=True, init_C=None, fixed_features=False,
             p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
         )
-    except ot.utils.UndefinedParameter:
-        Xb, Cb = ot.gromov.fgw_barycenters(
-            n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
-            alpha=0.5, fixed_structure=True, init_C=init_Cb, fixed_features=False,
-            p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
-        )
+
+    Xb, Cb = ot.gromov.fgw_barycenters(
+        n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
+        alpha=0.5, fixed_structure=True, init_C=init_Cb, fixed_features=False,
+        p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
+    )
     Xb, Cb = nx.to_numpy(Xb), nx.to_numpy(Cb)
     np.testing.assert_allclose(Cb.shape, (n_samples, n_samples))
     np.testing.assert_allclose(Xb.shape, (n_samples, ys.shape[1]))
@@ -1444,20 +1444,19 @@ def test_fgw_barycenter(nx):
     init_X = rng.randn(n_samples, ys.shape[1])
     init_Xb = nx.from_numpy(init_X)
 
-    try:  # to raise warning when `fixed_features=True`and `init_X=None`
+    with pytest.raises(ot.utils.UndefinedParameter):  # to raise warning when `fixed_features=True`and `init_X=None`
         Xb, Cb, logb = ot.gromov.fgw_barycenters(
             n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
             fixed_structure=False, fixed_features=True, init_X=None,
             p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
             warmstartT=True, log=True, random_state=98765, verbose=True
         )
-    except ot.utils.UndefinedParameter:
-        Xb, Cb, logb = ot.gromov.fgw_barycenters(
-            n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
-            fixed_structure=False, fixed_features=True, init_X=init_Xb,
-            p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
-            warmstartT=True, log=True, random_state=98765, verbose=True
-        )
+    Xb, Cb, logb = ot.gromov.fgw_barycenters(
+        n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
+        fixed_structure=False, fixed_features=True, init_X=init_Xb,
+        p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
+        warmstartT=True, log=True, random_state=98765, verbose=True
+    )
 
     X, C = nx.to_numpy(Xb), nx.to_numpy(Cb)
     np.testing.assert_allclose(C.shape, (n_samples, n_samples))

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -1431,7 +1431,7 @@ def test_fgw_barycenter(nx):
             alpha=0.5, fixed_structure=True, init_C=None, fixed_features=False,
             p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
         )
-    except:
+    except ot.utils.UndefinedParameter:
         Xb, Cb = ot.gromov.fgw_barycenters(
             n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
             alpha=0.5, fixed_structure=True, init_C=init_Cb, fixed_features=False,
@@ -1451,7 +1451,7 @@ def test_fgw_barycenter(nx):
             p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
             warmstartT=True, log=True, random_state=98765, verbose=True
         )
-    except:
+    except ot.utils.UndefinedParameter:
         Xb, Cb, logb = ot.gromov.fgw_barycenters(
             n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
             fixed_structure=False, fixed_features=True, init_X=init_Xb,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- correct independence of fgw barycenters to init by changing performing the 1st barycenter update after the computing the 1st OT matrices.
- Removed some unnecessary operations when `fixed_features=True` and/or `warmstart=False`.

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

- Cf Issue #547 

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

- already handled by existing tests.

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
