### PR TITLE
[MRG] Fix UnbalancedSinkhornTransport transform failing on nx.array_equal (closes #650)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
 
 - Fix mean centering in `ot.dr.fda` and `ot.dr.wda`: `np.mean(X)` returned a scalar instead of the per-feature mean, so `proj` did not center the data as documented. In `ot.dr.fda` the same pattern in the class means made the between-class scatter matrix independent of which features separate the classes, and FDA returned a non-discriminant direction (PR #840)
 - `ot.dr.fda` and `ot.dr.wda` no longer modify the input array `X` in place (PR #840)
+- Fix `UnbalancedSinkhornTransport` `transform` failing with `AttributeError: 'NoneType' object has no attribute 'array_equal'` when `fit` was called with missing parameters (PR #837, Issue #650)
 
 ## 0.9.7.post1
 

--- a/ot/da.py
+++ b/ot/da.py
@@ -2287,6 +2287,8 @@ class UnbalancedSinkhornTransport(BaseTransport):
             Returns self.
         """
 
+        self._get_backend(Xs, ys, Xt, yt)
+
         # check the necessary inputs parameters are here
         if check_params(Xs=Xs, Xt=Xt):
             super(UnbalancedSinkhornTransport, self).fit(Xs, ys, Xt, yt)

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -485,6 +485,34 @@ def test_unbalanced_sinkhorn_transport_class(nx):
 
 @pytest.skip_backend("jax")
 @pytest.skip_backend("tf")
+def test_unbalanced_sinkhorn_transport_nx_initialized(nx):
+    """non-regression test for issue #650
+
+    fit must always initialize the backend attribute nx, even when called
+    with missing parameters, so that transform fails on a clear error
+    instead of 'NoneType' object has no attribute 'array_equal'
+    """
+
+    ns = 50
+    Xs, ys = make_data_classif("3gauss", ns)
+    Xt, yt = make_data_classif("3gauss2", ns)
+
+    Xs, ys, Xt, yt = nx.from_numpy(Xs, ys, Xt, yt)
+
+    # incomplete fit (Xt missing) still initializes the backend
+    otda = ot.da.UnbalancedSinkhornTransport()
+    otda.fit(Xs=Xs)
+    assert otda.nx is not None
+
+    # complete fit followed by a separate transform call
+    otda = ot.da.UnbalancedSinkhornTransport()
+    otda.fit(Xs=Xs, Xt=Xt)
+    transp_Xs = otda.transform(Xs)
+    assert_equal(transp_Xs.shape, Xs.shape)
+
+
+@pytest.skip_backend("jax")
+@pytest.skip_backend("tf")
 def test_emd_transport_class(nx):
     """test_sinkhorn_transport"""
 


### PR DESCRIPTION
fit() now initializes the backend attribute nx before the check_params
gate, matching the behavior of BaseTransport.fit. Previously, a fit call
with missing parameters left self.nx as None, causing any subsequent
transform() call to crash with:
AttributeError: 'NoneType' object has no attribute 'array_equal'

Adds a non-regression test covering both incomplete fit and a separate
transform call.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->



## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->



## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->



## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->
