### PR TITLE
[MRG] Refactor: improve readibility in the convolutional module

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -40,6 +40,7 @@ This release also contains few bug fixes, concerning the support of any metric i
 - Notes before depreciating partial Gromov-Wasserstein function in `ot.partial` moved to ot.gromov  (PR #663)
 - Create `ot.gromov._partial` add new features `loss_fun = "kl_loss"` and `symmetry=False` to all solvers while increasing speed + updating adequatly `ot.solvers` (PR #663)
 - Added `ot.unbalanced.sinkhorn_unbalanced_translation_invariant` (PR #676)
+- Refactored `ot.bregman._convolutional` to improve readability (PR #709)
 
 #### Closed issues
 - Fixed `ot.gaussian` ignoring weights when computing means (PR #649, Issue #648)

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -46,6 +46,13 @@ def _get_convol_img_fn(nx, width, height, reg, type_as, log_domain=False):
     return convol_imgs
 
 
+def _print_report(ii, err):
+    """Print the report of the iteration."""
+    if ii % 200 == 0:
+        print("{:5s}|{:12s}".format("It.", "Err") + "\n" + "-" * 19)
+    print("{:5d}|{:8e}|".format(ii, err))
+
+
 def convolutional_barycenter2d(
     A,
     reg,
@@ -198,11 +205,8 @@ def _convolutional_barycenter2d(
             # log and verbose print
             if log:
                 log["err"].append(err)
-
             if verbose:
-                if ii % 200 == 0:
-                    print("{:5s}|{:12s}".format("It.", "Err") + "\n" + "-" * 19)
-                print("{:5d}|{:8e}|".format(ii, err))
+                _print_report(ii, err)
             if err < stopThr:
                 break
 
@@ -271,11 +275,8 @@ def _convolutional_barycenter2d_log(
             # log and verbose print
             if log:
                 log["err"].append(err)
-
             if verbose:
-                if ii % 200 == 0:
-                    print("{:5s}|{:12s}".format("It.", "Err") + "\n" + "-" * 19)
-                print("{:5d}|{:8e}|".format(ii, err))
+                _print_report(ii, err)
             if err < stopThr:
                 break
         G = log_bar[None, :, :] - log_KU
@@ -441,11 +442,8 @@ def _convolutional_barycenter2d_debiased(
             # log and verbose print
             if log:
                 log["err"].append(err)
-
             if verbose:
-                if ii % 200 == 0:
-                    print("{:5s}|{:12s}".format("It.", "Err") + "\n" + "-" * 19)
-                print("{:5d}|{:8e}|".format(ii, err))
+                _print_report(ii, err)
 
             # debiased Sinkhorn does not converge monotonically
             # guarantee a few iterations are done before stopping
@@ -515,11 +513,8 @@ def _convolutional_barycenter2d_debiased_log(
             # log and verbose print
             if log:
                 log["err"].append(err)
-
             if verbose:
-                if ii % 200 == 0:
-                    print("{:5s}|{:12s}".format("It.", "Err") + "\n" + "-" * 19)
-                print("{:5d}|{:8e}|".format(ii, err))
+                _print_report(ii, err)
             if err < stopThr and ii > 20:
                 break
         G = log_bar[None, :, :] - log_KU

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -31,7 +31,7 @@ def _get_convol_img_fn(nx, width, height, reg, type_as, log_domain=False):
     t2 = nx.linspace(0, 1, height, type_as=type_as)
     Y2, X2 = nx.meshgrid(t2, t2)
     M2 = -((X2 - Y2) ** 2) / reg
-    
+
     # If normal domain is selected, we can use M1 and M2 to compute the convolution
     if not log_domain:
         K1, K2 = nx.exp(M1), nx.exp(M2)
@@ -43,6 +43,7 @@ def _get_convol_img_fn(nx, width, height, reg, type_as, log_domain=False):
 
     # Else, we can use M1 and M2 to compute the convolution in log-domain
     else:
+
         def convol_imgs(log_imgs):
             log_imgs = nx.logsumexp(M1[:, :, None] + log_imgs[None], axis=1)
             log_imgs = nx.logsumexp(M2[:, :, None] + log_imgs.T[None], axis=1).T

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -246,11 +246,6 @@ def _convolutional_barycenter2d_log(
     A = list_to_array(A)
 
     nx = get_backend(A)
-    if nx.__name__ in ("jax", "tf"):
-        raise NotImplementedError(
-            "Log-domain functions are not yet implemented"
-            " for Jax and TF. Use numpy or torch arrays instead."
-        )
 
     n_hists, width, height = A.shape
 
@@ -483,11 +478,7 @@ def _convolutional_barycenter2d_debiased_log(
     A = list_to_array(A)
     n_hists, width, height = A.shape
     nx = get_backend(A)
-    if nx.__name__ in ("jax", "tf"):
-        raise NotImplementedError(
-            "Log-domain functions are not yet implemented"
-            " for Jax and TF. Use numpy or torch arrays instead."
-        )
+
     if weights is None:
         weights = nx.ones((n_hists,), type_as=A) / n_hists
     else:

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -246,6 +246,8 @@ def _convolutional_barycenter2d_log(
     A = list_to_array(A)
 
     nx = get_backend(A)
+    # This error is raised because we are using mutable assignment in the line
+    #  `log_KU[k] = ...` which is not allowed in Jax and TF.
     if nx.__name__ in ("jax", "tf"):
         raise NotImplementedError(
             "Log-domain functions are not yet implemented"
@@ -483,6 +485,8 @@ def _convolutional_barycenter2d_debiased_log(
     A = list_to_array(A)
     n_hists, width, height = A.shape
     nx = get_backend(A)
+    # This error is raised because we are using mutable assignment in the line
+    #  `log_KU[k] = ...` which is not allowed in Jax and TF.
     if nx.__name__ in ("jax", "tf"):
         raise NotImplementedError(
             "Log-domain functions are not yet implemented"

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -13,11 +13,15 @@ import warnings
 from ..backend import get_backend
 from ..utils import list_to_array
 
+_warning_msg = (
+    "Convolutional Sinkhorn did not converge. "
+    "Try a larger number of iterations `numItermax` "
+    "or a larger entropy `reg`."
+)
+
 
 def _get_convol_img_fn(nx, width, height, reg, type_as, log_domain=False):
-    """
-    Return the convolution operator for 2D images. The function constructed is equivalent to blurring on horizontal then vertical directions.
-    """
+    """Return the convolution operator for 2D images. The function constructed is equivalent to blurring on horizontal then vertical directions."""
     t1 = nx.linspace(0, 1, width, type_as=type_as)
     Y1, X1 = nx.meshgrid(t1, t1)
     M1 = -((X1 - Y1) ** 2) / reg
@@ -204,11 +208,7 @@ def _convolutional_barycenter2d(
 
     else:
         if warn:
-            warnings.warn(
-                "Convolutional Sinkhorn did not converge. "
-                "Try a larger number of iterations `numItermax` "
-                "or a larger entropy `reg`."
-            )
+            warnings.warn(_warning_msg)
     if log:
         log["niter"] = ii
         log["U"] = U
@@ -282,11 +282,7 @@ def _convolutional_barycenter2d_log(
 
     else:
         if warn:
-            warnings.warn(
-                "Convolutional Sinkhorn did not converge. "
-                "Try a larger number of iterations `numItermax` "
-                "or a larger entropy `reg`."
-            )
+            warnings.warn(_warning_msg)
     if log:
         log["niter"] = ii
         return nx.exp(log_bar), log
@@ -457,11 +453,7 @@ def _convolutional_barycenter2d_debiased(
                 break
     else:
         if warn:
-            warnings.warn(
-                "Sinkhorn did not converge. You might want to "
-                "increase the number of iterations `numItermax` "
-                "or the regularization parameter `reg`."
-            )
+            warnings.warn(_warning_msg)
     if log:
         log["niter"] = ii
         log["U"] = U
@@ -534,11 +526,7 @@ def _convolutional_barycenter2d_debiased_log(
 
     else:
         if warn:
-            warnings.warn(
-                "Convolutional Sinkhorn did not converge. "
-                "Try a larger number of iterations `numItermax` "
-                "or a larger entropy `reg`."
-            )
+            warnings.warn(_warning_msg)
     if log:
         log["niter"] = ii
         return nx.exp(log_bar), log

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -246,6 +246,11 @@ def _convolutional_barycenter2d_log(
     A = list_to_array(A)
 
     nx = get_backend(A)
+    if nx.__name__ in ("jax", "tf"):
+        raise NotImplementedError(
+            "Log-domain functions are not yet implemented"
+            " for Jax and TF. Use numpy or torch arrays instead."
+        )
 
     n_hists, width, height = A.shape
 
@@ -478,7 +483,11 @@ def _convolutional_barycenter2d_debiased_log(
     A = list_to_array(A)
     n_hists, width, height = A.shape
     nx = get_backend(A)
-
+    if nx.__name__ in ("jax", "tf"):
+        raise NotImplementedError(
+            "Log-domain functions are not yet implemented"
+            " for Jax and TF. Use numpy or torch arrays instead."
+        )
     if weights is None:
         weights = nx.ones((n_hists,), type_as=A) / n_hists
     else:

--- a/ot/bregman/_convolutional.py
+++ b/ot/bregman/_convolutional.py
@@ -21,7 +21,9 @@ _warning_msg = (
 
 
 def _get_convol_img_fn(nx, width, height, reg, type_as, log_domain=False):
-    """Return the convolution operator for 2D images. The function constructed is equivalent to blurring on horizontal then vertical directions."""
+    """Return the convolution operator for 2D images.
+
+    The function constructed is equivalent to blurring on horizontal then vertical directions."""
     t1 = nx.linspace(0, 1, width, type_as=type_as)
     Y1, X1 = nx.meshgrid(t1, t1)
     M1 = -((X1 - Y1) ** 2) / reg
@@ -30,11 +32,13 @@ def _get_convol_img_fn(nx, width, height, reg, type_as, log_domain=False):
     Y2, X2 = nx.meshgrid(t2, t2)
     M2 = -((X2 - Y2) ** 2) / reg
 
+    # As M1 and M2 are computed first, we can use them to compute the convolution in log-domain
     def convol_imgs(log_imgs):
         log_imgs = nx.logsumexp(M1[:, :, None] + log_imgs[None], axis=1)
         log_imgs = nx.logsumexp(M2[:, :, None] + log_imgs.T[None], axis=1).T
         return log_imgs
 
+    # If normal domain is selected, we can use M1 and M2 to compute the convolution
     if not log_domain:
         K1, K2 = nx.exp(M1), nx.exp(M2)
 

--- a/test/test_bregman.py
+++ b/test/test_bregman.py
@@ -825,22 +825,18 @@ def test_wasserstein_bary_2d(nx, method):
 
     # wasserstein
     reg = 1e-2
-    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
-        with pytest.raises(NotImplementedError):
-            ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
-    else:
-        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
-            A, reg, method=method, verbose=True, log=True
-        )
-        bary_wass = nx.to_numpy(
-            ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
-        )
+    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
+        A, reg, method=method, verbose=True, log=True
+    )
+    bary_wass = nx.to_numpy(
+        ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
+    )
 
-        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+    np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-        # help in checking if log and verbose do not bug the function
-        ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
+    # help in checking if log and verbose do not bug the function
+    ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
 
 
 @pytest.skip_backend("tf")
@@ -856,75 +852,6 @@ def test_wasserstein_bary_2d_dtype_device(nx, method):
 
         # wasserstein
         reg = 1e-2
-        if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
-            with pytest.raises(NotImplementedError):
-                ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-        else:
-            # Compute the barycenter with numpy
-            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
-                A, reg, method=method, verbose=True, log=True
-            )
-            # Compute the barycenter with the backend
-            bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-            # Convert the backend result to numpy, to compare with the numpy result
-            bary_wass = nx.to_numpy(bary_wass_b)
-
-            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
-
-            # help in checking if log and verbose do not bug the function
-            ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
-
-            # Test that the dtype and device are the same after the computation
-            nx.assert_same_dtype_device(Ab, bary_wass_b)
-
-
-@pytest.mark.skipif(not tf, reason="tf not installed")
-@pytest.mark.parametrize("method", ["sinkhorn", "sinkhorn_log"])
-def test_wasserstein_bary_2d_device_tf(method):
-    # Using the Tensorflow backend
-    nx = ot.backend.TensorflowBackend()
-
-    # Create the array of images to test
-    A = create_random_images_dist(42, size=20)
-
-    # Check that everything stays on the CPU
-    with tf.device("/CPU:0"):
-        Ab = nx.from_numpy(A)
-
-        # wasserstein
-        reg = 1e-2
-        if method == "sinkhorn_log":
-            with pytest.raises(NotImplementedError):
-                ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-        else:
-            # Compute the barycenter with numpy
-            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
-                A, reg, method=method, verbose=True, log=True
-            )
-            # Compute the barycenter with the backend
-            bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-            # Convert the backend result to numpy, to compare with the numpy result
-            bary_wass = nx.to_numpy(bary_wass_b)
-
-            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
-
-            # help in checking if log and verbose do not bug the function
-            ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
-
-            # Test that the dtype and device are the same after the computation
-            nx.assert_same_dtype_device(Ab, bary_wass_b)
-
-    # Check that everything happens on the GPU
-    Ab = nx.from_numpy(A)
-
-    # wasserstein
-    reg = 1e-2
-    if method == "sinkhorn_log":
-        with pytest.raises(NotImplementedError):
-            ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-    else:
         # Compute the barycenter with numpy
         bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
             A, reg, method=method, verbose=True, log=True
@@ -943,9 +870,66 @@ def test_wasserstein_bary_2d_device_tf(method):
         # Test that the dtype and device are the same after the computation
         nx.assert_same_dtype_device(Ab, bary_wass_b)
 
-        # Check this only if GPU is available
-        if len(tf.config.list_physical_devices("GPU")) > 0:
-            assert nx.dtype_device(bary_wass_b)[1].startswith("GPU")
+
+@pytest.mark.skipif(not tf, reason="tf not installed")
+@pytest.mark.parametrize("method", ["sinkhorn", "sinkhorn_log"])
+def test_wasserstein_bary_2d_device_tf(method):
+    # Using the Tensorflow backend
+    nx = ot.backend.TensorflowBackend()
+
+    # Create the array of images to test
+    A = create_random_images_dist(42, size=20)
+
+    # Check that everything stays on the CPU
+    with tf.device("/CPU:0"):
+        Ab = nx.from_numpy(A)
+
+        # wasserstein
+        reg = 1e-2
+        # Compute the barycenter with numpy
+        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
+            A, reg, method=method, verbose=True, log=True
+        )
+        # Compute the barycenter with the backend
+        bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+        # Convert the backend result to numpy, to compare with the numpy result
+        bary_wass = nx.to_numpy(bary_wass_b)
+
+        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+
+        # help in checking if log and verbose do not bug the function
+        ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
+
+        # Test that the dtype and device are the same after the computation
+        nx.assert_same_dtype_device(Ab, bary_wass_b)
+
+    # Check that everything happens on the GPU
+    Ab = nx.from_numpy(A)
+
+    # wasserstein
+    reg = 1e-2
+    # Compute the barycenter with numpy
+    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
+        A, reg, method=method, verbose=True, log=True
+    )
+    # Compute the barycenter with the backend
+    bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+    # Convert the backend result to numpy, to compare with the numpy result
+    bary_wass = nx.to_numpy(bary_wass_b)
+
+    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+    np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+
+    # help in checking if log and verbose do not bug the function
+    ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
+
+    # Test that the dtype and device are the same after the computation
+    nx.assert_same_dtype_device(Ab, bary_wass_b)
+
+    # Check this only if GPU is available
+    if len(tf.config.list_physical_devices("GPU")) > 0:
+        assert nx.dtype_device(bary_wass_b)[1].startswith("GPU")
 
 
 @pytest.mark.parametrize("method", ["sinkhorn", "sinkhorn_log"])
@@ -957,22 +941,18 @@ def test_wasserstein_bary_2d_debiased(nx, method):
 
     # wasserstein
     reg = 1e-2
-    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
-        with pytest.raises(NotImplementedError):
-            ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
-    else:
-        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
-            A, reg, method=method, verbose=True, log=True
-        )
-        bary_wass = nx.to_numpy(
-            ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
-        )
+    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
+        A, reg, method=method, verbose=True, log=True
+    )
+    bary_wass = nx.to_numpy(
+        ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
+    )
 
-        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+    np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-        # help in checking if log and verbose do not bug the function
-        ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
+    # help in checking if log and verbose do not bug the function
+    ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
 
 
 @pytest.skip_backend("tf")
@@ -988,31 +968,25 @@ def test_wasserstein_bary_2d_debiased_dtype_device(nx, method):
 
         # wasserstein
         reg = 1e-2
-        if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
-            with pytest.raises(NotImplementedError):
-                ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
-        else:
-            # Compute the barycenter with numpy
-            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
-                A, reg, method=method, verbose=True, log=True
-            )
-            # Compute the barycenter with the backend
-            bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(
-                Ab, reg, method=method
-            )
-            # Convert the backend result to numpy, to compare with the numpy result
-            bary_wass = nx.to_numpy(bary_wass_b)
+        # Compute the barycenter with numpy
+        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
+            A, reg, method=method, verbose=True, log=True
+        )
+        # Compute the barycenter with the backend
+        bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(
+            Ab, reg, method=method
+        )
+        # Convert the backend result to numpy, to compare with the numpy result
+        bary_wass = nx.to_numpy(bary_wass_b)
 
-            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-            # help in checking if log and verbose do not bug the function
-            ot.bregman.convolutional_barycenter2d_debiased(
-                A, reg, log=True, verbose=True
-            )
+        # help in checking if log and verbose do not bug the function
+        ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
 
-            # Test that the dtype and device are the same after the computation
-            nx.assert_same_dtype_device(Ab, bary_wass_b)
+        # Test that the dtype and device are the same after the computation
+        nx.assert_same_dtype_device(Ab, bary_wass_b)
 
 
 @pytest.mark.skipif(not tf, reason="tf not installed")
@@ -1030,41 +1004,6 @@ def test_wasserstein_bary_2d_debiased_device_tf(method):
 
         # wasserstein
         reg = 1e-2
-        if method == "sinkhorn_log":
-            with pytest.raises(NotImplementedError):
-                ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
-        else:
-            # Compute the barycenter with numpy
-            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
-                A, reg, method=method, verbose=True, log=True
-            )
-            # Compute the barycenter with the backend
-            bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(
-                Ab, reg, method=method
-            )
-            # Convert the backend result to numpy, to compare with the numpy result
-            bary_wass = nx.to_numpy(bary_wass_b)
-
-            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
-
-            # help in checking if log and verbose do not bug the function
-            ot.bregman.convolutional_barycenter2d_debiased(
-                A, reg, log=True, verbose=True
-            )
-
-            # Test that the dtype and device are the same after the computation
-            nx.assert_same_dtype_device(Ab, bary_wass_b)
-
-    # Check that everything happens on the GPU
-    Ab = nx.from_numpy(A)
-
-    # wasserstein
-    reg = 1e-2
-    if method == "sinkhorn_log":
-        with pytest.raises(NotImplementedError):
-            ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
-    else:
         # Compute the barycenter with numpy
         bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
             A, reg, method=method, verbose=True, log=True
@@ -1077,6 +1016,29 @@ def test_wasserstein_bary_2d_debiased_device_tf(method):
         bary_wass = nx.to_numpy(bary_wass_b)
 
         np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+
+        # help in checking if log and verbose do not bug the function
+        ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
+
+        # Test that the dtype and device are the same after the computation
+        nx.assert_same_dtype_device(Ab, bary_wass_b)
+
+    # Check that everything happens on the GPU
+    Ab = nx.from_numpy(A)
+
+    # wasserstein
+    reg = 1e-2
+    # Compute the barycenter with numpy
+    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
+        A, reg, method=method, verbose=True, log=True
+    )
+    # Compute the barycenter with the backend
+    bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
+    # Convert the backend result to numpy, to compare with the numpy result
+    bary_wass = nx.to_numpy(bary_wass_b)
+
+    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
 
 
 def test_unmix(nx):

--- a/test/test_bregman.py
+++ b/test/test_bregman.py
@@ -825,18 +825,22 @@ def test_wasserstein_bary_2d(nx, method):
 
     # wasserstein
     reg = 1e-2
-    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
-        A, reg, method=method, verbose=True, log=True
-    )
-    bary_wass = nx.to_numpy(
-        ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
-    )
+    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
+        with pytest.raises(NotImplementedError):
+            ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
+    else:
+        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
+            A, reg, method=method, verbose=True, log=True
+        )
+        bary_wass = nx.to_numpy(
+            ot.bregman.convolutional_barycenter2d(A_nx, reg, method=method)
+        )
 
-    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-    np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-    # help in checking if log and verbose do not bug the function
-    ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
+        # help in checking if log and verbose do not bug the function
+        ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
 
 
 @pytest.skip_backend("tf")
@@ -852,23 +856,27 @@ def test_wasserstein_bary_2d_dtype_device(nx, method):
 
         # wasserstein
         reg = 1e-2
-        # Compute the barycenter with numpy
-        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
-            A, reg, method=method, verbose=True, log=True
-        )
-        # Compute the barycenter with the backend
-        bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-        # Convert the backend result to numpy, to compare with the numpy result
-        bary_wass = nx.to_numpy(bary_wass_b)
+        if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
+            with pytest.raises(NotImplementedError):
+                ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+        else:
+            # Compute the barycenter with numpy
+            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
+                A, reg, method=method, verbose=True, log=True
+            )
+            # Compute the barycenter with the backend
+            bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+            # Convert the backend result to numpy, to compare with the numpy result
+            bary_wass = nx.to_numpy(bary_wass_b)
 
-        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-        # help in checking if log and verbose do not bug the function
-        ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
+            # help in checking if log and verbose do not bug the function
+            ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
 
-        # Test that the dtype and device are the same after the computation
-        nx.assert_same_dtype_device(Ab, bary_wass_b)
+            # Test that the dtype and device are the same after the computation
+            nx.assert_same_dtype_device(Ab, bary_wass_b)
 
 
 @pytest.mark.skipif(not tf, reason="tf not installed")
@@ -886,6 +894,37 @@ def test_wasserstein_bary_2d_device_tf(method):
 
         # wasserstein
         reg = 1e-2
+        if method == "sinkhorn_log":
+            with pytest.raises(NotImplementedError):
+                ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+        else:
+            # Compute the barycenter with numpy
+            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
+                A, reg, method=method, verbose=True, log=True
+            )
+            # Compute the barycenter with the backend
+            bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+            # Convert the backend result to numpy, to compare with the numpy result
+            bary_wass = nx.to_numpy(bary_wass_b)
+
+            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+
+            # help in checking if log and verbose do not bug the function
+            ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
+
+            # Test that the dtype and device are the same after the computation
+            nx.assert_same_dtype_device(Ab, bary_wass_b)
+
+    # Check that everything happens on the GPU
+    Ab = nx.from_numpy(A)
+
+    # wasserstein
+    reg = 1e-2
+    if method == "sinkhorn_log":
+        with pytest.raises(NotImplementedError):
+            ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
+    else:
         # Compute the barycenter with numpy
         bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
             A, reg, method=method, verbose=True, log=True
@@ -904,32 +943,9 @@ def test_wasserstein_bary_2d_device_tf(method):
         # Test that the dtype and device are the same after the computation
         nx.assert_same_dtype_device(Ab, bary_wass_b)
 
-    # Check that everything happens on the GPU
-    Ab = nx.from_numpy(A)
-
-    # wasserstein
-    reg = 1e-2
-    # Compute the barycenter with numpy
-    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d(
-        A, reg, method=method, verbose=True, log=True
-    )
-    # Compute the barycenter with the backend
-    bary_wass_b = ot.bregman.convolutional_barycenter2d(Ab, reg, method=method)
-    # Convert the backend result to numpy, to compare with the numpy result
-    bary_wass = nx.to_numpy(bary_wass_b)
-
-    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-    np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
-
-    # help in checking if log and verbose do not bug the function
-    ot.bregman.convolutional_barycenter2d(A, reg, log=True, verbose=True)
-
-    # Test that the dtype and device are the same after the computation
-    nx.assert_same_dtype_device(Ab, bary_wass_b)
-
-    # Check this only if GPU is available
-    if len(tf.config.list_physical_devices("GPU")) > 0:
-        assert nx.dtype_device(bary_wass_b)[1].startswith("GPU")
+        # Check this only if GPU is available
+        if len(tf.config.list_physical_devices("GPU")) > 0:
+            assert nx.dtype_device(bary_wass_b)[1].startswith("GPU")
 
 
 @pytest.mark.parametrize("method", ["sinkhorn", "sinkhorn_log"])
@@ -941,18 +957,22 @@ def test_wasserstein_bary_2d_debiased(nx, method):
 
     # wasserstein
     reg = 1e-2
-    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
-        A, reg, method=method, verbose=True, log=True
-    )
-    bary_wass = nx.to_numpy(
-        ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
-    )
+    if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
+        with pytest.raises(NotImplementedError):
+            ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
+    else:
+        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
+            A, reg, method=method, verbose=True, log=True
+        )
+        bary_wass = nx.to_numpy(
+            ot.bregman.convolutional_barycenter2d_debiased(A_nx, reg, method=method)
+        )
 
-    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-    np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-    # help in checking if log and verbose do not bug the function
-    ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
+        # help in checking if log and verbose do not bug the function
+        ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
 
 
 @pytest.skip_backend("tf")
@@ -968,25 +988,31 @@ def test_wasserstein_bary_2d_debiased_dtype_device(nx, method):
 
         # wasserstein
         reg = 1e-2
-        # Compute the barycenter with numpy
-        bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
-            A, reg, method=method, verbose=True, log=True
-        )
-        # Compute the barycenter with the backend
-        bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(
-            Ab, reg, method=method
-        )
-        # Convert the backend result to numpy, to compare with the numpy result
-        bary_wass = nx.to_numpy(bary_wass_b)
+        if nx.__name__ in ("jax", "tf") and method == "sinkhorn_log":
+            with pytest.raises(NotImplementedError):
+                ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
+        else:
+            # Compute the barycenter with numpy
+            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
+                A, reg, method=method, verbose=True, log=True
+            )
+            # Compute the barycenter with the backend
+            bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(
+                Ab, reg, method=method
+            )
+            # Convert the backend result to numpy, to compare with the numpy result
+            bary_wass = nx.to_numpy(bary_wass_b)
 
-        np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
 
-        # help in checking if log and verbose do not bug the function
-        ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
+            # help in checking if log and verbose do not bug the function
+            ot.bregman.convolutional_barycenter2d_debiased(
+                A, reg, log=True, verbose=True
+            )
 
-        # Test that the dtype and device are the same after the computation
-        nx.assert_same_dtype_device(Ab, bary_wass_b)
+            # Test that the dtype and device are the same after the computation
+            nx.assert_same_dtype_device(Ab, bary_wass_b)
 
 
 @pytest.mark.skipif(not tf, reason="tf not installed")
@@ -1004,6 +1030,41 @@ def test_wasserstein_bary_2d_debiased_device_tf(method):
 
         # wasserstein
         reg = 1e-2
+        if method == "sinkhorn_log":
+            with pytest.raises(NotImplementedError):
+                ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
+        else:
+            # Compute the barycenter with numpy
+            bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
+                A, reg, method=method, verbose=True, log=True
+            )
+            # Compute the barycenter with the backend
+            bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(
+                Ab, reg, method=method
+            )
+            # Convert the backend result to numpy, to compare with the numpy result
+            bary_wass = nx.to_numpy(bary_wass_b)
+
+            np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
+            np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
+
+            # help in checking if log and verbose do not bug the function
+            ot.bregman.convolutional_barycenter2d_debiased(
+                A, reg, log=True, verbose=True
+            )
+
+            # Test that the dtype and device are the same after the computation
+            nx.assert_same_dtype_device(Ab, bary_wass_b)
+
+    # Check that everything happens on the GPU
+    Ab = nx.from_numpy(A)
+
+    # wasserstein
+    reg = 1e-2
+    if method == "sinkhorn_log":
+        with pytest.raises(NotImplementedError):
+            ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
+    else:
         # Compute the barycenter with numpy
         bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
             A, reg, method=method, verbose=True, log=True
@@ -1016,29 +1077,6 @@ def test_wasserstein_bary_2d_debiased_device_tf(method):
         bary_wass = nx.to_numpy(bary_wass_b)
 
         np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
-        np.testing.assert_allclose(bary_wass, bary_wass_np, atol=1e-3)
-
-        # help in checking if log and verbose do not bug the function
-        ot.bregman.convolutional_barycenter2d_debiased(A, reg, log=True, verbose=True)
-
-        # Test that the dtype and device are the same after the computation
-        nx.assert_same_dtype_device(Ab, bary_wass_b)
-
-    # Check that everything happens on the GPU
-    Ab = nx.from_numpy(A)
-
-    # wasserstein
-    reg = 1e-2
-    # Compute the barycenter with numpy
-    bary_wass_np, log_np = ot.bregman.convolutional_barycenter2d_debiased(
-        A, reg, method=method, verbose=True, log=True
-    )
-    # Compute the barycenter with the backend
-    bary_wass_b = ot.bregman.convolutional_barycenter2d_debiased(Ab, reg, method=method)
-    # Convert the backend result to numpy, to compare with the numpy result
-    bary_wass = nx.to_numpy(bary_wass_b)
-
-    np.testing.assert_allclose(1, np.sum(bary_wass), rtol=1e-3)
 
 
 def test_unmix(nx):


### PR DESCRIPTION
## Types of changes
Refactor the `ot.bregman._convolutional.py` module to improve the readability of the module. These includes:
- Add a function that returns `convol_img` function.
- Leave the warning message as a constant in the top of the module.
- Create a function for the verbose report.



## Motivation and context / Related issue
There is a lot of duplicate code in this module, which can be encapsulated in functions to make it more modular. 



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
