### PR TITLE
[MRG] Load triton before TensorFlow in ot.backend (closes #816)

### DIFF
--- a/.github/requirements_doctests.txt
+++ b/.github/requirements_doctests.txt
@@ -5,7 +5,7 @@ autograd
 pymanopt
 cvxopt
 scikit-learn
-torch<2.12
+torch
 jax
 jaxlib
 tensorflow; python_version < '3.14'

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 0.9.8dev
+
+#### Closed issues
+
+- Load triton before TensorFlow in `ot.backend` so that building a torch optimizer no longer segfaults the interpreter, and remove the `torch<2.12` pin from the doctest and documentation requirements (PR #839, Issue #816)
+
 ## 0.9.7.post1
 
 This release is identical to 0.9.7 but will allow the upload of a source distribution to PyPI and release on conda-forge (that requires a source distribution).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ autograd
 pymanopt
 cvxopt
 scikit-learn
-torch<2.12
+torch
 pytest
 torch_geometric
 cvxpy

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -86,6 +86,7 @@ Performance
 #
 # License: MIT License
 
+import importlib.util
 import os
 import time
 import warnings
@@ -108,6 +109,21 @@ if not os.environ.get(DISABLE_TORCH_KEY, False):
         import torch
 
         torch_type = torch.Tensor
+
+        # Load triton before TensorFlow is imported below. Both triton and
+        # TensorFlow ship a statically linked LLVM, and loading triton's
+        # libtriton.so into a process that has already imported TensorFlow
+        # segfaults inside dlopen. torch only imports triton lazily, on the
+        # first use of a feature that needs it (constructing an optimizer is
+        # enough), which would otherwise happen after TensorFlow is loaded.
+        # See https://github.com/PythonOT/POT/issues/816
+        if not os.environ.get(DISABLE_TF_KEY, False) and (
+            importlib.util.find_spec("tensorflow") is not None
+        ):
+            try:
+                import triton  # noqa: F401
+            except ImportError:
+                pass
     except ImportError:
         torch = False
         torch_type = float

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -6,6 +6,10 @@
 #
 # License: MIT License
 
+import importlib.util
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal_nulp
@@ -914,3 +918,27 @@ def test_get_backend_none():
     assert str(nx) == "numpy"
     with pytest.raises(ValueError):
         get_backend(None, None)
+
+
+@pytest.mark.skipif(
+    not torch or not tf or importlib.util.find_spec("triton") is None,
+    reason="Requires torch, tensorflow and triton installed together",
+)
+def test_torch_optimizer_after_tensorflow_import():
+    """Non-regression test for issue #816.
+
+    Building a torch optimizer makes torch import triton lazily. If TensorFlow
+    was imported first, loading libtriton.so segfaults the interpreter, so this
+    has to run in a subprocess.
+    """
+    code = (
+        "import ot.backend\n"
+        "import torch\n"
+        "x = torch.zeros(3, requires_grad=True)\n"
+        "torch.optim.SGD([x], lr=0.1)\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True)
+    assert result.returncode == 0, (
+        f"interpreter died with returncode {result.returncode}: "
+        f"{result.stderr.decode(errors='replace')[-2000:]}"
+    )


### PR DESCRIPTION
## Types of changes

Bug fix (non-breaking change which fixes an issue).

## Motivation and context / Related issue

Closes #816.

triton and TensorFlow both ship a statically linked LLVM; loading `libtriton.so` after TensorFlow segfaults inside `dlopen`. torch imports triton lazily, on the first `torch.optim` constructor — which in a POT process is after TensorFlow is resident. TensorFlow is the trigger, not JAX.

`ot/backend.py` imports torch ~60 lines before TensorFlow, so the probe goes there, guarded on TensorFlow being importable. Not in `conftest.py`: the doc build never loads it. Both `torch<2.12` pins removed.

Upstream reproducer: `import tensorflow; import triton`.

## How has this been tested (if it applies)

On Linux with torch 2.13.0+cu130, triton 3.7.1, TensorFlow 2.21.0, `test/conftest.py` untouched:

| | with fix | without |
|---|---|---|
| `test_free_support_barycenter_generic_costs_auto_ground_bary` | passes | rc=139 SIGSEGV |
| new test | passes | fails, `returncode=-11` |
| `test_ot.py` + `test_backend.py` | 91 passed, 8 skipped | — |

The new test runs in a subprocess so the segfault is reported as a failure rather than killing the runner.

## PR checklist

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.