### PR TITLE
[FIX] numerical errors in ot.gmm

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,6 +54,7 @@ The contributors to this library are:
 * [Sonia Mazelet](https://github.com/SoniaMaz8) (Template based GNN layers)
 * [Laurène David](https://github.com/laudavid) (Low rank sinkhorn, Low rank Gromov-Wasserstein samples)
 * [Julie Delon](https://judelo.github.io/) (GMM OT)
+* [Samuel Boïté](https://samuelbx.github.io/) (GMM OT)
 
 ## Acknowledgments
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 # Releases
 
+## 0.9.6dev
+
+
 ## 0.9.5
 
 *November 2024*

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 
 #### Closed issues
 - Fixed `ot.mapping` solvers which depended on deprecated `cvxpy` `ECOS` solver (PR #692, Issue #668)
+- Fixed numerical errors in `ot.gmm` (PR #690, Issue #689)
 
 
 ## 0.9.5

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -74,7 +74,7 @@ from .lowrank import lowrank_sinkhorn
 # utils functions
 from .utils import dist, unif, tic, toc, toq
 
-__version__ = "0.9.5"
+__version__ = "0.9.6dev0"
 
 __all__ = [
     "emd",

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1072,7 +1072,7 @@ class Backend:
         See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.det.html
         """
         raise NotImplementedError()
-    
+
     def slogdet(self, a):
         r"""
         Compute the sign and (natural) logarithm of the determinant of an array.
@@ -1080,7 +1080,7 @@ class Backend:
         See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.slogdet.html
         """
         raise NotImplementedError()
-    
+
     def cholesky(self, a):
         r"""
         Cholesky decomposition.
@@ -1448,10 +1448,10 @@ class NumpyBackend(Backend):
 
     def det(self, a):
         return np.linalg.det(a)
-    
+
     def slogdet(self, a):
         return np.linalg.slogdet(a)
-    
+
     def cholesky(self, x):
         return np.linalg.cholesky(x)
 
@@ -1847,10 +1847,10 @@ class JaxBackend(Backend):
 
     def det(self, x):
         return jnp.linalg.det(x)
-    
+
     def slogdet(self, a):
         return jnp.linalg.slogdet(a)
-    
+
     def cholesky(self, x):
         return jnp.linalg.cholesky(x)
 
@@ -2386,10 +2386,10 @@ class TorchBackend(Backend):
 
     def det(self, x):
         return torch.linalg.det(x)
-    
+
     def slogdet(self, a):
         return torch.linalg.slogdet(a)
-    
+
     def cholesky(self, x):
         return torch.linalg.cholesky(x)
 
@@ -2800,10 +2800,10 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def det(self, x):
         return cp.linalg.det(x)
-    
+
     def slogdet(self, a):
         return cp.linalg.slogdet(a)
-    
+
     def cholesky(self, x):
         return cp.linalg.cholesky(x)
 
@@ -3244,10 +3244,10 @@ class TensorflowBackend(Backend):
 
     def det(self, x):
         return tf.linalg.det(x)
-    
+
     def slogdet(self, a):
         return tf.linalg.slogdet(a)
-    
+
     def cholesky(self, x):
         return tf.linalg.cholesky(x)
 

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -2330,7 +2330,7 @@ class TorchBackend(Backend):
 
     def sqrtm(self, a):
         L, V = torch.linalg.eigh(a)
-        L = torch.sqrt(torch.maximum(L, torch.tensor(0)))
+        L = torch.sqrt(L)
         # Q[...] = V[...] @ diag(L[...])
         Q = torch.einsum("...jk,...k->...jk", V, L)
         # R[...] = Q[...] @ V[...].T

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1072,6 +1072,22 @@ class Backend:
         See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.det.html
         """
         raise NotImplementedError()
+    
+    def slogdet(self, a):
+        r"""
+        Compute the sign and (natural) logarithm of the determinant of an array.
+
+        See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.slogdet.html
+        """
+        raise NotImplementedError()
+    
+    def cholesky(self, a):
+        r"""
+        Cholesky decomposition.
+
+        See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.cholesky.html
+        """
+        raise NotImplementedError()
 
 
 class NumpyBackend(Backend):
@@ -1432,6 +1448,12 @@ class NumpyBackend(Backend):
 
     def det(self, a):
         return np.linalg.det(a)
+    
+    def slogdet(self, a):
+        return np.linalg.slogdet(a)
+    
+    def cholesky(self, x):
+        return np.linalg.cholesky(x)
 
 
 _register_backend_implementation(NumpyBackend)
@@ -1825,6 +1847,12 @@ class JaxBackend(Backend):
 
     def det(self, x):
         return jnp.linalg.det(x)
+    
+    def slogdet(self, a):
+        return jnp.linalg.slogdet(a)
+    
+    def cholesky(self, x):
+        return jnp.linalg.cholesky(x)
 
 
 if jax:
@@ -2302,7 +2330,7 @@ class TorchBackend(Backend):
 
     def sqrtm(self, a):
         L, V = torch.linalg.eigh(a)
-        L = torch.sqrt(L)
+        L = torch.sqrt(torch.maximum(L, torch.tensor(0)))
         # Q[...] = V[...] @ diag(L[...])
         Q = torch.einsum("...jk,...k->...jk", V, L)
         # R[...] = Q[...] @ V[...].T
@@ -2358,6 +2386,12 @@ class TorchBackend(Backend):
 
     def det(self, x):
         return torch.linalg.det(x)
+    
+    def slogdet(self, a):
+        return torch.linalg.slogdet(a)
+    
+    def cholesky(self, x):
+        return torch.linalg.cholesky(x)
 
 
 if torch:
@@ -2766,6 +2800,12 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def det(self, x):
         return cp.linalg.det(x)
+    
+    def slogdet(self, a):
+        return cp.linalg.slogdet(a)
+    
+    def cholesky(self, x):
+        return cp.linalg.cholesky(x)
 
 
 if cp:
@@ -3204,6 +3244,12 @@ class TensorflowBackend(Backend):
 
     def det(self, x):
         return tf.linalg.det(x)
+    
+    def slogdet(self, a):
+        return tf.linalg.slogdet(a)
+    
+    def cholesky(self, x):
+        return tf.linalg.cholesky(x)
 
 
 if tf:

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1081,14 +1081,6 @@ class Backend:
         """
         raise NotImplementedError()
 
-    def cholesky(self, a):
-        r"""
-        Cholesky decomposition.
-
-        See: https://numpy.org/doc/stable/reference/generated/numpy.linalg.cholesky.html
-        """
-        raise NotImplementedError()
-
 
 class NumpyBackend(Backend):
     """
@@ -1451,9 +1443,6 @@ class NumpyBackend(Backend):
 
     def slogdet(self, a):
         return np.linalg.slogdet(a)
-
-    def cholesky(self, x):
-        return np.linalg.cholesky(x)
 
 
 _register_backend_implementation(NumpyBackend)
@@ -1850,9 +1839,6 @@ class JaxBackend(Backend):
 
     def slogdet(self, a):
         return jnp.linalg.slogdet(a)
-
-    def cholesky(self, x):
-        return jnp.linalg.cholesky(x)
 
 
 if jax:
@@ -2390,9 +2376,6 @@ class TorchBackend(Backend):
     def slogdet(self, a):
         return torch.linalg.slogdet(a)
 
-    def cholesky(self, x):
-        return torch.linalg.cholesky(x)
-
 
 if torch:
     # Only register torch backend if it is installed
@@ -2803,9 +2786,6 @@ class CupyBackend(Backend):  # pragma: no cover
 
     def slogdet(self, a):
         return cp.linalg.slogdet(a)
-
-    def cholesky(self, x):
-        return cp.linalg.cholesky(x)
 
 
 if cp:
@@ -3247,9 +3227,6 @@ class TensorflowBackend(Backend):
 
     def slogdet(self, a):
         return tf.linalg.slogdet(a)
-
-    def cholesky(self, x):
-        return tf.linalg.cholesky(x)
 
 
 if tf:

--- a/ot/gmm.py
+++ b/ot/gmm.py
@@ -15,6 +15,7 @@ import numpy as np
 from .lp import dist
 from .gaussian import bures_wasserstein_mapping
 
+
 def gaussian_logpdf(x, m, C):
     r"""
     Compute the log of the probability density function of a multivariate
@@ -43,8 +44,9 @@ def gaussian_logpdf(x, m, C):
     diff = x - m
     inv_C = nx.inv(C)
     z = nx.sum(diff * (diff @ inv_C), axis=-1)
-    _, log_det_C = nx.slogdet(C) # TODO: C should be positive definite
+    _, log_det_C = nx.slogdet(C)
     return -0.5 * (d * np.log(2 * np.pi) + log_det_C + z)
+
 
 def gaussian_pdf(x, m, C):
     r"""
@@ -67,6 +69,7 @@ def gaussian_pdf(x, m, C):
 
     """
     return get_backend(x, m, C).exp(gaussian_logpdf(x, m, C))
+
 
 def gmm_pdf(x, m, C, w):
     r"""
@@ -304,7 +307,9 @@ def gmm_ot_apply_map(
 
     if method == "bary":
         out = nx.zeros(x.shape)
-        logpdf = [gaussian_logpdf(x, m_s[k], C_s[k])[:, None] for k in range(m_s.shape[0])]
+        logpdf = [
+            gaussian_logpdf(x, m_s[k], C_s[k])[:, None] for k in range(m_s.shape[0])
+        ]
         print("where plan > 0", nx.where(plan > 0))
 
         # only need to compute for non-zero plan entries
@@ -322,7 +327,7 @@ def gmm_ot_apply_map(
             denom = nx.zeros(T_ij_x.shape)
             for k in range(w_s.shape[0]):
                 denom = denom + w_s[k] * nx.exp(logpdf[k] - logpdf[i])
-            
+
             out = out + plan[i, j] * T_ij_x / denom
 
         return out
@@ -344,7 +349,9 @@ def gmm_ot_apply_map(
             A[i, j] = Cs12inv @ M0 @ Cs12inv
             b[i, j] = m_t[j] - A[i, j] @ m_s[i]
 
-        logpdf = nx.stack([gaussian_logpdf(x, m_s[k], C_s[k]) for k in range(k_s)], axis=-1)
+        logpdf = nx.stack(
+            [gaussian_logpdf(x, m_s[k], C_s[k]) for k in range(k_s)], axis=-1
+        )
         # (n_samples, k_s)
         out = nx.zeros(x.shape)
 

--- a/ot/gmm.py
+++ b/ot/gmm.py
@@ -15,10 +15,9 @@ import numpy as np
 from .lp import dist
 from .gaussian import bures_wasserstein_mapping
 
-
-def gaussian_pdf(x, m, C):
+def gaussian_logpdf(x, m, C):
     r"""
-    Compute the probability density function of a multivariate
+    Compute the log of the probability density function of a multivariate
     Gaussian distribution.
 
     Parameters
@@ -40,11 +39,34 @@ def gaussian_pdf(x, m, C):
         x.shape[-1] == m.shape[-1] == C.shape[-1] == C.shape[-2]
     ), "Dimension mismatch"
     nx = get_backend(x, m, C)
-    d = x.shape[-1]
-    z = (2 * np.pi) ** (-d / 2) * nx.det(C) ** (-0.5)
-    exp = nx.exp(-0.5 * nx.sum(((x - m) @ nx.inv(C)) * (x - m), axis=-1))
-    return z * exp
+    d = m.shape[0]
+    diff = x - m
+    inv_C = nx.inv(C)
+    z = nx.sum(diff * (diff @ inv_C), axis=-1)
+    _, log_det_C = nx.slogdet(C) # TODO: C should be positive definite
+    return -0.5 * (d * np.log(2 * np.pi) + log_det_C + z)
 
+def gaussian_pdf(x, m, C):
+    r"""
+    Compute the probability density function of a multivariate
+    Gaussian distribution.
+
+    Parameters
+    ----------
+    x : array-like, shape (..., d)
+        The input samples.
+    m : array-like, shape (d,)
+        The mean vector of the Gaussian distribution.
+    C : array-like, shape (d, d)
+        The covariance matrix of the Gaussian distribution.
+
+    Returns
+    -------
+    pdf : array-like, shape (...,)
+        The probability density function evaluated at each sample.
+
+    """
+    return get_backend(x, m, C).exp(gaussian_logpdf(x, m, C))
 
 def gmm_pdf(x, m, C, w):
     r"""
@@ -281,15 +303,14 @@ def gmm_ot_apply_map(
     n_samples = x.shape[0]
 
     if method == "bary":
-        normalization = gmm_pdf(x, m_s, C_s, w_s)[:, None]
         out = nx.zeros(x.shape)
+        logpdf = [gaussian_logpdf(x, m_s[k], C_s[k])[:, None] for k in range(m_s.shape[0])]
         print("where plan > 0", nx.where(plan > 0))
 
         # only need to compute for non-zero plan entries
         for i, j in zip(*nx.where(plan > 0)):
             Cs12 = nx.sqrtm(C_s[i])
             Cs12inv = nx.inv(Cs12)
-            g = gaussian_pdf(x, m_s[i], C_s[i])[:, None]
 
             M0 = nx.sqrtm(Cs12 @ C_t[j] @ Cs12)
             A = Cs12inv @ M0 @ Cs12inv
@@ -297,9 +318,14 @@ def gmm_ot_apply_map(
 
             # gaussian mapping between components i and j applied to x
             T_ij_x = x @ A + b
-            out = out + plan[i, j] * g * T_ij_x
 
-        return out / normalization
+            denom = nx.zeros(T_ij_x.shape)
+            for k in range(w_s.shape[0]):
+                denom = denom + w_s[k] * nx.exp(logpdf[k] - logpdf[i])
+            
+            out = out + plan[i, j] * T_ij_x / denom
+
+        return out
 
     else:  # rand
         # A[i, j] is the linear part of the gaussian mapping between components
@@ -318,13 +344,17 @@ def gmm_ot_apply_map(
             A[i, j] = Cs12inv @ M0 @ Cs12inv
             b[i, j] = m_t[j] - A[i, j] @ m_s[i]
 
-        normalization = gmm_pdf(x, m_s, C_s, w_s)  # (n_samples,)
-        gs = np.stack([gaussian_pdf(x, m_s[i], C_s[i]) for i in range(k_s)], axis=-1)
+        logpdf = nx.stack([gaussian_logpdf(x, m_s[k], C_s[k]) for k in range(k_s)], axis=-1)
         # (n_samples, k_s)
         out = nx.zeros(x.shape)
 
         for i_sample in range(n_samples):
-            p_mat = plan * gs[i_sample][:, None] / normalization[i_sample]
+            log_g = logpdf[i_sample]
+            denom = nx.zeros(plan.shape)
+            for k in range(k_s):
+                denom[k, :] = nx.sum(w_s * nx.exp(log_g - log_g[k]), axis=0)
+            p_mat = plan / denom
+
             p = p_mat.reshape(k_s * k_t)  # stack line-by-line
             # sample between 0 and k_s * k_t - 1
             ij_mat = rng.choice(k_s * k_t, p=p)

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -271,6 +271,8 @@ def test_empty_backend():
         nx.eigh(M)
     with pytest.raises(NotImplementedError):
         nx.det(M)
+    with pytest.raises(NotImplementedError):
+        nx.slogdet(M)
 
 
 def test_func_backends(nx):
@@ -690,6 +692,11 @@ def test_func_backends(nx):
         d = nx.det(M1b)
         lst_b.append(nx.to_numpy(d))
         lst_name.append("det")
+
+        s, logabsd = nx.slogdet(M1b)
+        s, logabsd = nx.to_numpy(s), nx.to_numpy(logabsd)
+        lst_b.append(np.array([s, logabsd]))
+        lst_name.append("slogdet")
 
         assert not nx.array_equal(Mb, vb), "array_equal (shape)"
         assert nx.array_equal(Mb, Mb), "array_equal (elements) - expected true"


### PR DESCRIPTION
## Motivation and context / Related issue
This PR fixes numerical instability issues in `ot.gmm` in the `gaussian_pdf`and `gmm_ot_apply_map` methods, arising when handling high-dimensional Gaussians (see #689).

### Key changes
- [x] added `slogdet` (computing the log determinant of a matrix) to the backend
- [x] added a `ot.gmm.gaussian_logpdf` function to compute log density using `slogdet`
- [x] replaced fractions of densities in `gmm_ot_apply_map` by exp of difference of log densities

## How has this been tested (if it applies)
- [x] existing GMM examples produce identical results
- [x] linux-minimal-deps tests OK

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
