### PR TITLE
[MRG] fix: make the documentation of _get_loss_unbalanced as a raw string

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@
 - Automatic PR labeling and release file update check (PR #704)
 - Reorganize sub-module `ot/lp/__init__.py` into separate files (PR #714)
 - Fix warning raise when import the library (PR #716)
+- Fix documentation in the module `ot.gaussian` (PR #718)
 
 #### Closed issues
 - Fixed `ot.mapping` solvers which depended on deprecated `cvxpy` `ECOS` solver (PR #692, Issue #668)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 - Added feature `grad=last_step` for `ot.solvers.solve` (PR #693)
 - Automatic PR labeling and release file update check (PR #704)
 - Reorganize sub-module `ot/lp/__init__.py` into separate files (PR #714)
+- Fix warning raise when import the library (PR #716)
 
 #### Closed issues
 - Fixed `ot.mapping` solvers which depended on deprecated `cvxpy` `ECOS` solver (PR #692, Issue #668)

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -354,7 +354,7 @@ def bures_wasserstein_barycenter(
 
     The function estimates the optimal barycenter of the
     empirical distributions. This is equivalent to resolving the fixed point
-     algorithm for multiple Gaussian distributions :math:`\left{\mathcal{N}(\mu,\Sigma)\right}_{i=1}^n`
+    algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
     :ref:`[1] <references-OT-mapping-linear-barycenter>`.
 
     The barycenter still following a Gaussian distribution :math:`\mathcal{N}(\mu_b,\Sigma_b)`
@@ -452,7 +452,7 @@ def empirical_bures_wasserstein_barycenter(
 
     The function estimates the optimal barycenter of the
     empirical distributions. This is equivalent to resolving the fixed point
-     algorithm for multiple Gaussian distributions :math:`\left{\mathcal{N}(\mu,\Sigma)\right}_{i=1}^n`
+    algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
     :ref:`[1] <references-OT-mapping-linear-barycenter>`.
 
     The barycenter still following a Gaussian distribution :math:`\mathcal{N}(\mu_b,\Sigma_b)`

--- a/ot/unbalanced/_lbfgs.py
+++ b/ot/unbalanced/_lbfgs.py
@@ -18,7 +18,7 @@ from ..utils import list_to_array, get_parameter_pair
 
 
 def _get_loss_unbalanced(a, b, c, M, reg, reg_m1, reg_m2, reg_div="kl", regm_div="kl"):
-    """
+    r"""
     Return loss function for the L-BFGS-B solver
 
     .. note:: This function will be fed into scipy.optimize, so all input arrays must be Numpy arrays.


### PR DESCRIPTION
This is to avoid the following warning:
```
SyntaxWarning: invalid escape sequence '\m'
```

## Types of changes
Add a `r` at the beggining of the `_get_loss_unbalanced` documentation



## Motivation and context / Related issue
When I update the library, I realised that throws the following warning:
```
/home/.../site-packages/ot/unbalanced/_lbfgs.py:21: SyntaxWarning: invalid escape sequence '\m'
  """
```



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
