### PR TITLE
Finish PR 734 : typo in \text{max_nz} in ot.utils.projection_sparse_simplex

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -30,7 +30,7 @@
 - Clean references in documentation (PR #722)
 - Clean documentation for `ot.gromov.gromov_wasserstein` (PR #737)
 - Debug wheels building (PR #739)
-- Fix doc for projection sparse simplex (PR #734)
+- Fix doc for projection sparse simplex (PR #734, PR #746)
 
 ## 0.9.5
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -30,6 +30,7 @@
 - Clean references in documentation (PR #722)
 - Clean documentation for `ot.gromov.gromov_wasserstein` (PR #737)
 - Debug wheels building (PR #739)
+- Fix doc for projection sparse simplex (PR #734)
 
 ## 0.9.5
 

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -140,7 +140,7 @@ def projection_sparse_simplex(V, max_nz, z=1, axis=None, nx=None):
     r"""Projection of :math:`\mathbf{V}` onto the simplex with cardinality constraint (maximum number of non-zero elements) and then scaled by `z`.
 
     .. math::
-        P\left(\mathbf{V}, max_nz, z\right) = \mathop{\arg \min}_{\substack{\mathbf{y} >= 0 \\ \sum_i \mathbf{y}_i = z} \\ ||p||_0 \le \text{max_nz}} \quad \|\mathbf{y} - \mathbf{V}\|^2
+        P\left(\mathbf{V}, \text{max_nz}, z\right) = \mathop{\arg \min}_{\substack{\mathbf{y} >= 0 \\ \sum_i \mathbf{y}_i = z} \\ ||p||_0 \le \text{max_nz}} \quad \|\mathbf{y} - \mathbf{V}\|^2
 
     Parameters
     ----------

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -152,9 +152,9 @@ def projection_sparse_simplex(V, max_nz, z=1, axis=None, nx=None):
     z: float or array
         If array, len(z) must be compatible with :math:`\mathbf{V}`
     axis: None or int
-        - axis=None: project :math:`\mathbf{V}` by :math:`P(\mathbf{V}.\mathrm{ravel}(), max_nz, z)`
-        - axis=1: project each :math:`\mathbf{V}_i` by :math:`P(\mathbf{V}_i, max_nz, z_i)`
-        - axis=0: project each :math:`\mathbf{V}_{:, j}` by :math:`P(\mathbf{V}_{:, j}, max_nz, z_j)`
+        - axis=None: project :math:`\mathbf{V}` by :math:`P(\mathbf{V}.\mathrm{ravel}(), \text{max_nz}, z)`
+        - axis=1: project each :math:`\mathbf{V}_i` by :math:`P(\mathbf{V}_i, \text{max_nz}, z_i)`
+        - axis=0: project each :math:`\mathbf{V}_{:, j}` by :math:`P(\mathbf{V}_{:, j}, \text{max_nz}, z_j)`
 
     Returns
     -------

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -145,6 +145,10 @@ def projection_sparse_simplex(V, max_nz, z=1, axis=None, nx=None):
     Parameters
     ----------
     V: 1-dim or 2-dim ndarray
+    max_nz: int
+        Maximum number of non-zero elements in the projection.
+        If `max_nz` is larger than the number of elements in `V`, then
+        the projection is equivalent to `proj_simplex(V, z)`.
     z: float or array
         If array, len(z) must be compatible with :math:`\mathbf{V}`
     axis: None or int

--- a/ot/utils.py
+++ b/ot/utils.py
@@ -160,8 +160,9 @@ def projection_sparse_simplex(V, max_nz, z=1, axis=None, nx=None):
     -------
     projection: ndarray, shape :math:`\mathbf{V}`.shape
 
-    References:
-        Sparse projections onto the simplex
+    References
+    ----------
+    .. [1] Sparse projections onto the simplex
         Anastasios Kyrillidis, Stephen Becker, Volkan Cevher and, Christoph Koch
         ICML 2013
         https://arxiv.org/abs/1206.1529


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

This is a version of PR #734  with release file completed and doc updated 

## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
