### PR TITLE
[CI] Use Python 3.12 as default for tests

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - 'master'    
+      - 'master'
   push:
     branches:
-      - 'master'  
+      - 'master'
   create:
     branches:
       - 'master'
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -49,14 +49,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'no pep8')"
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
-        pip install flake8 
+        pip install flake8
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -70,10 +70,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'no ci')"
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
@@ -94,7 +94,7 @@ jobs:
        max-parallel: 4
        matrix:
          os: [macos-latest, macos-13]
-         python-version: ["3.11"]
+         python-version: ["3.12"]
 
      steps:
      - uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
        run: |
          python -m pip install --upgrade pip setuptools
          pip install -r requirements_all.txt
-         pip install pytest 
+         pip install pytest
      - name: Run tests
        run: |
          python -m pytest --durations=20  -v test/ ot/ --color=yes
@@ -121,7 +121,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,8 +6,8 @@ pymanopt
 cvxopt
 scikit-learn
 torch
-jax
-jaxlib
+jax<=0.4.24
+jaxlib<=0.4.24
 tensorflow
 pytest
 torch_geometric

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,8 +6,8 @@ pymanopt @ git+https://github.com/pymanopt/pymanopt.git@master
 cvxopt
 scikit-learn
 torch
-jax
-jaxlib
+jax<=0.4.24
+jaxlib<=0.4.24
 tensorflow
 pytest
 torch_geometric

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2,7 +2,7 @@ numpy>=1.20
 scipy>=1.6
 matplotlib
 autograd
-https://github.com/pymanopt/pymanopt/archive/master.zip
+pymanopt @ git+https://github.com/pymanopt.git@master
 cvxopt
 scikit-learn
 torch

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,8 +6,8 @@ pymanopt
 cvxopt
 scikit-learn
 torch
-jax<=0.4.24
-jaxlib<=0.4.24
+jax
+jaxlib
 tensorflow
 pytest
 torch_geometric

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2,12 +2,12 @@ numpy>=1.20
 scipy>=1.6
 matplotlib
 autograd
-pymanopt
+https://github.com/pymanopt/pymanopt/archive/master.zip
 cvxopt
 scikit-learn
 torch
-jax<=0.4.24
-jaxlib<=0.4.24
+jax
+jaxlib
 tensorflow
 pytest
 torch_geometric

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2,7 +2,7 @@ numpy>=1.20
 scipy>=1.6
 matplotlib
 autograd
-pymanopt @ git+https://github.com/pymanopt.git@master
+pymanopt @ git+https://github.com/pymanopt/pymanopt.git@master
 cvxopt
 scikit-learn
 torch

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'backend-tf': ['tensorflow'],
         'backend-torch': ['torch'],
         'cvxopt': ['cvxopt'], # on it's own to prevent accidental GPL violations
-        'dr': ['scikit-learn', 'pymanopt', 'autograd'],
+        'dr': ['scikit-learn', 'https://github.com/pymanopt/pymanopt/archive/master.zip', 'autograd'],
         'gnn': ['torch', 'torch_geometric'],
         'all': optional_requirements
     },

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'backend-tf': ['tensorflow'],
         'backend-torch': ['torch'],
         'cvxopt': ['cvxopt'], # on it's own to prevent accidental GPL violations
-        'dr': ['scikit-learn', 'https://github.com/pymanopt/pymanopt/archive/master.zip', 'autograd'],
+        'dr': ['scikit-learn', 'pymanopt', 'autograd'],
         'gnn': ['torch', 'torch_geometric'],
         'all': optional_requirements
     },


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* Add Python 3.12 to the Linux test matrix.
* Use Python 3.12 as the default Python for all other CI tests.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [N/A] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
