### PR TITLE
[CI] Add x86 based macOS to testing

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -88,11 +88,12 @@ jobs:
       uses: codecov/codecov-action@v3
 
   macos:
-     runs-on: macos-latest
+     runs-on: ${{ matrix.os }}
      if: "!contains(github.event.head_commit.message, 'no ci')"
      strategy:
        max-parallel: 4
        matrix:
+         os: [macos-latest, macos-13]
          python-version: ["3.11"]
 
      steps:


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* Use the 'macos-latest' runs-on option which now defaults to 'macos-14' which are Apple silicon runners.
   - c.f. https://github.com/actions/runner-images/blob/d31241d2c8c646cd0ba18579836636e62c38f1c9/images/macos/macos-14-arm64-Readme.md
* Keep a 'macos-13' runner to continue to test x86 based macOS for the latest Python version.
   - c.f. https://github.com/actions/runner-images/blob/d31241d2c8c646cd0ba18579836636e62c38f1c9/images/macos/macos-13-Readme.md


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

x86 macOS should still be tested.

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [N/A] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
