### PR TITLE
[MRG] Avoid changing precision in the backend

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,7 @@
 - Lazily instantiate backends to avoid unnecessary GPU memory pre-allocations on package import (Issue #516, PR #520)
 - Handle documentation and warnings when integers are provided to (f)gw solvers based on cg (Issue #530, PR #559)
 - Correct independence of `fgw_barycenters` to `init_C` and `init_X` (Issue #547, PR #566)
+- Avoid precision change when computing norm using PyTorch backend (Discussion #570, PR #572)
 
 ## 0.9.1
 *August 2023*

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1941,7 +1941,7 @@ class TorchBackend(Backend):
         return torch.pow(a, exponents)
 
     def norm(self, a, axis=None, keepdims=False):
-        return torch.linalg.norm(a.double(), dim=axis, keepdims=keepdims)
+        return torch.linalg.norm(a, dim=axis, keepdims=keepdims)
 
     def any(self, a):
         return torch.any(a)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -81,7 +81,7 @@ def test_empirical_bures_wasserstein_mapping_numerical_error_warning():
 
 
 def test_bures_wasserstein_distance(nx):
-    ms, mt = np.array([0]), np.array([10])
+    ms, mt = np.array([0]).astype(np.float32), np.array([10]).astype(np.float32)
     Cs, Ct = np.array([[1]]).astype(np.float32), np.array([[1]]).astype(np.float32)
     msb, mtb, Csb, Ctb = nx.from_numpy(ms, mt, Cs, Ct)
     Wb_log, log = ot.gaussian.bures_wasserstein_distance(msb, mtb, Csb, Ctb, log=True)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Fix previously added (see PR #507) precision change when computing norm on the PyTorch backend.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Precision change is not necessary, and fails on devices which don't have support for double precision.

Related discussion #570.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
n/a


## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
