### PR TITLE
[MRG] Add release version information to each example in the examples gallery

### DIFF
--- a/examples/backends/plot_Sinkhorn_gradients.py
+++ b/examples/backends/plot_Sinkhorn_gradients.py
@@ -6,6 +6,8 @@ Different gradient computations for regularized optimal transport
 
 This example illustrates the differences in terms of computation time between the gradient options for the Sinkhorn solver.
 
+.. note::
+    Notebook currently under development and has not been released yet. To be added in release: 0.9.6
 """
 
 # Author: Sonia Mazelet <sonia.mazelet@polytechnique.edu>

--- a/examples/backends/plot_dual_ot_pytorch.py
+++ b/examples/backends/plot_dual_ot_pytorch.py
@@ -4,6 +4,8 @@ r"""
 Dual OT solvers for entropic and quadratic regularized OT with Pytorch
 ======================================================================
 
+.. note::
+    Example added in release: 0.8.2.
 
 """
 

--- a/examples/backends/plot_optim_gromov_pytorch.py
+++ b/examples/backends/plot_optim_gromov_pytorch.py
@@ -3,6 +3,9 @@ r"""
 Optimizing the Gromov-Wasserstein distance with PyTorch
 =======================================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 In this example, we use the pytorch backend to optimize the Gromov-Wasserstein
 (GW) loss between two graphs expressed as empirical distribution.
 

--- a/examples/backends/plot_sliced_wass_grad_flow_pytorch.py
+++ b/examples/backends/plot_sliced_wass_grad_flow_pytorch.py
@@ -3,6 +3,9 @@ r"""
 Sliced Wasserstein barycenter and gradient flow with PyTorch
 ============================================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 In this example we use the pytorch backend to optimize the sliced Wasserstein
 loss between two empirical distributions [31].
 

--- a/examples/backends/plot_stoch_continuous_ot_pytorch.py
+++ b/examples/backends/plot_stoch_continuous_ot_pytorch.py
@@ -4,6 +4,8 @@ r"""
 Continuous OT plan estimation with Pytorch
 ======================================================================
 
+.. note::
+    Notebook added in release: 0.8.2.
 
 """
 

--- a/examples/backends/plot_unmix_optim_torch.py
+++ b/examples/backends/plot_unmix_optim_torch.py
@@ -4,6 +4,9 @@ r"""
 Wasserstein unmixing with PyTorch
 =================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 In this example we estimate mixing parameters from distributions that minimize
 the Wasserstein distance. In other words we suppose that a target
 distribution :math:`\mu^t` can be expressed as a weighted sum of source

--- a/examples/backends/plot_wass2_gan_torch.py
+++ b/examples/backends/plot_wass2_gan_torch.py
@@ -4,6 +4,9 @@ r"""
 Wasserstein 2 Minibatch GAN with PyTorch
 ========================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 In this example we train a Wasserstein GAN using Wasserstein 2 on minibatches
 as a distribution fitting term.
 

--- a/examples/barycenters/plot_debiased_barycenter.py
+++ b/examples/barycenters/plot_debiased_barycenter.py
@@ -4,6 +4,9 @@
 Debiased Sinkhorn barycenter demo
 =================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 This example illustrates the computation of the debiased Sinkhorn barycenter
 as proposed in [37]_.
 

--- a/examples/barycenters/plot_free_support_sinkhorn_barycenter.py
+++ b/examples/barycenters/plot_free_support_sinkhorn_barycenter.py
@@ -4,6 +4,9 @@
 2D free support Sinkhorn barycenters of distributions
 ========================================================
 
+.. note::
+    Example added in release: 0.9.1.
+
 Illustration of Sinkhorn barycenter calculation between empirical distributions understood as point clouds
 
 """

--- a/examples/barycenters/plot_gaussian_barycenter.py
+++ b/examples/barycenters/plot_gaussian_barycenter.py
@@ -5,7 +5,7 @@ Gaussian Bures-Wasserstein barycenters
 ========================================================
 
 .. note::
