### PR TITLE
[MRG] (f)gw barycenter solvers new features and cleaning

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,7 +17,7 @@
 + Add KL loss to all semi-relaxed (Fused) Gromov-Wasserstein solvers (PR #559)
 + Further upgraded unbalanced OT solvers for more flexibility and future use (PR #551)
 + New API function `ot.solve_sample` for solving OT problems from empirical samples (PR #563)
-+ Add `conv_criterion` feature to (un)regularized (f)gw barycenter solvers (PR #578)
++ Add `stop_criterion` feature to (un)regularized (f)gw barycenter solvers (PR #578)
 + Add `fixed_structure` and `fixed_features` to entropic fgw barycenter solver (PR #578)
 
 #### Closed issues

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,6 +17,8 @@
 + Add KL loss to all semi-relaxed (Fused) Gromov-Wasserstein solvers (PR #559)
 + Further upgraded unbalanced OT solvers for more flexibility and future use (PR #551)
 + New API function `ot.solve_sample` for solving OT problems from empirical samples (PR #563)
++ Add `conv_criterion` feature to (un)regularized (f)gw barycenter solvers (PR #578)
++ Add `fixed_structure` and `fixed_features` to entropic fgw barycenter solver (PR #578)
 
 #### Closed issues
 - Fix line search evaluating cost outside of the interpolation range (Issue #502, PR #504)

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -1037,7 +1037,7 @@ def entropic_fused_gromov_barycenters(
             log_['loss'] = []
             log_['err_rel_loss'] = []
 
-    while ((err_feature > tol or err_structure > tol) and err_rel_loss > tol and cpt < max_iter):
+    while ((err_feature > tol or err_structure > tol or err_rel_loss > tol) and cpt < max_iter):
         if conv_criterion == 'barycenter':
             Cprev = C
             Yprev = Y

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -423,6 +423,9 @@ def entropic_gromov_barycenters(
     if loss_fun not in ('square_loss', 'kl_loss'):
         raise ValueError(f"Unknown `loss_fun='{loss_fun}'`. Use one of: {'square_loss', 'kl_loss'}.")
 
+    if conv_criterion not in ['barycenter', 'loss']:
+        raise ValueError(f"Unknown `conv_criterion='{conv_criterion}'`. Use one of: {'barycenter', 'loss'}.")
+
     Cs = list_to_array(*Cs)
     arr = [*Cs]
     if ps is not None:
@@ -966,7 +969,7 @@ def entropic_fused_gromov_barycenters(
     if loss_fun not in ('square_loss', 'kl_loss'):
         raise ValueError(f"Unknown `loss_fun='{loss_fun}'`. Use one of: {'square_loss', 'kl_loss'}.")
 
-    if not conv_criterion in ['barycenter', 'loss']:
+    if conv_criterion not in ['barycenter', 'loss']:
         raise ValueError(f"Unknown `conv_criterion='{conv_criterion}'`. Use one of: {'barycenter', 'loss'}.")
 
     Cs = list_to_array(*Cs)

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -1013,15 +1013,20 @@ def entropic_fused_gromov_barycenters(
     Ms = [dist(Y, Ys[s]) for s in range(len(Ys))]
 
     cpt = 0
-    err_feature = 1e15
-    err_structure = 1e15
-    err_rel_loss = 1e15
 
     if conv_criterion == 'barycenter':
         inner_log = False
+        err_feature = 1e15
+        err_structure = 1e15
+        err_rel_loss = 0.
+
     else:
         inner_log = True
+        err_feature = 0.
+        err_structure = 0.
         curr_loss = 1e15
+        err_rel_loss = 1e15
+
     if log:
         log_ = {}
         if conv_criterion == 'barycenter':
@@ -1032,7 +1037,7 @@ def entropic_fused_gromov_barycenters(
             log_['loss'] = []
             log_['err_rel_loss'] = []
 
-    while ((err_feature > tol or err_structure > tol or err_rel_loss > tol) and cpt < max_iter):
+    while ((err_feature > tol or err_structure > tol) and err_rel_loss > tol and cpt < max_iter):
         if conv_criterion == 'barycenter':
             Cprev = C
             Yprev = Y

--- a/ot/gromov/_bregman.py
+++ b/ot/gromov/_bregman.py
@@ -345,8 +345,9 @@ def entropic_gromov_wasserstein2(
 
 def entropic_gromov_barycenters(
         N, Cs, ps=None, p=None, lambdas=None, loss_fun='square_loss',
-        epsilon=0.1, symmetric=True, max_iter=1000, tol=1e-9, warmstartT=False,
-        verbose=False, log=False, init_C=None, random_state=None, **kwargs):
+        epsilon=0.1, symmetric=True, max_iter=1000, tol=1e-9,
+        conv_criterion='barycenter', warmstartT=False, verbose=False,
+        log=False, init_C=None, random_state=None, **kwargs):
     r"""
     Returns the Gromov-Wasserstein barycenters of `S` measured similarity matrices :math:`(\mathbf{C}_s)_{1 \leq s \leq S}`
     estimated using Gromov-Wasserstein transports from Sinkhorn projections.
@@ -391,6 +392,10 @@ def entropic_gromov_barycenters(
     warmstartT: bool, optional
         Either to perform warmstart of transport plans in the successive
         gromov-wasserstein transport problems.
+    conv_criterion : str, optional. Default is 'barycenter'.
+        Convergence criterion taking values in ['barycenter', 'loss']. If set to 'barycenter'
+        uses absolute norm variations of estimated barycenters. Else if set to 'loss'
+        uses the relative variations of the loss.
     verbose : bool, optional
         Print information along iterations.
     log : bool, optional
@@ -446,45 +451,72 @@ def entropic_gromov_barycenters(
         C = init_C
 
     cpt = 0
-    err = 1
-
-    error = []
+    err = 1e15  # either the error on 'barycenter' or 'loss'
 
     if warmstartT:
         T = [None] * S
 
-    while (err > tol) and (cpt < max_iter):
-        Cprev = C
-        if warmstartT:
-            T = [entropic_gromov_wasserstein(
-                C, Cs[s], p, ps[s], loss_fun, epsilon, symmetric, T[s],
-                max_iter, 1e-4, verbose=verbose, log=False, **kwargs) for s in range(S)]
-        else:
-            T = [entropic_gromov_wasserstein(
-                C, Cs[s], p, ps[s], loss_fun, epsilon, symmetric, None,
-                max_iter, 1e-4, verbose=verbose, log=False, **kwargs) for s in range(S)]
+    if conv_criterion == 'barycenter':
+        inner_log = False
+    else:
+        inner_log = True
+        curr_loss = 1e15
 
+    if log:
+        log_ = {}
+        log_['err'] = []
+        if conv_criterion == 'loss':
+            log_['loss'] = []
+
+    while (err > tol) and (cpt < max_iter):
+        if conv_criterion == 'barycenter':
+            Cprev = C
+        else:
+            prev_loss = curr_loss
+
+        # get transport plans
+        if warmstartT:
+            res = [entropic_gromov_wasserstein(
+                C, Cs[s], p, ps[s], loss_fun, epsilon, symmetric, T[s],
+                max_iter, 1e-4, verbose=verbose, log=inner_log, **kwargs) for s in range(S)]
+        else:
+            res = [entropic_gromov_wasserstein(
+                C, Cs[s], p, ps[s], loss_fun, epsilon, symmetric, None,
+                max_iter, 1e-4, verbose=verbose, log=inner_log, **kwargs) for s in range(S)]
+        if conv_criterion == 'barycenter':
+            T = res
+        else:
+            T = [output[0] for output in res]
+            curr_loss = np.sum([output[1]['gw_dist'] for output in res])
+
+        # update barycenters
         if loss_fun == 'square_loss':
             C = update_square_loss(p, lambdas, T, Cs, nx)
         elif loss_fun == 'kl_loss':
             C = update_kl_loss(p, lambdas, T, Cs, nx)
 
-        if cpt % 10 == 0:
-            # we can speed up the process by checking for the error only all
-            # the 10th iterations
+        # update convergence criterion
+        if conv_criterion == 'barycenter':
             err = nx.norm(C - Cprev)
-            error.append(err)
+            if log:
+                log_['err'].append(err)
 
-            if verbose:
-                if cpt % 200 == 0:
-                    print('{:5s}|{:12s}'.format(
-                        'It.', 'Err') + '\n' + '-' * 19)
-                print('{:5d}|{:8e}|'.format(cpt, err))
+        else:
+            err = abs(curr_loss - prev_loss) / prev_loss if prev_loss != 0. else np.nan
+            if log:
+                log_['loss'].append(curr_loss)
+                log_['err'].append(err)
+
+        if verbose:
+            if cpt % 200 == 0:
+                print('{:5s}|{:12s}'.format(
+                    'It.', 'Err') + '\n' + '-' * 19)
+            print('{:5d}|{:8e}|'.format(cpt, err))
 
         cpt += 1
 
     if log:
-        return C, {"err": error}
+        return C, log_
     else:
         return C
 
@@ -838,8 +870,8 @@ def entropic_fused_gromov_wasserstein2(
 def entropic_fused_gromov_barycenters(
         N, Ys, Cs, ps=None, p=None, lambdas=None, loss_fun='square_loss',
         epsilon=0.1, symmetric=True, alpha=0.5, max_iter=1000, tol=1e-9,
-        warmstartT=False, verbose=False, log=False, init_C=None, init_Y=None,
-        random_state=None, **kwargs):
+        conv_criterion='barycenter', warmstartT=False, verbose=False,
+        log=False, init_C=None, init_Y=None, random_state=None, **kwargs):
     r"""
     Returns the Fused Gromov-Wasserstein barycenters of `S` measurable networks with node features :math:`(\mathbf{C}_s, \mathbf{Y}_s, \mathbf{p}_s)_{1 \leq s \leq S}`
     estimated using Fused Gromov-Wasserstein transports from Sinkhorn projections.
@@ -886,6 +918,10 @@ def entropic_fused_gromov_barycenters(
         Max number of iterations
     tol : float, optional
         Stop threshold on error (>0)
+    conv_criterion : str, optional. Default is 'barycenter'.
+        Convergence criterion taking values in ['barycenter', 'loss']. If set to 'barycenter'
+        uses absolute norm variations of estimated barycenters. Else if set to 'loss'
+        uses the relative variations of the loss.
     warmstartT: bool, optional
         Either to perform warmstart of transport plans in the successive
         fused gromov-wasserstein transport problems.
@@ -910,7 +946,11 @@ def entropic_fused_gromov_barycenters(
     C : array-like, shape (`N`, `N`)
         Similarity matrix in the barycenter space (permutated as Y's rows)
     log : dict
-        Log dictionary of error during iterations. Return only if `log=True` in parameters.
+        Only returned when log=True. It contains the keys:
+
+        - :math:`\mathbf{T}`: list of (`N`, `ns`) transport matrices
+        - :math:`(\mathbf{M}_s)_s`: all distance matrices between the feature of the barycenter and the other features :math:`(dist(\mathbf{X}, \mathbf{Y}_s))_s` shape (`N`, `ns`)
+        - values used in convergence evaluation.
 
     References
     ----------
@@ -925,6 +965,9 @@ def entropic_fused_gromov_barycenters(
     """
     if loss_fun not in ('square_loss', 'kl_loss'):
         raise ValueError(f"Unknown `loss_fun='{loss_fun}'`. Use one of: {'square_loss', 'kl_loss'}.")
+
+    if not conv_criterion in ['barycenter', 'loss']:
+        raise ValueError(f"Unknown `conv_criterion='{conv_criterion}'`. Use one of: {'barycenter', 'loss'}.")
 
     Cs = list_to_array(*Cs)
     Ys = list_to_array(*Ys)
@@ -967,31 +1010,50 @@ def entropic_fused_gromov_barycenters(
     Ms = [dist(Y, Ys[s]) for s in range(len(Ys))]
 
     cpt = 0
-    err = 1
+    err_feature = 1e15
+    err_structure = 1e15
+    err_rel_loss = 1e15
 
-    err_feature = 1
-    err_structure = 1
-
+    if conv_criterion == 'barycenter':
+        inner_log = False
+    else:
+        inner_log = True
+        curr_loss = 1e15
     if log:
         log_ = {}
-        log_['err_feature'] = []
-        log_['err_structure'] = []
-        log_['Ts_iter'] = []
+        if conv_criterion == 'barycenter':
+            log_['err_feature'] = []
+            log_['err_structure'] = []
+            log_['Ts_iter'] = []
+        else:
+            log_['loss'] = []
+            log_['err_rel_loss'] = []
 
-    while (err > tol) and (cpt < max_iter):
-        Cprev = C
-        Yprev = Y
+    while ((err_feature > tol or err_structure > tol or err_rel_loss > tol) and cpt < max_iter):
+        if conv_criterion == 'barycenter':
+            Cprev = C
+            Yprev = Y
+        else:
+            prev_loss = curr_loss
 
+        # get transport plans
         if warmstartT:
-            T = [entropic_fused_gromov_wasserstein(
+            res = [entropic_fused_gromov_wasserstein(
                 Ms[s], C, Cs[s], p, ps[s], loss_fun, epsilon, symmetric, alpha,
-                T[s], max_iter, 1e-4, verbose=verbose, log=False, **kwargs) for s in range(S)]
+                T[s], max_iter, 1e-4, verbose=verbose, log=inner_log, **kwargs) for s in range(S)]
 
         else:
-            T = [entropic_fused_gromov_wasserstein(
+            res = [entropic_fused_gromov_wasserstein(
                 Ms[s], C, Cs[s], p, ps[s], loss_fun, epsilon, symmetric, alpha,
-                None, max_iter, 1e-4, verbose=verbose, log=False, **kwargs) for s in range(S)]
+                None, max_iter, 1e-4, verbose=verbose, log=inner_log, **kwargs) for s in range(S)]
 
+        if conv_criterion == 'barycenter':
+            T = res
+        else:
+            T = [output[0] for output in res]
+            curr_loss = np.sum([output[1]['fgw_dist'] for output in res])
+
+        # update barycenters
         if loss_fun == 'square_loss':
             C = update_square_loss(p, lambdas, T, Cs, nx)
         elif loss_fun == 'kl_loss':
@@ -1001,9 +1063,8 @@ def entropic_fused_gromov_barycenters(
         Y = update_feature_matrix(lambdas, Ys_temp, T, p, nx).T
         Ms = [dist(Y, Ys[s]) for s in range(len(Ys))]
 
-        if cpt % 10 == 0:
-            # we can speed up the process by checking for the error only all
-            # the 10th iterations
+        # update convergence criterion
+        if conv_criterion == 'barycenter':
             err_feature = nx.norm(Y - nx.reshape(Yprev, (N, d)))
             err_structure = nx.norm(C - Cprev)
             if log:
@@ -1017,6 +1078,17 @@ def entropic_fused_gromov_barycenters(
                         'It.', 'Err') + '\n' + '-' * 19)
                 print('{:5d}|{:8e}|'.format(cpt, err_structure))
                 print('{:5d}|{:8e}|'.format(cpt, err_feature))
+        else:
+            err_rel_loss = abs(curr_loss - prev_loss) / prev_loss if prev_loss != 0. else np.nan
+            if log:
+                log_['loss'].append(curr_loss)
+                log_['err_rel_loss'].append(err_rel_loss)
+
+            if verbose:
+                if cpt % 200 == 0:
+                    print('{:5s}|{:12s}'.format(
+                        'It.', 'Err') + '\n' + '-' * 19)
+                print('{:5d}|{:8e}|'.format(cpt, err_rel_loss))
 
         cpt += 1
     if log:

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -770,7 +770,7 @@ def gromov_barycenters(
     conv_criterion : str, optional. Default is 'barycenter'.
         Convergence criterion taking values in ['barycenter', 'loss']. If set to 'barycenter'
         uses absolute norm variations of estimated barycenters. Else if set to 'loss'
-        uses the relative variations of the loss. 
+        uses the relative variations of the loss.
     warmstartT: bool, optional
         Either to perform warmstart of transport plans in the successive
         fused gromov-wasserstein transport problems.s
@@ -801,7 +801,7 @@ def gromov_barycenters(
         International Conference on Machine Learning (ICML). 2016.
 
     """
-    if not conv_criterion in ['barycenter', 'loss']:
+    if conv_criterion not in ['barycenter', 'loss']:
         raise ValueError(f"Unknown `conv_criterion='{conv_criterion}'`. Use one of: {'barycenter', 'loss'}.")
 
     Cs = list_to_array(*Cs)
@@ -962,7 +962,7 @@ def fgw_barycenters(
     conv_criterion : str, optional. Default is 'barycenter'.
         Convergence criterion taking values in ['barycenter', 'loss']. If set to 'barycenter'
         uses absolute norm variations of estimated barycenters. Else if set to 'loss'
-        uses the relative variations of the loss. 
+        uses the relative variations of the loss.
     warmstartT: bool, optional
         Either to perform warmstart of transport plans in the successive
         fused gromov-wasserstein transport problems.
@@ -1000,7 +1000,7 @@ def fgw_barycenters(
         "Optimal Transport for structured data with application on graphs"
         International Conference on Machine Learning (ICML). 2019.
     """
-    if not conv_criterion in ['barycenter', 'loss']:
+    if conv_criterion not in ['barycenter', 'loss']:
         raise ValueError(f"Unknown `conv_criterion='{conv_criterion}'`. Use one of: {'barycenter', 'loss'}.")
 
     Cs = list_to_array(*Cs)

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -1079,7 +1079,7 @@ def fgw_barycenters(
             log_['loss'] = []
             log_['err_rel_loss'] = []
 
-    while ((err_feature > tol or err_structure > tol) and err_rel_loss > tol and cpt < max_iter):
+    while ((err_feature > tol or err_structure > tol or err_rel_loss > tol) and cpt < max_iter):
         if conv_criterion == 'barycenter':
             Cprev = C
             Xprev = X

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -1055,15 +1055,20 @@ def fgw_barycenters(
         T = [None] * S
 
     cpt = 0
-    err_feature = 1e15
-    err_structure = 1e15
-    err_rel_loss = 1e15
 
     if conv_criterion == 'barycenter':
         inner_log = False
+        err_feature = 1e15
+        err_structure = 1e15
+        err_rel_loss = 0.
+
     else:
         inner_log = True
+        err_feature = 0.
+        err_structure = 0.
         curr_loss = 1e15
+        err_rel_loss = 1e15
+
     if log:
         log_ = {}
         if conv_criterion == 'barycenter':
@@ -1074,7 +1079,7 @@ def fgw_barycenters(
             log_['loss'] = []
             log_['err_rel_loss'] = []
 
-    while ((err_feature > tol or err_structure > tol or err_rel_loss > tol) and cpt < max_iter):
+    while ((err_feature > tol or err_structure > tol) and err_rel_loss > tol and cpt < max_iter):
         if conv_criterion == 'barycenter':
             Cprev = C
             Xprev = X

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -1118,8 +1118,11 @@ def fgw_barycenters(
 
         # update convergence criterion
         if conv_criterion == 'barycenter':
-            err_feature = nx.norm(X - nx.reshape(Xprev, (N, d)))
-            err_structure = nx.norm(C - Cprev)
+            err_feature, err_structure = 0., 0.
+            if not fixed_features:
+                err_feature = nx.norm(X - Xprev)
+            if not fixed_structure:
+                err_structure = nx.norm(C - Cprev)
             if log:
                 log_['err_feature'].append(err_feature)
                 log_['err_structure'].append(err_structure)
@@ -1129,8 +1132,8 @@ def fgw_barycenters(
                 if cpt % 200 == 0:
                     print('{:5s}|{:12s}'.format(
                         'It.', 'Err') + '\n' + '-' * 19)
-                    print('{:5d}|{:8e}|'.format(cpt, err_structure))
-                    print('{:5d}|{:8e}|'.format(cpt, err_feature))
+                print('{:5d}|{:8e}|'.format(cpt, err_structure))
+                print('{:5d}|{:8e}|'.format(cpt, err_feature))
         else:
             err_rel_loss = abs(curr_loss - prev_loss) / prev_loss if prev_loss != 0. else np.nan
             if log:

--- a/ot/gromov/_gw.py
+++ b/ot/gromov/_gw.py
@@ -1129,8 +1129,8 @@ def fgw_barycenters(
                 if cpt % 200 == 0:
                     print('{:5s}|{:12s}'.format(
                         'It.', 'Err') + '\n' + '-' * 19)
-                print('{:5d}|{:8e}|'.format(cpt, err_structure))
-                print('{:5d}|{:8e}|'.format(cpt, err_feature))
+                    print('{:5d}|{:8e}|'.format(cpt, err_structure))
+                    print('{:5d}|{:8e}|'.format(cpt, err_feature))
         else:
             err_rel_loss = abs(curr_loss - prev_loss) / prev_loss if prev_loss != 0. else np.nan
             if log:

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -839,25 +839,25 @@ def test_entropic_fgw_barycenter(nx):
             solver='PPA', numItermax=10, log=True, symmetric=True,
         )
     with pytest.raises(ValueError):
-        conv_criterion = 'unknown conv criterion'
+        stop_criterion = 'unknown stop criterion'
         X, C, log = ot.gromov.entropic_fused_gromov_barycenters(
             n_samples, [ys, yt], [C1, C2], None, p, [.5, .5], 'square_loss',
-            0.1, max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            0.1, max_iter=10, tol=1e-3, stop_criterion=stop_criterion,
             verbose=True, warmstartT=True, random_state=42,
             solver='PPA', numItermax=10, log=True, symmetric=True,
         )
 
-    for conv_criterion in ['barycenter', 'loss']:
+    for stop_criterion in ['barycenter', 'loss']:
         X, C, log = ot.gromov.entropic_fused_gromov_barycenters(
             n_samples, [ys, yt], [C1, C2], None, p, [.5, .5], 'square_loss',
-            epsilon=0.1, max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            epsilon=0.1, max_iter=10, tol=1e-3, stop_criterion=stop_criterion,
             verbose=True, warmstartT=True, random_state=42, solver='PPA',
             numItermax=10, log=True, symmetric=True
         )
         Xb, Cb = ot.gromov.entropic_fused_gromov_barycenters(
             n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], None, [.5, .5],
             'square_loss', epsilon=0.1, max_iter=10, tol=1e-3,
-            conv_criterion=conv_criterion, verbose=False, warmstartT=True,
+            stop_criterion=stop_criterion, verbose=False, warmstartT=True,
             random_state=42, solver='PPA', numItermax=10, log=False, symmetric=True)
         Xb, Cb = nx.to_numpy(Xb, Cb)
 
@@ -1054,22 +1054,22 @@ def test_gromov_barycenter(nx):
 
     C1b, C2b, p1b, p2b, pb = nx.from_numpy(C1, C2, p1, p2, p)
     with pytest.raises(ValueError):
-        conv_criterion = 'unknown conv criterion'
+        stop_criterion = 'unknown stop criterion'
         Cb = ot.gromov.gromov_barycenters(
             n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', max_iter=10,
-            tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            tol=1e-3, stop_criterion=stop_criterion, verbose=False,
             random_state=42
         )
 
-    for conv_criterion in ['barycenter', 'loss']:
+    for stop_criterion in ['barycenter', 'loss']:
         Cb = ot.gromov.gromov_barycenters(
             n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', max_iter=10,
-            tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            tol=1e-3, stop_criterion=stop_criterion, verbose=False,
             random_state=42
         )
         Cbb = nx.to_numpy(ot.gromov.gromov_barycenters(
             n_samples, [C1b, C2b], [p1b, p2b], None, [.5, .5], 'square_loss',
-            max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            max_iter=10, tol=1e-3, stop_criterion=stop_criterion,
             verbose=False, random_state=42
         ))
         np.testing.assert_allclose(Cb, Cbb, atol=1e-06)
@@ -1078,12 +1078,12 @@ def test_gromov_barycenter(nx):
         # test of gromov_barycenters with `log` on
         Cb_, err_ = ot.gromov.gromov_barycenters(
             n_samples, [C1, C2], [p1, p2], p, None, 'square_loss', max_iter=10,
-            tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            tol=1e-3, stop_criterion=stop_criterion, verbose=False,
             warmstartT=True, random_state=42, log=True
         )
         Cbb_, errb_ = ot.gromov.gromov_barycenters(
             n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5], 'square_loss',
-            max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            max_iter=10, tol=1e-3, stop_criterion=stop_criterion,
             verbose=False, warmstartT=True, random_state=42, log=True
         )
         Cbb_ = nx.to_numpy(Cbb_)
@@ -1149,10 +1149,10 @@ def test_gromov_entropic_barycenter(nx):
             max_iter=10, tol=1e-3, verbose=True, warmstartT=True, random_state=42
         )
     with pytest.raises(ValueError):
-        conv_criterion = 'unknown conv criterion'
+        stop_criterion = 'unknown stop criterion'
         Cb = ot.gromov.entropic_gromov_barycenters(
             n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', 1e-3,
-            max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            max_iter=10, tol=1e-3, stop_criterion=stop_criterion,
             verbose=True, warmstartT=True, random_state=42
         )
 
@@ -1168,15 +1168,15 @@ def test_gromov_entropic_barycenter(nx):
     np.testing.assert_allclose(Cbb.shape, (n_samples, n_samples))
 
     # test of entropic_gromov_barycenters with `log` on
-    for conv_criterion in ['barycenter', 'loss']:
+    for stop_criterion in ['barycenter', 'loss']:
         Cb_, err_ = ot.gromov.entropic_gromov_barycenters(
             n_samples, [C1, C2], [p1, p2], p, None, 'square_loss', 1e-3,
-            max_iter=10, tol=1e-3, conv_criterion=conv_criterion, verbose=True,
+            max_iter=10, tol=1e-3, stop_criterion=stop_criterion, verbose=True,
             random_state=42, log=True
         )
         Cbb_, errb_ = ot.gromov.entropic_gromov_barycenters(
             n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5], 'square_loss',
-            1e-3, max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            1e-3, max_iter=10, tol=1e-3, stop_criterion=stop_criterion,
             verbose=True, random_state=42, log=True
         )
         Cbb_ = nx.to_numpy(Cbb_)
@@ -1600,19 +1600,19 @@ def test_fgw_barycenter(nx):
 
     # add test with 'kl_loss'
     with pytest.raises(ValueError):
-        conv_criterion = 'unknown conv criterion'
+        stop_criterion = 'unknown stop criterion'
         X, C, log = ot.gromov.fgw_barycenters(
             n_samples, [ys, yt], [C1, C2], [p1, p2], [.5, .5], 0.5,
             fixed_structure=False, fixed_features=False, p=p, loss_fun='kl_loss',
-            max_iter=100, tol=1e-3, conv_criterion=conv_criterion, init_C=C,
+            max_iter=100, tol=1e-3, stop_criterion=stop_criterion, init_C=C,
             init_X=X, warmstartT=True, random_state=12345, log=True
         )
 
-    for conv_criterion in ['barycenter', 'loss']:
+    for stop_criterion in ['barycenter', 'loss']:
         X, C, log = ot.gromov.fgw_barycenters(
             n_samples, [ys, yt], [C1, C2], [p1, p2], [.5, .5], 0.5,
             fixed_structure=False, fixed_features=False, p=p, loss_fun='kl_loss',
-            max_iter=100, tol=1e-3, conv_criterion=conv_criterion, init_C=C,
+            max_iter=100, tol=1e-3, stop_criterion=stop_criterion, init_C=C,
             init_X=X, warmstartT=True, random_state=12345, log=True, verbose=True
         )
         np.testing.assert_allclose(C.shape, (n_samples, n_samples))

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -438,6 +438,7 @@ def test_entropic_gromov2(nx, loss_fun):
         q, Gb.sum(0), atol=1e-04)  # cf convergence gromov
 
 
+@pytest.skip_backend("tf", reason="test very slow with tf backend")
 def test_entropic_proximal_gromov(nx):
     n_samples = 10  # nb samples
 
@@ -463,14 +464,14 @@ def test_entropic_proximal_gromov(nx):
         loss_fun = 'weird_loss_fun'
         G, log = ot.gromov.entropic_gromov_wasserstein(
             C1, C2, None, q, loss_fun, symmetric=None, G0=G0,
-            epsilon=1e-1, max_iter=50, solver='PPA', verbose=True, log=True, numItermax=1)
+            epsilon=1e-1, max_iter=10, solver='PPA', verbose=True, log=True, numItermax=1)
 
     G, log = ot.gromov.entropic_gromov_wasserstein(
         C1, C2, None, q, 'square_loss', symmetric=None, G0=G0,
-        epsilon=1e-1, max_iter=50, solver='PPA', verbose=True, log=True, numItermax=1)
+        epsilon=1e-1, max_iter=10, solver='PPA', verbose=True, log=True, numItermax=1)
     Gb = nx.to_numpy(ot.gromov.entropic_gromov_wasserstein(
         C1b, C2b, pb, None, 'square_loss', symmetric=True, G0=None,
-        epsilon=1e-1, max_iter=50, solver='PPA', verbose=True, log=False, numItermax=1
+        epsilon=1e-1, max_iter=10, solver='PPA', verbose=True, log=False, numItermax=1
     ))
 
     # check constraints
@@ -478,7 +479,7 @@ def test_entropic_proximal_gromov(nx):
     np.testing.assert_allclose(
         p, Gb.sum(1), atol=1e-04)  # cf convergence gromov
     np.testing.assert_allclose(
-        q, Gb.sum(0), atol=1e-04)  # cf convergence gromov
+        q, Gb.sum(0), atol=1e-02)  # cf convergence gromov
 
     gw, log = ot.gromov.entropic_gromov_wasserstein2(
         C1, C2, p, q, 'kl_loss', symmetric=True, G0=None,
@@ -499,7 +500,7 @@ def test_entropic_proximal_gromov(nx):
     np.testing.assert_allclose(
         p, Gb.sum(1), atol=1e-04)  # cf convergence gromov
     np.testing.assert_allclose(
-        q, Gb.sum(0), atol=1e-04)  # cf convergence gromov
+        q, Gb.sum(0), atol=1e-02)  # cf convergence gromov
 
 
 @pytest.skip_backend("tf", reason="test very slow with tf backend")
@@ -836,22 +837,31 @@ def test_entropic_fgw_barycenter(nx):
             max_iter=10, tol=1e-3, verbose=True, warmstartT=True, random_state=42,
             solver='PPA', numItermax=10, log=True
         )
+    with pytest.raises(ValueError):
+        conv_criterion = 'unknown conv criterion'
+        X, C, log = ot.gromov.entropic_fused_gromov_barycenters(
+            n_samples, [ys, yt], [C1, C2], None, p, [.5, .5], 'square_loss',
+            0.1, max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            verbose=True, warmstartT=True, random_state=42,
+            solver='PPA', numItermax=10, log=True
+        )
 
-    X, C, log = ot.gromov.entropic_fused_gromov_barycenters(
-        n_samples, [ys, yt], [C1, C2], None, p, [.5, .5], 'square_loss', 0.1,
-        max_iter=10, tol=1e-3, verbose=True, warmstartT=True, random_state=42,
-        solver='PPA', numItermax=10, log=True
-    )
-    Xb, Cb = ot.gromov.entropic_fused_gromov_barycenters(
-        n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], None, [.5, .5], 'square_loss', 0.1,
-        max_iter=10, tol=1e-3, verbose=False, warmstartT=True, random_state=42,
-        solver='PPA', numItermax=10, log=False)
-    Xb, Cb = nx.to_numpy(Xb, Cb)
+    for conv_criterion in ['barycenter', 'loss']:
+        X, C, log = ot.gromov.entropic_fused_gromov_barycenters(
+            n_samples, [ys, yt], [C1, C2], None, p, [.5, .5], 'square_loss', 0.1,
+            max_iter=10, tol=1e-3, conv_criterion=conv_criterion, verbose=True,
+            warmstartT=True, random_state=42, solver='PPA', numItermax=10, log=True
+        )
+        Xb, Cb = ot.gromov.entropic_fused_gromov_barycenters(
+            n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], None, [.5, .5], 'square_loss', 0.1,
+            max_iter=10, tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            warmstartT=True, random_state=42, solver='PPA', numItermax=10, log=False)
+        Xb, Cb = nx.to_numpy(Xb, Cb)
 
-    np.testing.assert_allclose(C, Cb, atol=1e-06)
-    np.testing.assert_allclose(Cb.shape, (n_samples, n_samples))
-    np.testing.assert_allclose(X, Xb, atol=1e-06)
-    np.testing.assert_allclose(Xb.shape, (n_samples, ys.shape[1]))
+        np.testing.assert_allclose(C, Cb, atol=1e-06)
+        np.testing.assert_allclose(Cb.shape, (n_samples, n_samples))
+        np.testing.assert_allclose(X, Xb, atol=1e-06)
+        np.testing.assert_allclose(Xb.shape, (n_samples, ys.shape[1]))
 
     # test with 'kl_loss' and log=True
     # providing init_C, init_Y
@@ -995,39 +1005,51 @@ def test_gromov_barycenter(nx):
     p = ot.unif(n_samples)
 
     C1b, C2b, p1b, p2b, pb = nx.from_numpy(C1, C2, p1, p2, p)
+    with pytest.raises(ValueError):
+        conv_criterion = 'unknown conv criterion'
+        Cb = ot.gromov.gromov_barycenters(
+            n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', max_iter=10,
+            tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            random_state=42
+        )
 
-    Cb = ot.gromov.gromov_barycenters(
-        n_samples, [C1, C2], None, p, [.5, .5],
-        'square_loss', max_iter=100, tol=1e-3, verbose=False, random_state=42
-    )
-    Cbb = nx.to_numpy(ot.gromov.gromov_barycenters(
-        n_samples, [C1b, C2b], [p1b, p2b], None, [.5, .5],
-        'square_loss', max_iter=100, tol=1e-3, verbose=False, random_state=42
-    ))
-    np.testing.assert_allclose(Cb, Cbb, atol=1e-06)
-    np.testing.assert_allclose(Cbb.shape, (n_samples, n_samples))
+    for conv_criterion in ['barycenter', 'loss']:
+        Cb = ot.gromov.gromov_barycenters(
+            n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', max_iter=10,
+            tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            random_state=42
+        )
+        Cbb = nx.to_numpy(ot.gromov.gromov_barycenters(
+            n_samples, [C1b, C2b], [p1b, p2b], None, [.5, .5], 'square_loss',
+            max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            verbose=False, random_state=42
+        ))
+        np.testing.assert_allclose(Cb, Cbb, atol=1e-06)
+        np.testing.assert_allclose(Cbb.shape, (n_samples, n_samples))
 
-    # test of gromov_barycenters with `log` on
-    Cb_, err_ = ot.gromov.gromov_barycenters(
-        n_samples, [C1, C2], [p1, p2], p, None, 'square_loss', max_iter=100,
-        tol=1e-3, verbose=False, warmstartT=True, random_state=42, log=True
-    )
-    Cbb_, errb_ = ot.gromov.gromov_barycenters(
-        n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5], 'square_loss', max_iter=100,
-        tol=1e-3, verbose=False, warmstartT=True, random_state=42, log=True
-    )
-    Cbb_ = nx.to_numpy(Cbb_)
-    np.testing.assert_allclose(Cb_, Cbb_, atol=1e-06)
-    np.testing.assert_array_almost_equal(err_['err'], nx.to_numpy(*errb_['err']))
-    np.testing.assert_allclose(Cbb_.shape, (n_samples, n_samples))
+        # test of gromov_barycenters with `log` on
+        Cb_, err_ = ot.gromov.gromov_barycenters(
+            n_samples, [C1, C2], [p1, p2], p, None, 'square_loss', max_iter=10,
+            tol=1e-3, conv_criterion=conv_criterion, verbose=False,
+            warmstartT=True, random_state=42, log=True
+        )
+        Cbb_, errb_ = ot.gromov.gromov_barycenters(
+            n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5], 'square_loss',
+            max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            verbose=False, warmstartT=True, random_state=42, log=True
+        )
+        Cbb_ = nx.to_numpy(Cbb_)
+        np.testing.assert_allclose(Cb_, Cbb_, atol=1e-06)
+        np.testing.assert_array_almost_equal(err_['err'], nx.to_numpy(*errb_['err']))
+        np.testing.assert_allclose(Cbb_.shape, (n_samples, n_samples))
 
     Cb2 = ot.gromov.gromov_barycenters(
         n_samples, [C1, C2], [p1, p2], p, [.5, .5],
-        'kl_loss', max_iter=100, tol=1e-3, warmstartT=True, random_state=42
+        'kl_loss', max_iter=10, tol=1e-3, warmstartT=True, random_state=42
     )
     Cb2b = nx.to_numpy(ot.gromov.gromov_barycenters(
         n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5],
-        'kl_loss', max_iter=100, tol=1e-3, warmstartT=True, random_state=42
+        'kl_loss', max_iter=10, tol=1e-3, warmstartT=True, random_state=42
     ))
     np.testing.assert_allclose(Cb2, Cb2b, atol=1e-06)
     np.testing.assert_allclose(Cb2b.shape, (n_samples, n_samples))
@@ -1041,12 +1063,12 @@ def test_gromov_barycenter(nx):
     init_Cb = nx.from_numpy(init_C)
 
     Cb2_, err2_ = ot.gromov.gromov_barycenters(
-        n_samples, [C1, C2], [p1, p2], p, [.5, .5], 'kl_loss', max_iter=100,
+        n_samples, [C1, C2], [p1, p2], p, [.5, .5], 'kl_loss', max_iter=10,
         tol=1e-3, verbose=False, random_state=42, log=True, init_C=init_C
     )
     Cb2b_, err2b_ = ot.gromov.gromov_barycenters(
         n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5], 'kl_loss',
-        max_iter=100, tol=1e-3, verbose=True, random_state=42,
+        max_iter=10, tol=1e-3, verbose=True, random_state=42,
         init_C=init_Cb, log=True
     )
     Cb2b_ = nx.to_numpy(Cb2b_)
@@ -1078,6 +1100,13 @@ def test_gromov_entropic_barycenter(nx):
             n_samples, [C1, C2], None, p, [.5, .5], loss_fun, 1e-3,
             max_iter=10, tol=1e-3, verbose=True, warmstartT=True, random_state=42
         )
+    with pytest.raises(ValueError):
+        conv_criterion = 'unknown conv criterion'
+        Cb = ot.gromov.entropic_gromov_barycenters(
+            n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', 1e-3,
+            max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            verbose=True, warmstartT=True, random_state=42
+        )
 
     Cb = ot.gromov.entropic_gromov_barycenters(
         n_samples, [C1, C2], None, p, [.5, .5], 'square_loss', 1e-3,
@@ -1091,18 +1120,21 @@ def test_gromov_entropic_barycenter(nx):
     np.testing.assert_allclose(Cbb.shape, (n_samples, n_samples))
 
     # test of entropic_gromov_barycenters with `log` on
-    Cb_, err_ = ot.gromov.entropic_gromov_barycenters(
-        n_samples, [C1, C2], [p1, p2], p, None,
-        'square_loss', 1e-3, max_iter=10, tol=1e-3, verbose=True, random_state=42, log=True
-    )
-    Cbb_, errb_ = ot.gromov.entropic_gromov_barycenters(
-        n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5],
-        'square_loss', 1e-3, max_iter=10, tol=1e-3, verbose=True, random_state=42, log=True
-    )
-    Cbb_ = nx.to_numpy(Cbb_)
-    np.testing.assert_allclose(Cb_, Cbb_, atol=1e-06)
-    np.testing.assert_array_almost_equal(err_['err'], nx.to_numpy(*errb_['err']))
-    np.testing.assert_allclose(Cbb_.shape, (n_samples, n_samples))
+    for conv_criterion in ['barycenter', 'loss']:
+        Cb_, err_ = ot.gromov.entropic_gromov_barycenters(
+            n_samples, [C1, C2], [p1, p2], p, None, 'square_loss', 1e-3,
+            max_iter=10, tol=1e-3, conv_criterion=conv_criterion, verbose=True,
+            random_state=42, log=True
+        )
+        Cbb_, errb_ = ot.gromov.entropic_gromov_barycenters(
+            n_samples, [C1b, C2b], [p1b, p2b], pb, [.5, .5], 'square_loss',
+            1e-3, max_iter=10, tol=1e-3, conv_criterion=conv_criterion,
+            verbose=True, random_state=42, log=True
+        )
+        Cbb_ = nx.to_numpy(Cbb_)
+        np.testing.assert_allclose(Cb_, Cbb_, atol=1e-06)
+        np.testing.assert_array_almost_equal(err_['err'], nx.to_numpy(*errb_['err']))
+        np.testing.assert_allclose(Cbb_.shape, (n_samples, n_samples))
 
     Cb2 = ot.gromov.entropic_gromov_barycenters(
         n_samples, [C1, C2], [p1, p2], p, [.5, .5],
@@ -1220,8 +1252,12 @@ def test_asymmetric_fgw(nx):
     M = ot.dist(F1, F2)
     Mb, C1b, C2b, pb, qb, G0b = nx.from_numpy(M, C1, C2, p, q, G0)
 
-    G, log = ot.gromov.fused_gromov_wasserstein(M, C1, C2, p, q, 'square_loss', alpha=0.5, G0=G0, log=True, symmetric=False, verbose=True)
-    Gb, logb = ot.gromov.fused_gromov_wasserstein(Mb, C1b, C2b, pb, qb, 'square_loss', alpha=0.5, log=True, symmetric=None, G0=G0b, verbose=True)
+    G, log = ot.gromov.fused_gromov_wasserstein(
+        M, C1, C2, p, q, 'square_loss', alpha=0.5, G0=G0, log=True,
+        symmetric=False, verbose=True)
+    Gb, logb = ot.gromov.fused_gromov_wasserstein(
+        Mb, C1b, C2b, pb, qb, 'square_loss', alpha=0.5, log=True,
+        symmetric=None, G0=G0b, verbose=True)
     Gb = nx.to_numpy(Gb)
     # check constraints
     np.testing.assert_allclose(G, Gb, atol=1e-06)
@@ -1233,8 +1269,12 @@ def test_asymmetric_fgw(nx):
     np.testing.assert_allclose(log['fgw_dist'], 0., atol=1e-04)
     np.testing.assert_allclose(logb['fgw_dist'], 0., atol=1e-04)
 
-    fgw, log = ot.gromov.fused_gromov_wasserstein2(M, C1, C2, p, q, 'square_loss', alpha=0.5, G0=G0, log=True, symmetric=None, verbose=True)
-    fgwb, logb = ot.gromov.fused_gromov_wasserstein2(Mb, C1b, C2b, pb, qb, 'square_loss', alpha=0.5, log=True, symmetric=False, G0=G0b, verbose=True)
+    fgw, log = ot.gromov.fused_gromov_wasserstein2(
+        M, C1, C2, p, q, 'square_loss', alpha=0.5, G0=G0, log=True,
+        symmetric=None, verbose=True)
+    fgwb, logb = ot.gromov.fused_gromov_wasserstein2(
+        Mb, C1b, C2b, pb, qb, 'square_loss', alpha=0.5, log=True,
+        symmetric=False, G0=G0b, verbose=True)
 
     G = log['T']
     Gb = nx.to_numpy(logb['T'])
@@ -1250,8 +1290,12 @@ def test_asymmetric_fgw(nx):
 
     # Tests with kl-loss:
     for armijo in [False, True]:
-        G, log = ot.gromov.fused_gromov_wasserstein(M, C1, C2, p, q, 'kl_loss', alpha=0.5, armijo=armijo, G0=G0, log=True, symmetric=False, verbose=True)
-        Gb, logb = ot.gromov.fused_gromov_wasserstein(Mb, C1b, C2b, pb, qb, 'kl_loss', alpha=0.5, armijo=armijo, log=True, symmetric=None, G0=G0b, verbose=True)
+        G, log = ot.gromov.fused_gromov_wasserstein(
+            M, C1, C2, p, q, 'kl_loss', alpha=0.5, armijo=armijo, G0=G0,
+            log=True, symmetric=False, verbose=True)
+        Gb, logb = ot.gromov.fused_gromov_wasserstein(
+            Mb, C1b, C2b, pb, qb, 'kl_loss', alpha=0.5, armijo=armijo,
+            log=True, symmetric=None, G0=G0b, verbose=True)
         Gb = nx.to_numpy(Gb)
         # check constraints
         np.testing.assert_allclose(G, Gb, atol=1e-06)
@@ -1263,8 +1307,12 @@ def test_asymmetric_fgw(nx):
         np.testing.assert_allclose(log['fgw_dist'], 0., atol=1e-04)
         np.testing.assert_allclose(logb['fgw_dist'], 0., atol=1e-04)
 
-        fgw, log = ot.gromov.fused_gromov_wasserstein2(M, C1, C2, p, q, 'kl_loss', alpha=0.5, G0=G0, log=True, symmetric=None, verbose=True)
-        fgwb, logb = ot.gromov.fused_gromov_wasserstein2(Mb, C1b, C2b, pb, qb, 'kl_loss', alpha=0.5, log=True, symmetric=False, G0=G0b, verbose=True)
+        fgw, log = ot.gromov.fused_gromov_wasserstein2(
+            M, C1, C2, p, q, 'kl_loss', alpha=0.5, G0=G0, log=True,
+            symmetric=None, verbose=True)
+        fgwb, logb = ot.gromov.fused_gromov_wasserstein2(
+            Mb, C1b, C2b, pb, qb, 'kl_loss', alpha=0.5, log=True,
+            symmetric=False, G0=G0b, verbose=True)
 
         G = log['T']
         Gb = nx.to_numpy(logb['T'])
@@ -1297,8 +1345,12 @@ def test_fgw_integer_warnings(nx):
     M = ot.dist(F1, F2).astype(np.int32)
     Mb, C1b, C2b, pb, qb, G0b = nx.from_numpy(M, C1, C2, p, q, G0)
 
-    G, log = ot.gromov.fused_gromov_wasserstein(M, C1, C2, p, q, 'square_loss', alpha=0.5, G0=G0, log=True, symmetric=False, verbose=True)
-    Gb, logb = ot.gromov.fused_gromov_wasserstein(Mb, C1b, C2b, pb, qb, 'square_loss', alpha=0.5, log=True, symmetric=None, G0=G0b, verbose=True)
+    G, log = ot.gromov.fused_gromov_wasserstein(
+        M, C1, C2, p, q, 'square_loss', alpha=0.5, G0=G0, log=True,
+        symmetric=False, verbose=True)
+    Gb, logb = ot.gromov.fused_gromov_wasserstein(
+        Mb, C1b, C2b, pb, qb, 'square_loss', alpha=0.5, log=True,
+        symmetric=None, G0=G0b, verbose=True)
     Gb = nx.to_numpy(Gb)
     # check constraints
     np.testing.assert_allclose(G, Gb, atol=1e-06)
@@ -1446,7 +1498,7 @@ def test_fgw_barycenter(nx):
     Ysb = [ysb, ytb]
     Xb, Cb, logb = ot.gromov.fgw_barycenters(
         n_samples, Ysb, Csb, None, lambdas, 0.5, fixed_structure=False,
-        fixed_features=False, p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
+        fixed_features=False, p=pb, loss_fun='square_loss', max_iter=10, tol=1e-3,
         random_state=12345, log=True
     )
     # test correspondance with utils function
@@ -1465,13 +1517,13 @@ def test_fgw_barycenter(nx):
         Xb, Cb = ot.gromov.fgw_barycenters(
             n_samples, Ysb, Csb, ps=[p1b, p2b], lambdas=None,
             alpha=0.5, fixed_structure=True, init_C=None, fixed_features=False,
-            p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
+            p=None, loss_fun='square_loss', max_iter=10, tol=1e-3
         )
 
     Xb, Cb = ot.gromov.fgw_barycenters(
         n_samples, [ysb, ytb], [C1b, C2b], ps=[p1b, p2b], lambdas=None,
         alpha=0.5, fixed_structure=True, init_C=init_Cb, fixed_features=False,
-        p=None, loss_fun='square_loss', max_iter=100, tol=1e-3
+        p=None, loss_fun='square_loss', max_iter=10, tol=1e-3
     )
     Xb, Cb = nx.to_numpy(Xb), nx.to_numpy(Cb)
     np.testing.assert_allclose(Cb.shape, (n_samples, n_samples))
@@ -1484,13 +1536,13 @@ def test_fgw_barycenter(nx):
         Xb, Cb, logb = ot.gromov.fgw_barycenters(
             n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
             fixed_structure=False, fixed_features=True, init_X=None,
-            p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
+            p=pb, loss_fun='square_loss', max_iter=10, tol=1e-3,
             warmstartT=True, log=True, random_state=98765, verbose=True
         )
     Xb, Cb, logb = ot.gromov.fgw_barycenters(
         n_samples, [ysb, ytb], [C1b, C2b], [p1b, p2b], [.5, .5], 0.5,
         fixed_structure=False, fixed_features=True, init_X=init_Xb,
-        p=pb, loss_fun='square_loss', max_iter=100, tol=1e-3,
+        p=pb, loss_fun='square_loss', max_iter=10, tol=1e-3,
         warmstartT=True, log=True, random_state=98765, verbose=True
     )
 
@@ -1499,17 +1551,27 @@ def test_fgw_barycenter(nx):
     np.testing.assert_allclose(X.shape, (n_samples, ys.shape[1]))
 
     # add test with 'kl_loss'
-    X, C, log = ot.gromov.fgw_barycenters(
-        n_samples, [ys, yt], [C1, C2], [p1, p2], [.5, .5], 0.5,
-        fixed_structure=False, fixed_features=False, p=p, loss_fun='kl_loss',
-        max_iter=100, tol=1e-3, init_C=C, init_X=X, warmstartT=True,
-        random_state=12345, log=True
-    )
-    np.testing.assert_allclose(C.shape, (n_samples, n_samples))
-    np.testing.assert_allclose(X.shape, (n_samples, ys.shape[1]))
+    with pytest.raises(ValueError):
+        conv_criterion = 'unknown conv criterion'
+        X, C, log = ot.gromov.fgw_barycenters(
+            n_samples, [ys, yt], [C1, C2], [p1, p2], [.5, .5], 0.5,
+            fixed_structure=False, fixed_features=False, p=p, loss_fun='kl_loss',
+            max_iter=100, tol=1e-3, conv_criterion=conv_criterion, init_C=C,
+            init_X=X, warmstartT=True, random_state=12345, log=True
+        )
+
+    for conv_criterion in ['barycenter', 'loss']:
+        X, C, log = ot.gromov.fgw_barycenters(
+            n_samples, [ys, yt], [C1, C2], [p1, p2], [.5, .5], 0.5,
+            fixed_structure=False, fixed_features=False, p=p, loss_fun='kl_loss',
+            max_iter=100, tol=1e-3, conv_criterion=conv_criterion, init_C=C,
+            init_X=X, warmstartT=True, random_state=12345, log=True, verbose=True
+        )
+        np.testing.assert_allclose(C.shape, (n_samples, n_samples))
+        np.testing.assert_allclose(X.shape, (n_samples, ys.shape[1]))
 
     # test correspondance with utils function
-    recovered_C = ot.gromov.update_kl_loss(p, lambdas, log['Ts_iter'][-1], [C1, C2])
+    recovered_C = ot.gromov.update_kl_loss(p, lambdas, log['T'], [C1, C2])
     np.testing.assert_allclose(C, recovered_C)
 
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- add a new option to (un)regularized (f)gw barycenter solvers : `conv_criterion` taking values into `{"barycenter", "loss"}` so the user can choose convergence criterions either based on the absolute norm variations of the barycenter, or relative loss variations, respectively : The last criterion is most likely meaningful for most applications, plus suit to the ones used in inner (f)gw solvers based on conditional gradient. This feature is also added to the entropic (f)gw barycenter solvers and would come with an overhead of computing the loss at the last iteration of the inner entropic solvers. Whereas for CG inner functions, computing the barycenter loss is performed in O(#samples). 

- Trying to harmonise the behavior across all (f)gw barycenter solvers :
     - Some solvers were updating their convergence criterions at only few epochs to reduce the computational burden of computing norms over the barycenter, but it is really not convenient to analyse the convergence of these solvers.
     - Add `fixed_structure` and `fixed_features` to `entropic_fused_gromov_barycenter`, same than unregularized solver.

- Adapt and improve these functions documentation.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

- Previous tests are running. Additional tests to do.

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
