### PR TITLE
[MRG] Only Minkowski metrics can be used for emd_1d

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,7 @@
 
 #### Closed issues
 - Fixed `ot.gaussian` ignoring weights when computing means (PR #649, Issue #648)
+- Fixed `ot.emd_1d` and `ot.emd2_1d` incorrectly allowing any metric (PR #670, Issue #669)
 
 ## 0.9.4
 *June 2024*

--- a/ot/lp/emd_wrap.pyx
+++ b/ot/lp/emd_wrap.pyx
@@ -141,10 +141,8 @@ def emd_1d_sorted(np.ndarray[double, ndim=1, mode="c"] u_weights,
     v : (nt,) ndarray, float64
         Target dirac locations (on the real line)
     metric: str, optional (default='sqeuclidean')
-        Metric to be used. Only strings listed in :func:`ot.dist` are accepted.
-        Due to implementation details, this function runs faster when
-        `'sqeuclidean'`, `'minkowski'`, `'cityblock'`,  or `'euclidean'` metrics
-        are used.
+        Metric to be used. Only works with either of the strings
+        `'sqeuclidean'`, `'minkowski'`, `'cityblock'`,  or `'euclidean'`.
     p: float, optional (default=1.0)
          The p-norm to apply for if metric='minkowski'
 
@@ -182,8 +180,9 @@ def emd_1d_sorted(np.ndarray[double, ndim=1, mode="c"] u_weights,
         elif metric == 'minkowski':
             m_ij = math.pow(math.fabs(u[i] - v[j]), p)
         else:
-            m_ij = dist(u[i].reshape((1, 1)), v[j].reshape((1, 1)),
-                        metric=metric)[0, 0]
+            raise ValueError("Solver for EMD in 1d only supports metrics " +
+                             "from the following list: " +
+                             "`['sqeuclidean', 'minkowski', 'cityblock', 'euclidean']`")
         if w_i < w_j or j == m - 1:
             cost += m_ij * w_i
             G[cur_idx] = w_i

--- a/ot/lp/solver_1d.py
+++ b/ot/lp/solver_1d.py
@@ -152,7 +152,7 @@ def emd_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
     - x_a and x_b are the samples
     - a and b are the sample weights
 
-    This implementation only supports metrics 
+    This implementation only supports metrics
     of the form :math:`d(x, y) = |x - y|^p`.
 
     Uses the algorithm detailed in [1]_
@@ -304,7 +304,7 @@ def emd2_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
     - x_a and x_b are the samples
     - a and b are the sample weights
 
-    This implementation only supports metrics 
+    This implementation only supports metrics
     of the form :math:`d(x, y) = |x - y|^p`.
 
     Uses the algorithm detailed in [1]_

--- a/ot/lp/solver_1d.py
+++ b/ot/lp/solver_1d.py
@@ -152,7 +152,8 @@ def emd_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
     - x_a and x_b are the samples
     - a and b are the sample weights
 
-    When 'minkowski' is used as a metric, :math:`d(x, y) = |x - y|^p`.
+    This implementation only supports metrics 
+    of the form :math:`d(x, y) = |x - y|^p`.
 
     Uses the algorithm detailed in [1]_
 
@@ -167,9 +168,8 @@ def emd_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
     b : (nt,) ndarray, float64, optional
         Target histogram (default is uniform weight)
     metric: str, optional (default='sqeuclidean')
-        Metric to be used. Only strings listed in :func:`ot.dist` are accepted.
-        Due to implementation details, this function runs faster when
-        `'sqeuclidean'`, `'cityblock'`,  or `'euclidean'` metrics are used.
+        Metric to be used. Only works with either of the strings
+        `'sqeuclidean'`, `'minkowski'`, `'cityblock'`,  or `'euclidean'`.
     p: float, optional (default=1.0)
          The p-norm to apply for if metric='minkowski'
     dense: boolean, optional (default=True)
@@ -234,6 +234,10 @@ def emd_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
         "emd_1d should only be used with monodimensional data"
     assert (x_b.ndim == 1 or x_b.ndim == 2 and x_b.shape[1] == 1), \
         "emd_1d should only be used with monodimensional data"
+    assert metric in ['sqeuclidean', 'minkowski', 'cityblock', 'euclidean'], \
+        "Solver for EMD in 1d only supports metrics " + \
+        "from the following list: " + \
+        "`['sqeuclidean', 'minkowski', 'cityblock', 'euclidean']`"
 
     # if empty array given then use uniform distributions
     if a is None or a.ndim == 0 or len(a) == 0:
@@ -300,7 +304,8 @@ def emd2_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
     - x_a and x_b are the samples
     - a and b are the sample weights
 
-    When 'minkowski' is used as a metric, :math:`d(x, y) = |x - y|^p`.
+    This implementation only supports metrics 
+    of the form :math:`d(x, y) = |x - y|^p`.
 
     Uses the algorithm detailed in [1]_
 
@@ -315,10 +320,8 @@ def emd2_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
     b : (nt,) ndarray, float64, optional
         Target histogram (default is uniform weight)
     metric: str, optional (default='sqeuclidean')
-        Metric to be used. Only strings listed in :func:`ot.dist` are accepted.
-        Due to implementation details, this function runs faster when
-        `'sqeuclidean'`, `'minkowski'`, `'cityblock'`,  or `'euclidean'` metrics
-        are used.
+        Metric to be used. Only works with either of the strings
+        `'sqeuclidean'`, `'minkowski'`, `'cityblock'`,  or `'euclidean'`.
     p: float, optional (default=1.0)
          The p-norm to apply for if metric='minkowski'
     dense: boolean, optional (default=True)

--- a/ot/lp/solver_1d.py
+++ b/ot/lp/solver_1d.py
@@ -234,10 +234,12 @@ def emd_1d(x_a, x_b, a=None, b=None, metric='sqeuclidean', p=1., dense=True,
         "emd_1d should only be used with monodimensional data"
     assert (x_b.ndim == 1 or x_b.ndim == 2 and x_b.shape[1] == 1), \
         "emd_1d should only be used with monodimensional data"
-    assert metric in ['sqeuclidean', 'minkowski', 'cityblock', 'euclidean'], \
-        "Solver for EMD in 1d only supports metrics " + \
-        "from the following list: " + \
-        "`['sqeuclidean', 'minkowski', 'cityblock', 'euclidean']`"
+    if metric not in ['sqeuclidean', 'minkowski', 'cityblock', 'euclidean']:
+        raise ValueError(
+            "Solver for EMD in 1d only supports metrics " +
+            "from the following list: " +
+            "`['sqeuclidean', 'minkowski', 'cityblock', 'euclidean']`"
+        )
 
     # if empty array given then use uniform distributions
     if a is None or a.ndim == 0 or len(a) == 0:

--- a/test/test_1d_solver.py
+++ b/test/test_1d_solver.py
@@ -50,6 +50,12 @@ def test_emd_1d_emd2_1d_with_weights():
     np.testing.assert_allclose(w_u, G.sum(1))
     np.testing.assert_allclose(w_v, G.sum(0))
 
+    # check that an error is raised if the metric is not a Minkowski one
+    np.testing.assert_raises(ValueError, ot.emd_1d,
+                             u, v, w_u, w_v, metric='cosine')
+    np.testing.assert_raises(ValueError, ot.emd2_1d,
+                             u, v, w_u, w_v, metric='cosine')
+
 
 def test_wasserstein_1d(nx):
     rng = np.random.RandomState(0)


### PR DESCRIPTION
## Types of changes

The point here is to prevent anyone from using the `emd_1d` and `emd2_1d` functions with metrics that are not Minkowski ones, since this implementation is valid only in this case.

As such, I have left the opportunity to use `'sqeuclidean'`, `'minkowski'`, `'cityblock'`,  or `'euclidean'` as metrics. Another option would be to remove the `metrics` keyword and only specify `p`, but that would break backward compatibility, so I assumed this change was better for maintenance purposes. Let me know if this should be changed.



## Motivation and context / Related issue

This PR aims at solving issue #669.



## How has this been tested (if it applies)

Not tested yet.



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
