### PR TITLE
[MRG] Temporary limit on jax version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pymanopt
 cvxopt
 scikit-learn
 torch
-jax
+jax<=0.4.24
 jaxlib
 tensorflow
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cvxopt
 scikit-learn
 torch
 jax<=0.4.24
-jaxlib
+jaxlib<=0.4.24
 tensorflow
 pytest
 torch_geometric


### PR DESCRIPTION
Limit the max version of jax to allow for old config because of pymanopt using deprecated version

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->



## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
