### PR TITLE
[MRG] Fix documentation for lowrank_sinkhorn and lowrank_gromov_wasserstein…

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -32,7 +32,8 @@ This new release adds support for sparse cost matrices and a new lazy EMD solver
   implemented in `ot.sgot` (PR #792)
 - Add batch FUGW loss to `ot.batch` and fix issues in some default parameters in the batch module (PR #775)
 - Build wheels on ubuntu ARM to avoid QEMU emulation (PR #818)
-- Add new methods to compute the linear transport map and the related 2-Wasserstein distance betweeen high-dimensional (HD) Gaussian distributions as described in [88], implemented in  `ot.gaussian.bures_wasserstein_mapping_hd` and `ot.gaussian.bures_wasserstein_distance_hd`, respectively. Two additional methods estimate the same quantities from the source and destination observed data and are implemented in `ot.gaussian.empirical_bures_wasserstein_mapping_hd` and `ot.gaussian.empirical_bures_wasserstein_distance_hd`, respectively (PR #814)   
+- Add new methods to compute the linear transport map and the related 2-Wasserstein distance betweeen high-dimensional (HD) Gaussian distributions as described in [88], implemented in  `ot.gaussian.bures_wasserstein_mapping_hd` and `ot.gaussian.bures_wasserstein_distance_hd`, respectively. Two additional methods estimate the same quantities from the source and destination observed data and are implemented in `ot.gaussian.empirical_bures_wasserstein_mapping_hd` and `ot.gaussian.empirical_bures_wasserstein_distance_hd`, respectively (PR #814)
+- Fix docstrings for `lowrank_gromov_wasserstein_samples` and `lowrank_sinkhorn` (PR #823)   
 
 
 #### Closed issues

--- a/ot/gromov/_lowrank.py
+++ b/ot/gromov/_lowrank.py
@@ -93,7 +93,7 @@ def lowrank_gromov_wasserstein_samples(
     where :
 
     - :math:`A` is the (`dim_a`, `dim_a`) square pairwise cost matrix of the source domain.
-    - :math:`B` is the (`dim_a`, `dim_a`) square pairwise cost matrix of the target domain.
+    - :math:`B` is the (`dim_b`, `dim_b`) square pairwise cost matrix of the target domain.
     - :math:`\mathcal{Q}_{A,B}` is quadratic objective function of the Gromov Wasserstein plan.
     - :math:`Q` and `R` are the low-rank matrix decomposition of the Gromov-Wasserstein plan.
     - :math:`g` is the weight vector for the low-rank decomposition of the Gromov-Wasserstein plan.
@@ -119,9 +119,9 @@ def lowrank_gromov_wasserstein_samples(
         Regularization term >=0
     rank : int, optional. Default is None. (>0)
         Nonnegative rank of the OT plan. If None, min(ns, nt) is considered.
-    alpha : int, optional. Default is 1e-10. (>0 and <1/r)
+    alpha : float, optional. Default is 1e-10. (>0 and <1/r)
         Lower bound for the weight vector g.
-    rescale_cost : bool, optional. Default is False
+    rescale_cost : bool, optional. Default is True
         Rescale the low rank factorization of the sqeuclidean cost matrix
     seed_init : int, optional. Default is 49. (>0)
         Random state for the 'random' initialization of low rank couplings
@@ -135,9 +135,9 @@ def lowrank_gromov_wasserstein_samples(
         Stop threshold on error (>0) for Low Rank GW
         The error is the sum of Kullback Divergences computed for each low rank
         coupling (Q, R and g) and scaled using gamma.
-    numItermax_dykstra : int, optional. Default is 2000.
+    numItermax_dykstra : int, optional. Default is 10000.
         Max number of iterations for the Dykstra algorithm
-    stopThr_dykstra : float, optional. Default is 1e-7.
+    stopThr_dykstra : float, optional. Default is 1e-3.
         Stop threshold on error (>0) in Dykstra
     cost_factorized_Xs: tuple, optional. Default is None
         Tuple with two pre-computed low rank decompositions (A1, A2) of the source cost

--- a/ot/lowrank.py
+++ b/ot/lowrank.py
@@ -374,7 +374,7 @@ def lowrank_sinkhorn(
         Nonnegative rank of the OT plan. If None, min(ns, nt) is considered.
     alpha : int, optional. Default is 1e-10. (>0 and <1/r)
         Lower bound for the weight vector g.
-    rescale_cost : bool, optional. Default is False
+    rescale_cost : bool, optional. Default is True
         Rescale the low rank factorization of the sqeuclidean cost matrix
     init : str, optional. Default is 'random'.
         Initialization strategy for the low rank couplings. 'random', 'deterministic' or 'kmeans'


### PR DESCRIPTION
The docstrings for `lowrank_gromov_wasserstein_samples` and `lowrank_sinkhorn` have inaccuracies. I modified the docstring to match the actual usage.

In `lowrank_gromov_wasserstein_samples`:
1. The matrix B should have dimensions (dim_b, dim_b) not (dim_a, dim_a)
2. `alpha` is a float, not an int
3. ` rescale_cost` is `True` by default, not `False`
4. `numItermax_dykstra` is 10000 by default, not 2000
5. `stopThr_dykstra` is 1e-3 by default, not 1e-7

In `lowrank_sinkhorn`: 
1. `rescale_cost` is `True` by default, not `False`

## PR checklist

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