-    Notebook added in release: 0.9.2.
+    Example added in release: 0.9.2.
 
 Illustration of Gaussian Bures-Wasserstein barycenters.
 

--- a/examples/barycenters/plot_gaussian_barycenter.py
+++ b/examples/barycenters/plot_gaussian_barycenter.py
@@ -4,6 +4,9 @@
 Gaussian Bures-Wasserstein barycenters
 ========================================================
 
+.. note::
+    Notebook added in release: 0.9.2.
+
 Illustration of Gaussian Bures-Wasserstein barycenters.
 
 """

--- a/examples/barycenters/plot_generalized_free_support_barycenter.py
+++ b/examples/barycenters/plot_generalized_free_support_barycenter.py
@@ -4,6 +4,9 @@
 Generalized Wasserstein Barycenter Demo
 =======================================
 
+.. note::
+    Example added in release: 0.9.1.
+
 This example illustrates the computation of Generalized Wasserstein Barycenter
 as proposed in [42].
 

--- a/examples/domain-adaptation/plot_otda_classes.py
+++ b/examples/domain-adaptation/plot_otda_classes.py
@@ -4,6 +4,9 @@
 OT for domain adaptation
 ========================
 
+.. note::
+    Example added in release: 0.1.9.
+
 This example introduces a domain adaptation in a 2D setting and the 4 OTDA
 approaches currently supported in POT.
 

--- a/examples/domain-adaptation/plot_otda_color_images.py
+++ b/examples/domain-adaptation/plot_otda_color_images.py
@@ -4,6 +4,9 @@
 OT for image color adaptation
 =============================
 
+.. note::
+    Example added in release: 0.1.9.
+
 This example presents a way of transferring colors between two images
 with Optimal Transport as introduced in [6]
 

--- a/examples/domain-adaptation/plot_otda_d2.py
+++ b/examples/domain-adaptation/plot_otda_d2.py
@@ -4,6 +4,9 @@
 OT for domain adaptation on empirical distributions
 ===================================================
 
+.. note::
+    Example added in release: 0.1.9.
+
 This example introduces a domain adaptation in a 2D setting. It explicit
 the problem of domain adaptation and introduces some optimal transport
 approaches to solve it.

--- a/examples/domain-adaptation/plot_otda_jcpot.py
+++ b/examples/domain-adaptation/plot_otda_jcpot.py
@@ -4,6 +4,9 @@
 OT for multi-source target shift
 ================================
 
+.. note::
+    Example added in release: 0.7.0.
+
 This example introduces a target shift problem with two 2D source and 1 target domain.
 
 """

--- a/examples/domain-adaptation/plot_otda_laplacian.py
+++ b/examples/domain-adaptation/plot_otda_laplacian.py
@@ -4,6 +4,9 @@
 OT with Laplacian regularization for domain adaptation
 ======================================================
 
+.. note::
+    Example added in release: 0.7.0.
+
 This example introduces a domain adaptation in a 2D setting and OTDA
 approach with Laplacian regularization.
 

--- a/examples/domain-adaptation/plot_otda_linear_mapping.py
+++ b/examples/domain-adaptation/plot_otda_linear_mapping.py
@@ -6,7 +6,7 @@ Linear OT mapping estimation
 ============================
 
 .. note::
-    Notebook updated in release: 0.9.1.
+    Example updated in release: 0.9.1.
 
 """
 

--- a/examples/domain-adaptation/plot_otda_linear_mapping.py
+++ b/examples/domain-adaptation/plot_otda_linear_mapping.py
@@ -5,6 +5,8 @@
 Linear OT mapping estimation
 ============================
 
+.. note::
+    Notebook updated in release: 0.9.1.
 
 """
 

