### PR TITLE
[MRG] Add implicit Sinkhorn gradients

### DIFF
--- a/ot/backend.py
+++ b/ot/backend.py
@@ -281,12 +281,12 @@ class Backend():
         """Define the gradients for the value val wrt the inputs """
         raise NotImplementedError()
 
-    def detach(self, a):
+    def detach(self, *arrays):
         """Detach the tensor from the computation graph"""
         if len(arrays) == 1:
-            return self._detach(arrays[0], type_as=type_as)
+            return self._detach(arrays[0])
         else:
-            return [self._detach(array, type_as=type_as) for array in arrays]
+            return [self._detach(array) for array in arrays]
 
     def _detach(self, a):
         """Detach the tensor from the computation graph"""

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -282,7 +282,9 @@ class Backend():
         raise NotImplementedError()
 
     def detach(self, *arrays):
-        """Detach the tensor from the computation graph"""
+        """Detach the tensors from the computation graph
+
+        See: https://pytorch.org/docs/stable/generated/torch.Tensor.detach.html"""
         if len(arrays) == 1:
             return self._detach(arrays[0])
         else:
@@ -1038,14 +1040,6 @@ class Backend():
         """
         raise NotImplementedError()
 
-    def detach(self, *args):
-        r"""
-        Detach tensors in arguments from the current graph.
-
-        See: https://pytorch.org/docs/stable/generated/torch.Tensor.detach.html
-        """
-        raise NotImplementedError()
-
     def matmul(self, a, b):
         r"""
         Matrix product of two arrays.
@@ -1406,11 +1400,6 @@ class NumpyBackend(Backend):
 
     def transpose(self, a, axes=None):
         return np.transpose(a, axes)
-
-    def detach(self, *args):
-        if len(args) == 1:
-            return args[0]
-        return args
 
     def matmul(self, a, b):
         return np.matmul(a, b)
@@ -1782,11 +1771,6 @@ class JaxBackend(Backend):
 
     def transpose(self, a, axes=None):
         return jnp.transpose(a, axes)
-
-    def detach(self, *args):
-        if len(args) == 1:
-            return jax.lax.stop_gradient((args[0],))[0]
-        return [jax.lax.stop_gradient((a,))[0] for a in args]
 
     def matmul(self, a, b):
         return jnp.matmul(a, b)
@@ -2277,11 +2261,6 @@ class TorchBackend(Backend):
             axes = tuple(range(a.ndim)[::-1])
         return a.permute(axes)
 
-    def detach(self, *args):
-        if len(args) == 1:
-            return args[0].detach()
-        return [a.detach() for a in args]
-
     def matmul(self, a, b):
         return torch.matmul(a, b)
 
@@ -2680,11 +2659,6 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def transpose(self, a, axes=None):
         return cp.transpose(a, axes)
-
-    def detach(self, *args):
-        if len(args) == 1:
-            return args[0]
-        return args
 
     def matmul(self, a, b):
         return cp.matmul(a, b)
@@ -3109,11 +3083,6 @@ class TensorflowBackend(Backend):
 
     def transpose(self, a, axes=None):
         return tf.transpose(a, perm=axes)
-
-    def detach(self, *args):
-        if len(args) == 1:
-            return tf.stop_gradient(args[0])
-        return [tf.stop_gradient(a) for a in args]
 
     def matmul(self, a, b):
         return tnp.matmul(a, b)

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -326,7 +326,7 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
                 if grad == 'implicit':  # set the gradient at convergence
 
                     value = nx.set_gradients(value, (M0, a0, b0),
-                                             (plan, potentials[0], potentials[1]))
+                                             (plan, reg * (potentials[0] - potentials[0].mean()), reg * (potentials[1] - potentials[1].mean())))
 
             elif reg_type.lower() == 'l2':
 

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -140,6 +140,16 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
         # or for original Sinkhorn paper formulation [2]
         res = ot.solve(M, a, b, reg=1.0, reg_type='entropy')
 
+        # Use implicit differentiation for memory saving
+        res = ot.solve(M, a, b, reg=1.0, grad='implicit') # M, a, b are torch tensors
+        res.value.backward() # only the value is differentiable
+
+    Note that by default the Sinkhorn solver uses automatic differentiation to
+    compute the gradients of the values and plan. This can be changed with the
+    `grad` parameter. The `implicit` mode computes the implicit gradients only
+    for the value and the other outputs are detached. This is useful for
+    memory saving when only the gradient of value is needed.
+
     - **Quadratic regularized OT [17]** (when ``reg!=None`` and ``reg_type="L2"``):
 
     .. math::
