### PR TITLE
[MRG] docs: fix missing delimeter for left

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 - Added feature `grad=last_step` for `ot.solvers.solve` (PR #693)
 - Automatic PR labeling and release file update check (PR #704)
 - Reorganize sub-module `ot/lp/__init__.py` into separate files (PR #714)
+- Fix documentation in the module `ot.gaussian` (PR #718)
 
 #### Closed issues
 - Fixed `ot.mapping` solvers which depended on deprecated `cvxpy` `ECOS` solver (PR #692, Issue #668)

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -354,7 +354,7 @@ def bures_wasserstein_barycenter(
 
     The function estimates the optimal barycenter of the
     empirical distributions. This is equivalent to resolving the fixed point
-     algorithm for multiple Gaussian distributions :math:`\left{\mathcal{N}(\mu,\Sigma)\right}_{i=1}^n`
+     algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
     :ref:`[1] <references-OT-mapping-linear-barycenter>`.
 
     The barycenter still following a Gaussian distribution :math:`\mathcal{N}(\mu_b,\Sigma_b)`
@@ -452,7 +452,7 @@ def empirical_bures_wasserstein_barycenter(
 
     The function estimates the optimal barycenter of the
     empirical distributions. This is equivalent to resolving the fixed point
-     algorithm for multiple Gaussian distributions :math:`\left{\mathcal{N}(\mu,\Sigma)\right}_{i=1}^n`
+     algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
     :ref:`[1] <references-OT-mapping-linear-barycenter>`.
 
     The barycenter still following a Gaussian distribution :math:`\mathcal{N}(\mu_b,\Sigma_b)`

--- a/ot/gaussian.py
+++ b/ot/gaussian.py
@@ -354,7 +354,7 @@ def bures_wasserstein_barycenter(
 
     The function estimates the optimal barycenter of the
     empirical distributions. This is equivalent to resolving the fixed point
-     algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
+    algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
     :ref:`[1] <references-OT-mapping-linear-barycenter>`.
 
     The barycenter still following a Gaussian distribution :math:`\mathcal{N}(\mu_b,\Sigma_b)`
@@ -452,7 +452,7 @@ def empirical_bures_wasserstein_barycenter(
 
     The function estimates the optimal barycenter of the
     empirical distributions. This is equivalent to resolving the fixed point
-     algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
+    algorithm for multiple Gaussian distributions :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
     :ref:`[1] <references-OT-mapping-linear-barycenter>`.
 
     The barycenter still following a Gaussian distribution :math:`\mathcal{N}(\mu_b,\Sigma_b)`


### PR DESCRIPTION
## Types of changes
 * Add backslash in mathematical environment. 
    E.g.: from 
    ```
    :math:`\left{\mathcal{N}(\mu,\Sigma)\right}_{i=1}^n`
    ```
    now is 
    ```
    :math:`\left\{\mathcal{N}(\mu,\Sigma)\right\}_{i=1}^n`
    ```
* Delete spaces at the change of line.


## Motivation and context / Related issue
In the documentation of [`ot.gaussian`](https://pythonot.github.io/master/gen_modules/ot.gaussian.html) appears the following warning:

`Missing or unrecognized delimiter for \left`



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