--- a/examples/domain-adaptation/plot_otda_mapping.py
+++ b/examples/domain-adaptation/plot_otda_mapping.py
@@ -4,6 +4,9 @@
 OT mapping estimation for domain adaptation
 ===========================================
 
+.. note::
+    Example added in release: 0.1.9.
+
 This example presents how to use MappingTransport to estimate at the same
 time both the coupling transport and approximate the transport map with either
 a linear or a kernelized mapping as introduced in [8].

--- a/examples/domain-adaptation/plot_otda_mapping_colors_images.py
+++ b/examples/domain-adaptation/plot_otda_mapping_colors_images.py
@@ -4,6 +4,9 @@
 OT for image color adaptation with mapping estimation
 =====================================================
 
+.. note::
+    Example added in release: 0.1.9.
+
 OT for domain adaptation with image color adaptation [6] with mapping
 estimation [8].
 

--- a/examples/domain-adaptation/plot_otda_semi_supervised.py
+++ b/examples/domain-adaptation/plot_otda_semi_supervised.py
@@ -4,6 +4,9 @@
 OTDA unsupervised vs semi-supervised setting
 ============================================
 
+.. note::
+    Example added in release: 0.1.9.
+
 This example introduces a semi supervised domain adaptation in a 2D setting.
 It explicit the problem of semi supervised domain adaptation and introduces
 some optimal transport approaches to solve it.

--- a/examples/gromov/plot_fgw_solvers.py
+++ b/examples/gromov/plot_fgw_solvers.py
@@ -4,6 +4,9 @@
 Comparison of Fused Gromov-Wasserstein solvers
 ==============================
 
+.. note::
+    Notebook added in release: 0.9.1.
+
 This example illustrates the computation of FGW for attributed graphs
 using 4 different solvers to estimate the distance based on Conditional
 Gradient [24], Sinkhorn projections [12, 51] and alternated Bregman

--- a/examples/gromov/plot_fgw_solvers.py
+++ b/examples/gromov/plot_fgw_solvers.py
@@ -5,7 +5,7 @@ Comparison of Fused Gromov-Wasserstein solvers
 ==============================
 
 .. note::
-    Notebook added in release: 0.9.1.
+    Example added in release: 0.9.1.
 
 This example illustrates the computation of FGW for attributed graphs
 using 4 different solvers to estimate the distance based on Conditional

--- a/examples/gromov/plot_gnn_TFGW.py
+++ b/examples/gromov/plot_gnn_TFGW.py
@@ -4,6 +4,9 @@
 Graph classification with Template Based Fused Gromov Wasserstein
 ==============================
 
+.. note::
+    Notebook added in release: 0.9.1.
+
 This example first illustrates how to train a graph classification gnn based on the Template Fused Gromov Wasserstein layer as proposed in [52] .
 
 [53] C. Vincent-Cuaz, R. Flamary, M. Corneli, T. Vayer, N. Courty (2022).Template based graph neural network with optimal transport distances. Advances in Neural Information Processing Systems, 35.

--- a/examples/gromov/plot_gnn_TFGW.py
+++ b/examples/gromov/plot_gnn_TFGW.py
@@ -5,7 +5,7 @@ Graph classification with Template Based Fused Gromov Wasserstein
 ==============================
 
 .. note::
-    Notebook added in release: 0.9.1.
+    Example added in release: 0.9.1.
 
 This example first illustrates how to train a graph classification gnn based on the Template Fused Gromov Wasserstein layer as proposed in [52] .
 

--- a/examples/gromov/plot_gromov.py
+++ b/examples/gromov/plot_gromov.py
@@ -3,6 +3,10 @@
 ==========================
 Gromov-Wasserstein example
 ==========================
+
+.. note::
+    Example added in release: 0.8.0.
+
 This example is designed to show how to use the Gromov-Wasserstein distance
 computation in POT.
 We first compare 3 solvers to estimate the distance based on

