### PR TITLE
Fix Wasserstein distance exponent in user guide formula

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -244,7 +244,7 @@ b is defined as
 
     .. math::
 
-        W_p(a,b)=(\min_{\gamma \in \mathbb{R}_+^{m\times n}} \sum_{i,j}\gamma_{i,j}\|x_i-y_j\|_p)^\frac{1}{p}
+        W_p(a,b)=\left(\min_{\gamma \in \mathbb{R}_+^{m\times n}} \sum_{i,j}\gamma_{i,j}\|x_i-y_j\|^p\right)^{\frac{1}{p}}
 
         s.t. \gamma 1 = a; \gamma^T 1= b; \gamma\geq 0
 


### PR DESCRIPTION
## Problem

The Wasserstein-*p* distance formula in the user guide has the exponent *p* placed as a **subscript** on the norm (denoting the *p*-norm) instead of a **superscript** (raising the ground cost to the *p*-th power):

```
# Current (incorrect)
\|x_i - y_j\|_p      ← reads as "the p-norm"

# Corrected
\|x_i - y_j\|^p      ← reads as "the norm, raised to power p"
```

These are mathematically distinct. The Wasserstein-*p* distance is defined with an arbitrary ground metric raised to the *p*-th power ([Villani 2009](https://doi.org/10.1007/978-3-540-71050-9), Definition 6.1):

$$W_p(\mu, \nu) = \left( \inf_{\gamma \in \Pi(\mu,\nu)} \int d(x,y)^p \, d\gamma(x,y) \right)^{1/p}$$

The subscript `_p` would instead change which norm is used as the ground metric, which is a different choice entirely.

## Fix

A single-line change in `docs/source/user_guide.rst`:

- `\|x_i-y_j\|_p` → `\|x_i-y_j\|^p`
- Also switched to `\left( ... \right)` for properly auto-scaled delimiters

## Consistency check

The surrounding text is already correct and consistent with the fixed formula:

> *"if you want to compute $W_2$ you need to compute the square root of `ot.emd2` when providing `M = ot.dist(xs, xt)`, that uses the **squared euclidean distance** by default"*

This makes sense only with $\|x_i - y_j\|^2$ (norm squared), not with $\|x_i - y_j\|_2$ (2-norm, which equals the standard Euclidean norm and would not require squaring).

Fixes #779