### PR TITLE
[MRG] Fix mean centering in ot.dr.fda and ot.dr.wda

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 0.9.8dev
+
+#### Closed issues
+
+- Fix mean centering in `ot.dr.fda` and `ot.dr.wda`: `np.mean(X)` returned a scalar instead of the per-feature mean, so `proj` did not center the data as documented. In `ot.dr.fda` the same pattern in the class means made the between-class scatter matrix independent of which features separate the classes, and FDA returned a non-discriminant direction (PR #838)
+- `ot.dr.fda` and `ot.dr.wda` no longer modify the input array `X` in place (PR #838)
+
 ## 0.9.7.post1
 
 This release is identical to 0.9.7 but will allow the upload of a source distribution to PyPI and release on conda-forge (that requires a source distribution).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,8 +4,8 @@
 
 #### Closed issues
 
-- Fix mean centering in `ot.dr.fda` and `ot.dr.wda`: `np.mean(X)` returned a scalar instead of the per-feature mean, so `proj` did not center the data as documented. In `ot.dr.fda` the same pattern in the class means made the between-class scatter matrix independent of which features separate the classes, and FDA returned a non-discriminant direction (PR #838)
-- `ot.dr.fda` and `ot.dr.wda` no longer modify the input array `X` in place (PR #838)
+- Fix mean centering in `ot.dr.fda` and `ot.dr.wda`: `np.mean(X)` returned a scalar instead of the per-feature mean, so `proj` did not center the data as documented. In `ot.dr.fda` the same pattern in the class means made the between-class scatter matrix independent of which features separate the classes, and FDA returned a non-discriminant direction (PR #840)
+- `ot.dr.fda` and `ot.dr.wda` no longer modify the input array `X` in place (PR #840)
 
 ## 0.9.7.post1
 

--- a/ot/dr.py
+++ b/ot/dr.py
@@ -101,8 +101,8 @@ def fda(X, y, p=2, reg=1e-16):
         projection function including mean centering
     """
 
-    mx = np.mean(X)
-    X -= mx.reshape((1, -1))
+    mx = np.mean(X, axis=0)
+    X = X - mx.reshape((1, -1))
 
     # data split between classes
     d = X.shape[1]
@@ -119,7 +119,7 @@ def fda(X, y, p=2, reg=1e-16):
     mxc = np.zeros((d, nc))
 
     for i in range(nc):
-        mxc[:, i] = np.mean(xc[i])
+        mxc[:, i] = np.mean(xc[i], axis=0)
 
     mx0 = np.mean(mxc, 1)
     Cb = 0
@@ -218,8 +218,8 @@ def wda(
     else:
         raise ValueError("Unknown Sinkhorn method '%s'." % sinkhorn_method)
 
-    mx = np.mean(X)
-    X -= mx.reshape((1, -1))
+    mx = np.mean(X, axis=0)
+    X = X - mx.reshape((1, -1))
 
     # data split between classes
     d = X.shape[1]

--- a/test/test_dr.py
+++ b/test/test_dr.py
@@ -40,6 +40,51 @@ def test_fda():
 
 
 @pytest.mark.skipif(nogo, reason="Missing modules (autograd or pymanopt)")
+def test_fda_recovers_discriminant_direction():
+    # classes are separated along the first feature only, all others are noise,
+    # so FDA must return a direction aligned with e_0
+    rng = np.random.RandomState(1)
+    n_features = 5
+    xs = np.concatenate(
+        [
+            rng.randn(60, n_features) * 0.3 + shift * np.eye(1, n_features, 0)
+            for shift in [-6.0, 0.0, 6.0]
+        ]
+    )
+    ys = np.repeat([0, 1, 2], 60)
+
+    Pfda, _ = ot.dr.fda(xs, ys, p=1)
+
+    direction = Pfda[:, 0] / np.linalg.norm(Pfda[:, 0])
+    np.testing.assert_array_less(0.95, np.abs(direction[0]))
+
+
+@pytest.mark.skipif(nogo, reason="Missing modules (autograd or pymanopt)")
+def test_fda_projection_is_centered():
+    rng = np.random.RandomState(0)
+    xs, ys = ot.datasets.make_data_classif("gaussrot", 90, random_state=rng)
+    xs = xs + 10.0  # off-centered data makes an absent centering visible
+
+    _, projfda = ot.dr.fda(xs, ys, p=1)
+
+    np.testing.assert_allclose(projfda(xs).mean(axis=0), 0.0, atol=1e-10)
+
+
+@pytest.mark.skipif(nogo, reason="Missing modules (autograd or pymanopt)")
+def test_fda_wda_do_not_modify_input():
+    rng = np.random.RandomState(0)
+    xs, ys = ot.datasets.make_data_classif("gaussrot", 90, random_state=rng)
+    xs = xs + 10.0
+
+    xs_copy = xs.copy()
+    ot.dr.fda(xs, ys, p=1)
+    np.testing.assert_allclose(xs, xs_copy)
+
+    ot.dr.wda(xs, ys, p=1, reg=1.0, k=5, maxiter=5)
+    np.testing.assert_allclose(xs, xs_copy)
+
+
+@pytest.mark.skipif(nogo, reason="Missing modules (autograd or pymanopt)")
 def test_wda():
     n_samples = 100  # nb samples in source and target datasets
     rng = np.random.RandomState(0)


### PR DESCRIPTION
## Types of changes

Bug fix (non-breaking change which fixes an issue).

## Motivation and context / Related issue

`np.mean(X)` without `axis` returns a scalar; `.reshape((1, -1))` on it gives `(1, 1)` and broadcasts silently.

1. `X -= mx.reshape((1, -1))` subtracts one scalar from every feature, so `proj` does not center as documented. `wda`'s learned `P` is unaffected — the cost sees only pairwise differences.
2. In `fda`, `mxc[:, i] = np.mean(xc[i])` makes every class mean a constant vector, so `Cb = [Σ_i (m_i − m̄)²]·11ᵀ`: rank one, no information about which features separate the classes.
3. Both mutated the caller's `X` in place.

On 3 classes separated along feature 0 with 4 noise features, `fda` gave `[0.68, 0.99, 0.63, 1.00, 0.97]`; now `[1.00, 0.022, 0.043, 0.034, 0.124]`, matching sklearn's LDA to `|cos| = 1.0`.

`ot.dr.fda` is the baseline in `examples/others/plot_WDA.py`.

## How has this been tested (if it applies)

3 new tests, each verified failing on master. `test_dr.py` 9 passed, pre-commit clean.

## PR checklist

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.