--- a/examples/gromov/plot_gromov_wasserstein_dictionary_learning.py
+++ b/examples/gromov/plot_gromov_wasserstein_dictionary_learning.py
@@ -5,6 +5,9 @@ r"""
 (Fused) Gromov-Wasserstein Linear Dictionary Learning
 =====================================================
 
+.. note::
+    Example added in release: 0.8.2.
+
 In this example, we illustrate how to learn a Gromov-Wasserstein dictionary on
 a dataset of structured data such as graphs, denoted
 :math:`\{ \mathbf{C_s} \}_{s \in [S]}` where every nodes have uniform weights.

--- a/examples/gromov/plot_partial_fgw.py
+++ b/examples/gromov/plot_partial_fgw.py
@@ -5,7 +5,7 @@ Plot partial FGW for subgraph matching
 =================================
 
 .. note::
-    Notebook currently under development and has not been released yet. To be added in release: 0.9.6
+    Example currently under development and has not been released yet. To be added in release: 0.9.6
 
 This example illustrates the computation of partial (Fused) Gromov-Wasserstein
 divergences for subgraph matching tasks, using the exact formulation $p(F)GW$ and

--- a/examples/gromov/plot_partial_fgw.py
+++ b/examples/gromov/plot_partial_fgw.py
@@ -4,6 +4,9 @@ r"""
 Plot partial FGW for subgraph matching
 =================================
 
+.. note::
+    Notebook currently under development and has not been released yet. To be added in release: 0.9.6
+
 This example illustrates the computation of partial (Fused) Gromov-Wasserstein
 divergences for subgraph matching tasks, using the exact formulation $p(F)GW$ and
 the entropically regularized one $p(F)GW_e$ [18, 29].

--- a/examples/gromov/plot_quantized_gromov_wasserstein.py
+++ b/examples/gromov/plot_quantized_gromov_wasserstein.py
@@ -5,7 +5,7 @@ Quantized Fused Gromov-Wasserstein examples
 ===============================================
 
 .. note::
-    Notebook added in release: 0.9.4.
+    Examples added in release: 0.9.4.
 
 These examples show how to use the quantized (Fused) Gromov-Wasserstein
 solvers (qFGW) [68]. POT provides a generic solver `quantized_fused_gromov_wasserstein_partitioned`

--- a/examples/gromov/plot_quantized_gromov_wasserstein.py
+++ b/examples/gromov/plot_quantized_gromov_wasserstein.py
@@ -4,6 +4,9 @@
 Quantized Fused Gromov-Wasserstein examples
 ===============================================
 
+.. note::
+    Notebook added in release: 0.9.4.
+
 These examples show how to use the quantized (Fused) Gromov-Wasserstein
 solvers (qFGW) [68]. POT provides a generic solver `quantized_fused_gromov_wasserstein_partitioned`
 that takes as inputs partitioned graphs potentially endowed with node features,

--- a/examples/gromov/plot_semirelaxed_gromov_wasserstein_barycenter.py
+++ b/examples/gromov/plot_semirelaxed_gromov_wasserstein_barycenter.py
@@ -5,6 +5,9 @@ r"""
 Semi-relaxed (Fused) Gromov-Wasserstein Barycenter as Dictionary Learning
 =====================================================
 
+.. note::
+    Example added in release: 0.9.5.
+
 In this example, we illustrate how to learn a semi-relaxed Gromov-Wasserstein
 (srGW) barycenter using a Block-Coordinate Descent algorithm, on a dataset of
 structured data such as graphs, denoted :math:`\{ \mathbf{C_s} \}_{s \in [S]}`

--- a/examples/others/plot_EWCA.py
+++ b/examples/others/plot_EWCA.py
@@ -4,6 +4,9 @@
 Entropic Wasserstein Component Analysis
 =======================================
 
+.. note::
+    Notebook added in release: 0.9.1.
+
 This example illustrates the use of EWCA as proposed in [52].
 
 

--- a/examples/others/plot_EWCA.py
+++ b/examples/others/plot_EWCA.py
@@ -5,7 +5,7 @@ Entropic Wasserstein Component Analysis
 =======================================
 
 .. note::
-    Notebook added in release: 0.9.1.
+    Example added in release: 0.9.1.
 
 This example illustrates the use of EWCA as proposed in [52].
 

--- a/examples/others/plot_SSNB.py
+++ b/examples/others/plot_SSNB.py
@@ -5,7 +5,7 @@ Smooth and Strongly Convex Nearest Brenier Potentials
 =====================================================
 
 .. note::
-    Notebook added in release: 0.9.2.
+    Example added in release: 0.9.2.
 
 This example is designed to show how to use SSNB [58] in POT.
 SSNB computes an l-strongly convex potential :math:`\varphi` with an L-Lipschitz gradient such that

--- a/examples/others/plot_SSNB.py
+++ b/examples/others/plot_SSNB.py
@@ -4,6 +4,9 @@ r"""
 Smooth and Strongly Convex Nearest Brenier Potentials
 =====================================================
 