@@ -1023,6 +1033,16 @@ def solve_sample(X_a, X_b, a=None, b=None, metric='sqeuclidean', reg=None, reg_t
         res = ot.solve_sample(xa, xb, a, b, reg=1.0, lazy=True, batch_size=100)
         # lazy OT plan
         lazy_plan = res.lazy_plan
+
+        # Use implicit differentiation for memory saving
+        res = ot.solve_sample(xa, xb, a, b, reg=1.0, grad='implicit')
+        res.value.backward() # only the value is differentiable
+
+    Note that by default the Sinkhorn solver uses automatic differentiation to
+    compute the gradients of the values and plan. This can be changed with the
+    `grad` parameter. The `implicit` mode computes the implicit gradients only
+    for the value and the other outputs are detached. This is useful for
+    memory saving when only the gradient of value is needed.
 
     We also have a very efficient solver with compiled CPU/CUDA code using
     geomloss/PyKeOps that can be used with the following code:

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -29,7 +29,7 @@ lst_method_lazy = ['1d', 'gaussian', 'lowrank', 'factored', 'geomloss', 'geomlos
 
 def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
           unbalanced_type='KL', method=None, n_threads=1, max_iter=None, plan_init=None,
-          potentials_init=None, tol=None, verbose=False, grad='implicit'):
+          potentials_init=None, tol=None, verbose=False, grad='autodiff'):
     r"""Solve the discrete optimal transport problem and return :any:`OTResult` object
 
     The function solves the following general optimal transport problem
@@ -80,8 +80,11 @@ def solve(M, a=None, b=None, reg=None, reg_type="KL", unbalanced=None,
     verbose : bool, optional
         Print information in the solver, by default False
     grad : str, optional
-        Type of gradient computation, either 'implicit' or 'explicit' only for
-        inkhorn solver. By default 'implicit'.
+        Type of gradient computation, either or 'autodiff' or 'implicit'  used only for
+        Sinkhorn solver. By default 'autodiff' provides gradients wrt all
+        outputs (`plan, value, value_linear`) but with important memory cost.
+        'implicit' provides gradients only for `value` and and other outputs are
+        detached. This is useful for memory saving when only the value is needed.
 
     Returns
     -------
@@ -882,7 +885,7 @@ def solve_sample(X_a, X_b, a=None, b=None, metric='sqeuclidean', reg=None, reg_t
                  unbalanced=None,
                  unbalanced_type='KL', lazy=False, batch_size=None, method=None, n_threads=1, max_iter=None, plan_init=None, rank=100, scaling=0.95,
                  potentials_init=None, X_init=None, tol=None, verbose=False,
-                 grad='implicit'):
+                 grad='autodiff'):
     r"""Solve the discrete optimal transport problem using the samples in the source and target domains.
 
     The function solves the following general optimal transport problem
