### PR TITLE
[MRG] Sinkhorn gradient last step

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 #### New features
 - Implement CG solvers for partial FGW (PR #687)
+- Added feature `grad=last_step` for `ot.solvers.solve` (PR #693)
 
 #### Closed issues
 - Fixed `ot.mapping` solvers which depended on deprecated `cvxpy` `ECOS` solver (PR #692, Issue #668)

--- a/examples/backends/plot_Sinkhorn_gradients.py
+++ b/examples/backends/plot_Sinkhorn_gradients.py
@@ -1,4 +1,3 @@
-# %%
 # -*- coding: utf-8 -*-
 """
 ================================================
@@ -27,7 +26,7 @@ from ot.backend import torch
 
 # %% parameters
 
-n_trials = 30
+n_trials = 10
 times_autodiff = torch.zeros(n_trials)
 times_envelope = torch.zeros(n_trials)
 times_last_step = torch.zeros(n_trials)

--- a/examples/backends/plot_Sinkhorn_gradients.py
+++ b/examples/backends/plot_Sinkhorn_gradients.py
@@ -13,7 +13,7 @@ This example illustrates the differences in terms of computation time between th
 #
 # License: MIT License
 
-# sphinx_gallery_thumbnail_number = 4
+# sphinx_gallery_thumbnail_number = 1
 
 import matplotlib.pylab as pl
 import ot

--- a/examples/plot_Sinkhorn_gradients.py
+++ b/examples/plot_Sinkhorn_gradients.py
@@ -15,10 +15,8 @@ This example illustrates the differences in terms of computation time between th
 
 # sphinx_gallery_thumbnail_number = 4
 
-import numpy as np
 import matplotlib.pylab as pl
 import ot
-from ot.datasets import make_1D_gauss as gauss
 from ot.backend import torch
 
 
@@ -78,7 +76,7 @@ for i in range(n_trials):
     times_last_step[i] = ot.toq()
 
 pl.figure(1, figsize=(5, 3))
-pl.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
+pl.ticklabel_format(axis="y", style="sci", scilimits=(0, 0))
 pl.boxplot(
     ([times_autodiff, times_envelope, times_last_step]),
     tick_labels=["autodiff", "envelope", "last_step"],

--- a/examples/plot_Sinkhorn_gradients.py
+++ b/examples/plot_Sinkhorn_gradients.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+================================================
+Different gradient computations for regularized optimal transport
+================================================
+
+This example illustrates the differences in terms of computation time between the gradient options for the Sinkhorn solver.
+
+"""
+
+# Author: Sonia Mazelet <sonia.mazelet@polytechnique.edu>
+#
+# License: MIT License
+
+# sphinx_gallery_thumbnail_number = 4
+
+import numpy as np
+import matplotlib.pylab as pl
+import ot
+from ot.datasets import make_1D_gauss as gauss
+from ot.backend import torch
+
+
+##############################################################################
+# Time comparison of the Sinkhorn solver for different gradient options
+# -------------
+
+
+# %% parameters
+
+n = 100  # nb bins
+n_trials = 500
+times_autodiff = torch.zeros(n_trials)
+times_envelope = torch.zeros(n_trials)
+times_last_step = torch.zeros(n_trials)
+
+# bin positions
+x = np.arange(n, dtype=np.float64)
+
+# Time required for the Sinkhorn solver and gradient computations, for different gradient options over multiple Gaussian distributions
+for i in range(n_trials):
+    # Gaussian distributions with random parameters
+    ma = np.random.randint(10, 40, 2)
+    sa = np.random.randint(5, 10, 2)
+    mb = np.random.randint(10, 40)
+    sb = np.random.randint(5, 10)
+
+    a = 0.6 * gauss(n, m=ma[0], s=sa[0]) + 0.4 * gauss(
+        n, m=ma[1], s=sa[1]
+    )  # m= mean, s= std
+    b = gauss(n, m=mb, s=sb)
+
+    # loss matrix
+    M = ot.dist(x.reshape((n, 1)), x.reshape((n, 1)))
+    M /= M.max()
+
+    a = torch.tensor(a, requires_grad=True)
+    b = torch.tensor(b, requires_grad=True)
+    M = torch.tensor(M, requires_grad=True)
+
+    # autodiff provides the gradient for all the outputs (plan, value, value_linear)
+    ot.tic()
+    res_autodiff = ot.solve(M, a, b, reg=10, grad="autodiff")
+    res_autodiff.value.backward()
+    times_autodiff[i] = ot.toq()
+
+    # envelope provides the gradient for value
+    ot.tic()
+    res_envelope = ot.solve(M, a, b, reg=10, grad="envelope")
+    res_envelope.value.backward()
+    times_envelope[i] = ot.toq()
+
+    # last_step provides the gradient for all the outputs, but only for the last iteration of the Sinkhorn algorithm
+    ot.tic()
+    res_last_step = ot.solve(M, a, b, reg=10, grad="last_step")
+    res_last_step.value.backward()
+    times_last_step[i] = ot.toq()
+
+pl.figure(1, figsize=(4, 3))
+pl.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
+pl.boxplot(
+    ([times_autodiff, times_envelope, times_last_step]),
+    tick_labels=["autodiff", "envelope", "last_step"],
+    showfliers=False,
+)
+pl.ylabel("Time (s)")
+pl.show()

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -131,6 +131,7 @@ def solve(
         'envelope' provides gradients only for `value` and and other outputs are
         detached. This is useful for memory saving when only the value is needed. 'last_step' provides
         gradients only for the last iteration of the Sinkhorn solver, but provides gradient for both the OT plan and the objective values.
+        'detach' does not compute the gradients for the Sinkhorn solver.
 
     Returns
     -------
@@ -415,7 +416,8 @@ def solve(
                 if grad in [
                     "envelope",
                     "last_step",
-                ]:  # if envelope or last_step then detach the input
+                    "detach",
+                ]:  # if envelope, last_step or detach then detach the input
                     M0, a0, b0 = M, a, b
                     M, a, b = nx.detach(M, a, b)
 
@@ -444,6 +446,7 @@ def solve(
 
                 potentials = (log["log_u"], log["log_v"])
 
+                # if last_step, compute the last step of the Sinkhorn algorithm with the non-detached inputs
                 if grad == "last_step":
                     loga = nx.log(a0)
                     logb = nx.log(b0)

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -445,16 +445,17 @@ def solve(
                 potentials = (log["log_u"], log["log_v"])
 
                 if grad == "last_step":
-                    plan, log = sinkhorn_log(
-                        a0,
-                        b0,
-                        M0,
-                        reg=reg,
-                        numItermax=1,
-                        stopThr=tol,
-                        log=True,
-                        warmstart=potentials,
-                    )
+                    loga = nx.log(a0)
+                    logb = nx.log(b0)
+                    v = logb - nx.logsumexp(-M0 / reg + potentials[0][:, None], 0)
+                    u = loga - nx.logsumexp(-M0 / reg + potentials[1][None, :], 1)
+                    plan = nx.exp(-M0 / reg + u[:, None] + v[None, :])
+                    potentials = (u, v)
+                    log["niter"] = max_iter + 1
+                    log["log_u"] = u
+                    log["log_v"] = v
+                    log["u"] = nx.exp(u)
+                    log["v"] = nx.exp(v)
 
                 value_linear = nx.sum(M * plan)
 

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -130,7 +130,7 @@ def solve(
         outputs (`plan, value, value_linear`) but with important memory cost.
         'envelope' provides gradients only for `value` and and other outputs are
         detached. This is useful for memory saving when only the value is needed. 'last_step' provides
-        gradients only for the last iteration of the Sinkhorn solver.
+        gradients only for the last iteration of the Sinkhorn solver, but provides gradient for both the OT plan and the objective values.
 
     Returns
     -------
@@ -412,9 +412,10 @@ def solve(
                 potentials = (log["u"], log["v"])
 
             elif reg_type.lower() in ["entropy", "kl"]:
-                if (
-                    grad in ["envelope",  "last_step"]
-                ):  # if envelope or last_step then detach the input
+                if grad in [
+                    "envelope",
+                    "last_step",
+                ]:  # if envelope or last_step then detach the input
                     M0, a0, b0 = M, a, b
                     M, a, b = nx.detach(M, a, b)
 

--- a/ot/solvers.py
+++ b/ot/solvers.py
@@ -413,7 +413,7 @@ def solve(
 
             elif reg_type.lower() in ["entropy", "kl"]:
                 if (
-                    grad == "envelope" or grad == "last_step"
+                    grad in ["envelope",  "last_step"]
                 ):  # if envelope or last_step then detach the input
                     M0, a0, b0 = M, a, b
                     M, a, b = nx.detach(M, a, b)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -179,10 +179,19 @@ def test_solve_last_step():
     ga = a.grad.clone()
     gb = b.grad.clone()
 
+    cos = torch.nn.CosineSimilarity(dim=0, eps=1e-6)
+
     # Note, gradients are invariant to change in constant so we center them
-    assert not torch.allclose(gM0, gM)
-    assert not torch.allclose(ga0 - ga0.mean(), ga - ga.mean())
-    assert not torch.allclose(gb0 - gb0.mean(), gb - gb.mean())
+    tolerance = 0.96
+    assert cos(gM0.flatten(), gM.flatten()) > tolerance
+    assert cos(ga0 - ga0.mean(), ga - ga.mean()) > tolerance
+    assert cos(gb0 - gb0.mean(), gb - gb.mean()) > tolerance
+
+    assert torch.allclose(sol0.plan, sol.plan)
+    assert torch.allclose(sol0.value, sol.value)
+    assert torch.allclose(sol0.value_linear, sol.value_linear)
+    assert torch.allclose(sol0.potentials[0], sol.potentials[0])
+    assert torch.allclose(sol0.potentials[1], sol.potentials[1])
 
     with pytest.raises(ValueError):
         ot.solve(M, a, b, grad="last_step", max_iter=0, reg=10)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -156,7 +156,7 @@ def test_solve_last_step():
     b = ot.utils.unif(n_samples_t)
     M = ot.dist(x, y)
 
-    # Check that for multiple iterations, autodiff and last_step give different gradients
+    # Check that last_step and autodiff give the same result and similar gradients
     a = torch.tensor(a, requires_grad=True)
     b = torch.tensor(b, requires_grad=True)
     M = torch.tensor(M, requires_grad=True)
@@ -179,9 +179,8 @@ def test_solve_last_step():
     ga = a.grad.clone()
     gb = b.grad.clone()
 
-    cos = torch.nn.CosineSimilarity(dim=0, eps=1e-6)
-
     # Note, gradients are invariant to change in constant so we center them
+    cos = torch.nn.CosineSimilarity(dim=0, eps=1e-6)
     tolerance = 0.96
     assert cos(gM0.flatten(), gM.flatten()) > tolerance
     assert cos(ga0 - ga0.mean(), ga - ga.mean()) > tolerance

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -184,6 +184,9 @@ def test_solve_last_step():
     assert not torch.allclose(ga0 - ga0.mean(), ga - ga.mean())
     assert not torch.allclose(gb0 - gb0.mean(), gb - gb.mean())
 
+    with pytest.raises(ValueError):
+        ot.solve(M, a, b, grad="last_step", max_iter=0, reg=10)
+
 
 @pytest.mark.skipif(not torch, reason="torch no installed")
 def test_solve_envelope():

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -156,40 +156,12 @@ def test_solve_last_step():
     b = ot.utils.unif(n_samples_t)
     M = ot.dist(x, y)
 
-    # Check that for one iteration, autodiff and last_step give the same gradients
-    a = torch.tensor(a, requires_grad=True)
-    b = torch.tensor(b, requires_grad=True)
-    M = torch.tensor(M, requires_grad=True)
-
-    sol0 = ot.solve(M, a, b, max_iter=1, grad="autodiff")
-    sol0.value.backward()
-
-    gM0 = M.grad.clone()
-    ga0 = a.grad.clone()
-    gb0 = b.grad.clone()
-
-    a = torch.tensor(a, requires_grad=True)
-    b = torch.tensor(b, requires_grad=True)
-    M = torch.tensor(M, requires_grad=True)
-
-    sol = ot.solve(M, a, b, max_iter=1, grad="last_step")
-    sol.value.backward()
-
-    gM = M.grad.clone()
-    ga = a.grad.clone()
-    gb = b.grad.clone()
-
-    # Note, gradients are invariant to change in constant so we center them
-    assert torch.allclose(gM0, gM)
-    assert torch.allclose(ga0 - ga0.mean(), ga - ga.mean())
-    assert torch.allclose(gb0 - gb0.mean(), gb - gb.mean())
-
     # Check that for multiple iterations, autodiff and last_step give different gradients
     a = torch.tensor(a, requires_grad=True)
     b = torch.tensor(b, requires_grad=True)
     M = torch.tensor(M, requires_grad=True)
 
-    sol0 = ot.solve(M, a, b, reg=1, grad="autodiff")
+    sol0 = ot.solve(M, a, b, reg=10, grad="autodiff")
     sol0.value.backward()
 
     gM0 = M.grad.clone()
@@ -200,14 +172,14 @@ def test_solve_last_step():
     b = torch.tensor(b, requires_grad=True)
     M = torch.tensor(M, requires_grad=True)
 
-    sol = ot.solve(M, a, b, reg=1, grad="last_ste")
+    sol = ot.solve(M, a, b, reg=10, grad="last_step")
     sol.value.backward()
-
-    print(sol, sol0)
 
     gM = M.grad.clone()
     ga = a.grad.clone()
     gb = b.grad.clone()
+
+    print(gM, gM0)
 
     # Note, gradients are invariant to change in constant so we center them
     assert not torch.allclose(gM0, gM)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -179,8 +179,6 @@ def test_solve_last_step():
     ga = a.grad.clone()
     gb = b.grad.clone()
 
-    print(gM, gM0)
-
     # Note, gradients are invariant to change in constant so we center them
     assert not torch.allclose(gM0, gM)
     assert not torch.allclose(ga0 - ga0.mean(), ga - ga.mean())


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
I added a `grad=last_step` feature to the `ot.solvers.solve` function to limit the gradient computation to the last iteration of Sinkhorn instead of computing the gradient for every iteration.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
This change is required in the case where computing the gradient for all the Sinkhorn iterations is too heavy.


## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
I created a `test_solve_last_step` test to check that the gradient is different when using `grad=last_step` and `grad=autodiff`.



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