+.. note::
+    Notebook added in release: 0.9.2.
+
 This example is designed to show how to use SSNB [58] in POT.
 SSNB computes an l-strongly convex potential :math:`\varphi` with an L-Lipschitz gradient such that
 :math:`\nabla \varphi \# \mu \approx \nu`. This regularity can be enforced only on the components of a partition

--- a/examples/others/plot_WDA.py
+++ b/examples/others/plot_WDA.py
@@ -4,6 +4,9 @@
 Wasserstein Discriminant Analysis
 =================================
 
+.. note::
+    Example added in release: 0.3.0.
+
 This example illustrate the use of WDA as proposed in [11].
 
 

--- a/examples/others/plot_WeakOT_VS_OT.py
+++ b/examples/others/plot_WeakOT_VS_OT.py
@@ -4,6 +4,9 @@
 Weak Optimal Transport VS exact Optimal Transport
 ====================================================
 
+.. note::
+    Example added in release: 0.8.2.
+
 Illustration of 2D optimal transport between distributions that are weighted
 sum of Diracs. The OT matrix is plotted with the samples.
 

--- a/examples/others/plot_dmmot.py
+++ b/examples/others/plot_dmmot.py
@@ -5,7 +5,7 @@ Computing d-dimensional Barycenters via d-MMOT
 ===============================================================================
 
 .. note::
-    Notebook added in release: 0.9.1.
+    Example added in release: 0.9.1.
 
 When the cost is discretized (Monge), the d-MMOT solver can more quickly
 compute and minimize the distance between many distributions without the need

--- a/examples/others/plot_dmmot.py
+++ b/examples/others/plot_dmmot.py
@@ -4,6 +4,9 @@ r"""
 Computing d-dimensional Barycenters via d-MMOT
 ===============================================================================
 
+.. note::
+    Notebook added in release: 0.9.1.
+
 When the cost is discretized (Monge), the d-MMOT solver can more quickly
 compute and minimize the distance between many distributions without the need
 for intermediate barycenter computations. This example compares the time to

--- a/examples/others/plot_factored_coupling.py
+++ b/examples/others/plot_factored_coupling.py
@@ -4,6 +4,9 @@
 Optimal transport with factored couplings
 ==========================================
 
+.. note::
+    Example added in release: 0.8.2.
+
 Illustration of the factored coupling OT between 2D empirical distributions
 
 """

