### PR TITLE
Docs: add documentation dependencies

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,6 +28,7 @@ This new release adds support for sparse cost matrices and a new lazy EMD solver
 - Fix code coverage (PR #791)
 - Fix test of the version of jax in `ot.backend` (PR #794)
 - Reverting the openmp fix on macOS (PR #789) for macOS (PR #797)
+- Align documentation build dependencies and doc extras (PR #801)
 
 
 ## 0.9.6.post1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,9 @@
-sphinx_gallery
-sphinx_rtd_theme
+sphinx
+sphinx-rtd-theme
+sphinx-gallery
+sphinxcontrib-jquery
 numpydoc
-memory_profiler
+myst-parser
 pillow
 networkx
-myst-parser
+memory_profiler

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,17 @@ setup(
         "dr": ["scikit-learn", "pymanopt", "autograd"],
         "gnn": ["torch", "torch_geometric"],
         "plot": ["matplotlib"],
+        "doc": [
+            "sphinx",
+            "sphinx-rtd-theme",
+            "sphinx-gallery",
+            "sphinxcontrib-jquery",
+            "numpydoc",
+            "myst-parser",
+            "pillow",
+            "networkx",
+            "memory_profiler",
+        ],
         "all": [
             "jax",
             "jaxlib",


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation
- [x] Maintenance / tooling (dependencies)

## Motivation and context / Related issue
This PR adds/updates the dependencies required to build the documentation (Sphinx + theme/extensions).
It makes it possible to set up the docs environment via:
`pip install -r docs/requirements.txt`.

Related issue: N/A.

## How has this been tested (if it applies)
Not run end-to-end locally (dependency list change only).
Intended verification:
- `pip install -r docs/requirements.txt`
- build the docs using the project’s documentation build.

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->