### PR TITLE
[FIX] Default to using scipy v1.8.0+ API

### DIFF
--- a/ot/optim.py
+++ b/ot/optim.py
@@ -17,9 +17,10 @@ from .backend import get_backend
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     try:
-        from scipy.optimize import scalar_search_armijo
-    except ImportError:
         from scipy.optimize._linesearch import scalar_search_armijo
+    except ModuleNotFoundError:
+        # scipy<1.8.0
+        from scipy.optimize.linesearch import scalar_search_armijo
 
 # The corresponding scipy function does not work for matrices
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

As most users will be installing the latest `scipy` release when they install `POT`, default to using the `scipy` `v1.8.0+` API and catch the `ModuleNotFoundError` in the rare case in which `scipy` `v1.7.3` or older is required. (https://github.com/scipy/scipy/pull/14966 is in `scipy` `v1.8.0+`)

In all situations,import from the `scipy.optimize.{_}linesearch` API as the newest version of scipy that supports Python 3.7 is `v1.7.3` which does not support `from scipy.optimize import scalar_search_armijo`, just as scipy v1.14.0+ does not.

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Amends PR https://github.com/PythonOT/POT/pull/642

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

```console
$ docker run --rm -ti python:3.8 /bin/bash
root@62c4a7db4ec9:/# python -m pip --quiet install uv
root@62c4a7db4ec9:/# uv venv
Using Python 3.8.19 interpreter at: usr/local/bin/python3
Creating virtualenv at: .venv
root@62c4a7db4ec9:/# . .venv/bin/activate
(.venv) root@62c4a7db4ec9:/# uv pip install 'scipy==1.8.0'
Resolved 2 packages in 327ms
Prepared 2 packages in 1.10s
Installed 2 packages in 27ms
 + numpy==1.24.4
 + scipy==1.8.0
(.venv) root@62c4a7db4ec9:/# python -c 'from scipy.optimize._linesearch import scalar_search_armijo; print(scalar_search_armijo)'
<function scalar_search_armijo at 0x7536b52294c0>
(.venv) root@62c4a7db4ec9:/#
```

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
   - Codecov is giving 0% coverage to the diff, but that is only because the `ImportError` raising branch isn't ever being taken as the version of scipy to raise it is old.
- [N/A] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.
   - This doesn't' change the logic from PR https://github.com/PythonOT/POT/pull/642 so no need to update the release notes(?)

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