--- a/examples/others/plot_logo.py
+++ b/examples/others/plot_logo.py
@@ -4,6 +4,9 @@ r"""
 Logo of the POT toolbox
 =======================
 
+.. note::
+    Example added in release: 0.8.2.
+
 In this example we plot the logo of the POT toolbox.
 
 This logo is that it is done 100% in Python and generated using

--- a/examples/others/plot_lowrank_GW.py
+++ b/examples/others/plot_lowrank_GW.py
@@ -4,6 +4,9 @@
 Low rank Gromov-Wasterstein between samples
 ========================================
 
+.. note::
+    Notebook added in release: 0.9.4.
+
 Comparison between entropic Gromov-Wasserstein and Low Rank Gromov Wasserstein [67]
 on two curves in 2D and 3D, both sampled with 200 points.
 

--- a/examples/others/plot_lowrank_GW.py
+++ b/examples/others/plot_lowrank_GW.py
@@ -5,7 +5,7 @@ Low rank Gromov-Wasterstein between samples
 ========================================
 
 .. note::
-    Notebook added in release: 0.9.4.
+    Example added in release: 0.9.4.
 
 Comparison between entropic Gromov-Wasserstein and Low Rank Gromov Wasserstein [67]
 on two curves in 2D and 3D, both sampled with 200 points.

--- a/examples/others/plot_lowrank_sinkhorn.py
+++ b/examples/others/plot_lowrank_sinkhorn.py
@@ -5,7 +5,7 @@ Low rank Sinkhorn
 ========================================
 
 .. note::
-    Notebook added in release: 0.9.2.
+    Example added in release: 0.9.2.
 
 This example illustrates the computation of Low Rank Sinkhorn [26].
 

--- a/examples/others/plot_lowrank_sinkhorn.py
+++ b/examples/others/plot_lowrank_sinkhorn.py
@@ -4,6 +4,9 @@
 Low rank Sinkhorn
 ========================================
 
+.. note::
+    Notebook added in release: 0.9.2.
+
 This example illustrates the computation of Low Rank Sinkhorn [26].
 
 [65] Scetbon, M., Cuturi, M., & Peyré, G. (2021).

--- a/examples/others/plot_outlier_detection_with_COOT_and_unbalanced_COOT.py
+++ b/examples/others/plot_outlier_detection_with_COOT_and_unbalanced_COOT.py
@@ -4,6 +4,9 @@ r"""
 Detecting outliers by learning sample marginal distribution with CO-Optimal Transport and by using unbalanced Co-Optimal Transport
 ======================================================================================================================================
 
+.. note::
+    Example added in release: 0.9.5.
+
 In this example, we consider two point clouds living in different Euclidean spaces, where the outliers
 are artificially injected into the target data. We illustrate two methods which allow to filter out
 these outliers.

--- a/examples/others/plot_screenkhorn_1D.py
+++ b/examples/others/plot_screenkhorn_1D.py
@@ -4,6 +4,9 @@
 Screened optimal transport (Screenkhorn)
 ========================================
 
+.. note::
+    Example added in release: 0.7.0.
+
 This example illustrates the computation of Screenkhorn [26].
 
 [26] Alaya M. Z., Bérar M., Gasso G., Rakotomamonjy A. (2019).

--- a/examples/plot_OT_1D_smooth.py
+++ b/examples/plot_OT_1D_smooth.py
@@ -5,7 +5,7 @@ Smooth and sparse OT example
 ================================
 
 .. note::
-    Notebook updated in release: 0.9.1.
+    Example updated in release: 0.9.1.
 
 This example illustrates the computation of
 Smooth and Sparse (KL an L2 reg.) OT and

--- a/examples/plot_OT_1D_smooth.py
+++ b/examples/plot_OT_1D_smooth.py
@@ -4,6 +4,9 @@
 Smooth and sparse OT example
 ================================
 
+.. note::
+    Notebook updated in release: 0.9.1.
+
 This example illustrates the computation of
 Smooth and Sparse (KL an L2 reg.) OT and
 sparsity-constrained OT, together with their visualizations.

--- a/examples/plot_quickstart_guide.py
+++ b/examples/plot_quickstart_guide.py
@@ -4,6 +4,8 @@
 Quickstart Guide
 =============================================
 
+.. note::
+    Notebook currently under development and has not been released yet. To be added in release: 0.9.6
 
 Quickstart guide to the POT toolbox.
 

