### PR TITLE
[CI] Remove redundant CIBW_BEFORE_BUILD

### DIFF
--- a/.github/workflows/build_wheels_weekly.yml
+++ b/.github/workflows/build_wheels_weekly.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - "master"
-      
+
 jobs:
   build_wheels:
     name: ${{ matrix.os }}
@@ -40,7 +40,6 @@ jobs:
     - name: Build wheels
       env:
         CIBW_SKIP: "pp*-win* pp*-macosx* cp2* pp* cp*musl* cp36* *i686" # remove pypy on mac and win (wrong version)
-        CIBW_BEFORE_BUILD: "pip install numpy cython"
         CIBW_ARCHS_LINUX: auto aarch64 # force aarch64 with QEMU
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
       run: |

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ aautopep8 :
 	autopep8 -air test ot examples --jobs -1
 	
 wheels :
-	CIBW_BEFORE_BUILD="pip install numpy cython" cibuildwheel --platform linux --output-dir dist
+	cibuildwheel --platform linux --output-dir dist
 
 dist : wheels
 	$(PYTHON) setup.py sdist


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

The build system should define all required build components and make them available at wheel build time. As this `pip` install step is not required, remove `CIBW_BEFORE_BUILD`.

From the `cibuildwheel` docs https://cibuildwheel.pypa.io/en/stable/options/#before-build

> If dependencies are required to build your wheel (for example if you include a header from a Python module), instead of using this command, we recommend adding requirements to a pyproject.toml file's build-system.requires array instead.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Follow up PR to PR #629 

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [N/A] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