@@ -949,8 +952,11 @@ def solve_sample(X_a, X_b, a=None, b=None, metric='sqeuclidean', reg=None, reg_t
     verbose : bool, optional
         Print information in the solver, by default False
     grad : str, optional
-        Type of gradient computation, either 'implicit' or 'unroll' (only for
-        sinkhorn solver), by default 'implicit'.
+        Type of gradient computation, either or 'autodiff' or 'implicit'  used only for
+        Sinkhorn solver. By default 'autodiff' provides gradients wrt all
+        outputs (`plan, value, value_linear`) but with important memory cost.
+        'implicit' provides gradients only for `value` and and other outputs are
+        detached. This is useful for memory saving when only the value is needed.
 
     Returns
     -------

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -267,7 +267,13 @@ def test_empty_backend():
     with pytest.raises(NotImplementedError):
         nx.nan_to_num(M)
     with pytest.raises(NotImplementedError):
-        nx.detach(M)
+        nx.sign(M)
+    with pytest.raises(NotImplementedError):
+        nx.dtype_device(M)
+    with pytest.raises(NotImplementedError):
+        nx.assert_same_dtype_device(M, M)
+    with pytest.raises(NotImplementedError):
+        nx.eigh(M)
 
 
 def test_func_backends(nx):
@@ -658,10 +664,6 @@ def test_func_backends(nx):
         A = nx.transpose(Mb)
         lst_b.append(nx.to_numpy(A))
         lst_name.append("transpose")
-
-        A = nx.detach(Mb)
-        lst_b.append(nx.to_numpy(A))
-        lst_name.append("detach")
 
         A, B = nx.detach(Mb, Mb)
         lst_b.append(nx.to_numpy(A))

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -266,6 +266,8 @@ def test_empty_backend():
         nx.matmul(M, M.T)
     with pytest.raises(NotImplementedError):
         nx.nan_to_num(M)
+    with pytest.raises(NotImplementedError):
+        nx.detach(M)
 
 
 def test_func_backends(nx):
@@ -310,6 +312,11 @@ def test_func_backends(nx):
 
         lst_b.append(nx.to_numpy(A))
         lst_name.append('set_gradients')
+
+        A = nx.detach(Mb)
+        A, B = nx.detach(Mb, Mb)
+        lst_b.append(nx.to_numpy(A))
+        lst_name.append('detach')
 
         A = nx.zeros((10, 3))
         A = nx.zeros((10, 3), type_as=Mb)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -12,6 +12,7 @@ import sys
 
 import ot
 from ot.bregman import geomloss
+from ot.backend import torch
 
 lst_reg = [None, 1]
 lst_reg_type = ['KL', 'entropy', 'L2']
@@ -105,6 +106,47 @@ def test_solve(nx):
     # test not implemented reg_type and check raise
     with pytest.raises(NotImplementedError):
         sol0 = ot.solve(M, reg=1, reg_type='cryptic divergence')
+
+
+@pytest.mark.skipif(not torch, reason="torch no installed")
+def test_solve_implicit():
+
+    n_samples_s = 10
+    n_samples_t = 7
+    n_features = 2
+    rng = np.random.RandomState(0)
+
+    x = rng.randn(n_samples_s, n_features)
+    y = rng.randn(n_samples_t, n_features)
+    a = ot.utils.unif(n_samples_s)
+    b = ot.utils.unif(n_samples_t)
+    M = ot.dist(x, y)
+
+    a = torch.tensor(a, requires_grad=True)
+    b = torch.tensor(b, requires_grad=True)
+    M = torch.tensor(M, requires_grad=True)
+
+    sol0 = ot.solve(M, a, b, reg=1)
+    sol0.value.backward()
+
+    gM0 = M.grad.clone()
+    ga0 = a.grad.clone()
+    gb0 = b.grad.clone()
+
+    a = torch.tensor(a, requires_grad=True)
+    b = torch.tensor(b, requires_grad=True)
+    M = torch.tensor(M, requires_grad=True)
+
+    sol = ot.solve(M, a, b, reg=1, grad='unroll')
+    sol.value.backward()
+
+    gM = M.grad.clone()
+    ga = a.grad.clone()
+    gb = b.grad.clone()
+
+    assert torch.allclose(gM0, gM)
+    assert torch.allclose(ga0 - ga0.mean(), ga - ga.mean())
+    assert torch.allclose(gb0 - gb0.mean(), gb - gb.mean())
 
 
 @pytest.mark.parametrize("reg,reg_type,unbalanced,unbalanced_type", itertools.product(lst_reg, lst_reg_type, lst_unbalanced, lst_unbalanced_type))

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -126,7 +126,7 @@ def test_solve_implicit():
     b = torch.tensor(b, requires_grad=True)
     M = torch.tensor(M, requires_grad=True)
 
-    sol0 = ot.solve(M, a, b, reg=1)
+    sol0 = ot.solve(M, a, b, reg=10, grad='implicit')
     sol0.value.backward()
 
     gM0 = M.grad.clone()
@@ -137,13 +137,14 @@ def test_solve_implicit():
     b = torch.tensor(b, requires_grad=True)
     M = torch.tensor(M, requires_grad=True)
 
-    sol = ot.solve(M, a, b, reg=1, grad='unroll')
+    sol = ot.solve(M, a, b, reg=10, grad='autodiff')
     sol.value.backward()
 
     gM = M.grad.clone()
     ga = a.grad.clone()
     gb = b.grad.clone()
 
+    # Note, gradients aer invariant to change in constant so we center them
     assert torch.allclose(gM0, gM)
     assert torch.allclose(ga0 - ga0.mean(), ga - ga.mean())
     assert torch.allclose(gb0 - gb0.mean(), gb - gb.mean())


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
This PR aims at 
- [x] implementing the detach function in the backend to allow speedup on CPU/GPU in some solvers (which was already done in a previous PR but with limited doc).
- [x] Implement variants of Sinkhorn where computations are detached and gradients at convergence is returned instead

This PR should solve #565 and greatly limit memory for sinkhorn when computing gradienst wrt the value.

In order to use implicit diffeerntiation one needs to set the `grad` parameter in `ot.solve`and `ot.solve_sample`as such
```python
sol = ot.solve(M, a, b, reg=10, grad='implicit')
sol.value.backward()
# beware with  grad='implicit', sol.value_linear and sol.plan are not differentiable (not implemented yet).
```
On a simple example with pytorch arrays with required gradients, I has a 1000x gain in memory for solving the problem when a  large number of sinkhorn operations are needed.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
