### PR TITLE
[MRG] no longer impose ECOS solver for SSNB, use new CVXPY default (Clarabel)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## 0.9.6dev
 
+#### Closed issues
+- Fixed `ot.mapping` solvers which depended on deprecated `cvxpy` `ECOS` solver
+  (PR #692, Issue #668)
+
 
 ## 0.9.5
 

--- a/ot/mapping.py
+++ b/ot/mapping.py
@@ -173,7 +173,7 @@ def nearest_brenier_potential_fit(
                         - c3 * (G[j] - G[i]).T @ (X[j] - X[i])
                     ]
         problem = cvx.Problem(objective, constraints)
-        problem.solve(solver=cvx.ECOS)
+        problem.solve()
         phi_val, G_val = phi.value, G.value
         it_log_dict = {
             "solve_time": problem.solver_stats.solve_time,
@@ -368,7 +368,7 @@ def nearest_brenier_potential_predict_bounds(
                 - c3 * (G[j] - G_l_y).T @ (X[j] - Y[y_idx])
             ]
         problem = cvx.Problem(objective, constraints)
-        problem.solve(solver=cvx.ECOS)
+        problem.solve()
         phi_lu[0, y_idx] = phi_l_y.value
         G_lu[0, y_idx] = G_l_y.value
         if log:
@@ -395,7 +395,7 @@ def nearest_brenier_potential_predict_bounds(
                 - c3 * (G_u_y - G[i]).T @ (Y[y_idx] - X[i])
             ]
         problem = cvx.Problem(objective, constraints)
-        problem.solve(solver=cvx.ECOS)
+        problem.solve()
         phi_lu[1, y_idx] = phi_u_y.value
         G_lu[1, y_idx] = G_u_y.value
         if log:

--- a/ot/mapping.py
+++ b/ot/mapping.py
@@ -31,6 +31,7 @@ def nearest_brenier_potential_fit(
     its=100,
     log=False,
     init_method="barycentric",
+    solver=None,
 ):
     r"""
     Computes optimal values and gradients at X for a strongly convex potential :math:`\varphi` with Lipschitz gradients
@@ -87,7 +88,10 @@ def nearest_brenier_potential_fit(
     log : bool, optional
         record log if true
     init_method : str, optional
-        'target' initialises G=V, 'barycentric' initialises at the image of X by the barycentric projection
+        'target' initialises G=V, 'barycentric' initialises at the image of X by
+        the barycentric projection
+    solver : str, optional
+        The CVXPY solver to use
 
     Returns
     -------
@@ -173,7 +177,7 @@ def nearest_brenier_potential_fit(
                         - c3 * (G[j] - G[i]).T @ (X[j] - X[i])
                     ]
         problem = cvx.Problem(objective, constraints)
-        problem.solve()
+        problem.solve(solver=solver)
         phi_val, G_val = phi.value, G.value
         it_log_dict = {
             "solve_time": problem.solver_stats.solve_time,
@@ -231,6 +235,7 @@ def nearest_brenier_potential_predict_bounds(
     strongly_convex_constant=0.6,
     gradient_lipschitz_constant=1.4,
     log=False,
+    solver=None
 ):
     r"""
     Compute the values of the lower and upper bounding potentials at the input points Y, using the potential optimal
@@ -290,6 +295,8 @@ def nearest_brenier_potential_predict_bounds(
         constant for the Lipschitz property of the input gradient G, defaults to 1.4
     log : bool, optional
         record log if true
+    solver : str, optional
+        The CVXPY solver to use
 
     Returns
     -------
@@ -368,7 +375,7 @@ def nearest_brenier_potential_predict_bounds(
                 - c3 * (G[j] - G_l_y).T @ (X[j] - Y[y_idx])
             ]
         problem = cvx.Problem(objective, constraints)
-        problem.solve()
+        problem.solve(solver=solver)
         phi_lu[0, y_idx] = phi_l_y.value
         G_lu[0, y_idx] = G_l_y.value
         if log:
@@ -395,7 +402,7 @@ def nearest_brenier_potential_predict_bounds(
                 - c3 * (G_u_y - G[i]).T @ (Y[y_idx] - X[i])
             ]
         problem = cvx.Problem(objective, constraints)
-        problem.solve()
+        problem.solve(solver=solver)
         phi_lu[1, y_idx] = phi_u_y.value
         G_lu[1, y_idx] = G_u_y.value
         if log:

--- a/ot/mapping.py
+++ b/ot/mapping.py
@@ -235,7 +235,7 @@ def nearest_brenier_potential_predict_bounds(
     strongly_convex_constant=0.6,
     gradient_lipschitz_constant=1.4,
     log=False,
-    solver=None
+    solver=None,
 ):
     r"""
     Compute the values of the lower and upper bounding potentials at the input points Y, using the potential optimal


### PR DESCRIPTION
## Types of changes
CVXPY changed its default solver (from ECOS to Clarabel), changing the mapping solvers to use the default CVXPY solver instead of asking for an old solver that is no longer installed by default



## Motivation and context / Related issue
Fix #688



## How has this been tested (if it applies)
Example + pytest



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x]  I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