--- a/examples/plot_quickstart_guide.py
+++ b/examples/plot_quickstart_guide.py
@@ -5,7 +5,7 @@ Quickstart Guide
 =============================================
 
 .. note::
-    Notebook currently under development and has not been released yet. To be added in release: 0.9.6
+    Example currently under development and has not been released yet. To be added in release: 0.9.6
 
 Quickstart guide to the POT toolbox.
 

--- a/examples/sliced-wasserstein/plot_variance.py
+++ b/examples/sliced-wasserstein/plot_variance.py
@@ -4,6 +4,9 @@
 Sliced Wasserstein Distance on 2D distributions
 ===============================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 This example illustrates the computation of the sliced Wasserstein Distance as
 proposed in [31].
 

--- a/examples/sliced-wasserstein/plot_variance_ssw.py
+++ b/examples/sliced-wasserstein/plot_variance_ssw.py
@@ -4,6 +4,9 @@
 Spherical Sliced Wasserstein on distributions in S^2
 ====================================================
 
+.. note::
+    Example added in release: 0.8.0.
+
 This example illustrates the computation of the spherical sliced Wasserstein discrepancy as
 proposed in [46].
 

--- a/examples/unbalanced-partial/plot_conv_sinkhorn_ti.py
+++ b/examples/unbalanced-partial/plot_conv_sinkhorn_ti.py
@@ -4,6 +4,9 @@
 Translation Invariant Sinkhorn for Unbalanced Optimal Transport
 ===============================================================
 
+.. note::
+    Example added in release: 0.9.5.
+
 This examples illustrates the better convergence of the translation
 invariance Sinkhorn algorithm proposed in [73] compared to the classical
 Sinkhorn algorithm.

--- a/examples/unbalanced-partial/plot_partial_wass_and_gromov.py
+++ b/examples/unbalanced-partial/plot_partial_wass_and_gromov.py
@@ -4,6 +4,9 @@
 Partial Wasserstein and Gromov-Wasserstein example
 ==================================================
 
+.. note::
+    Example added in release: 0.7.0.
+
 This example is designed to show how to use the Partial (Gromov-)Wasserstein
 distance computation in POT [29].
 

--- a/examples/unbalanced-partial/plot_regpath.py
+++ b/examples/unbalanced-partial/plot_regpath.py
@@ -3,6 +3,10 @@
 ================================================================
 Regularization path of l2-penalized unbalanced optimal transport
 ================================================================
+
+.. note::
+    Example added in release: 0.8.0.
+
 This example illustrate the regularization path for 2D unbalanced
 optimal transport. We present here both the fully relaxed case
 and the semi-relaxed case.

--- a/examples/unbalanced-partial/plot_unbalanced_OT.py
+++ b/examples/unbalanced-partial/plot_unbalanced_OT.py
@@ -3,6 +3,10 @@
 ==============================================================
 2D examples of exact and entropic unbalanced optimal transport
 ==============================================================
+
+.. note::
+    Example added in release: 0.8.2.
+
 This example is designed to show how to compute unbalanced and
 partial OT in POT.
 


### PR DESCRIPTION
## Types of changes
<!--- Added comments at the beginning of each examples in the example gallery mentioning the release version in which all examples were introduced. I used information in the section releases to find the appropriate release for each examples. Some where not mentioned anywhere in the code so I did not modify them. -->



## Motivation and context / Related issue
<!--- This change was initially required since some examples are in the latest release of the website while other are still on the development version (unreleased - version 0.9.6). -->
<!--- For example, in the first section of the examples gallery (section OT and regularized OT) one can see that the quickstart guide is in the 0.9.6 unreleased version (https://pythonot.github.io/master/auto_examples/index.html) but not in the released one (https://pythonot.github.io/auto_examples/index.html). -->




## How has this been tested (if it applies)
<!--- Nothing to test. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [ x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ x] All tests passed, and additional code has been **covered with new tests**.
- [x ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
