### PR TITLE
[MRG] Create the CUDA context only when a GPU tensor is actually used

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@
 #### Closed issues
 
 - Preserve input dtype and device for expected sliced plans, avoid materializing dense distance matrices for sparse plans, and fix weighted sparse-distance ordering (PR #846, Issue #845)
-- Build the CUDA generator and the CUDA entries of `TorchBackend.__type_list__` lazily, so that using POT with CPU-only torch tensors no longer initialises a CUDA context and claims device memory (Issue #612)
+- Build the CUDA generator and the CUDA entries of `TorchBackend.__type_list__` lazily, so that using POT with CPU-only torch tensors no longer initialises a CUDA context and claims device memory (PR #847, Issue #612)
 - Fix the sign issue in updates of the previous transport plan in `ot.batch.proximal_bregman_log_plan_batch` (Issue #842)
 - Load triton before TensorFlow in `ot.backend` so that building a torch optimizer no longer segfaults the interpreter, and remove the `torch<2.12` pin from the doctest and documentation requirements (PR #839, Issue #816)
 - Fix mean centering in `ot.dr.fda` and `ot.dr.wda`: `np.mean(X)` returned a scalar instead of the per-feature mean, so `proj` did not center the data as documented. In `ot.dr.fda` the same pattern in the class means made the between-class scatter matrix independent of which features separate the classes, and FDA returned a non-discriminant direction (PR #840)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
 #### Closed issues
 
 - Preserve input dtype and device for expected sliced plans, avoid materializing dense distance matrices for sparse plans, and fix weighted sparse-distance ordering (PR #846, Issue #845)
+- Build the CUDA generator and the CUDA entries of `TorchBackend.__type_list__` lazily, so that using POT with CPU-only torch tensors no longer initialises a CUDA context and claims device memory (Issue #612)
 - Fix the sign issue in updates of the previous transport plan in `ot.batch.proximal_bregman_log_plan_batch` (Issue #842)
 - Load triton before TensorFlow in `ot.backend` so that building a torch optimizer no longer segfaults the interpreter, and remove the `torch<2.12` pin from the doctest and documentation requirements (PR #839, Issue #816)
 - Fix mean centering in `ot.dr.fda` and `ot.dr.wda`: `np.mean(X)` returned a scalar instead of the per-feature mean, so `proj` did not center the data as documented. In `ot.dr.fda` the same pattern in the class means made the between-class scatter matrix independent of which features separate the classes, and FDA returned a non-discriminant direction (PR #840)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -2066,7 +2066,7 @@ class TorchBackend(Backend):
 
     __name__ = "torch"
     __type__ = torch_type
-    __type_list__ = None
+    # __type_list__ is a property below: its CUDA entries are built lazily.
 
     rng_ = None
 
@@ -2074,22 +2074,17 @@ class TorchBackend(Backend):
         self.rng_ = torch.Generator("cpu")
         self.rng_.seed()
 
-        self.__type_list__ = [
+        # The CUDA generator and the CUDA entries of the type list are built the
+        # first time something asks for them. Building either here initialises a
+        # CUDA context, which claims device memory and wakes the GPU even when
+        # the computation stays entirely on the CPU.
+        self._type_list_cpu = [
             torch.tensor(1, dtype=torch.float32),
             torch.tensor(1, dtype=torch.float64),
         ]
-
-        if torch.cuda.is_available():
-            self.rng_cuda_ = torch.Generator("cuda")
-            self.rng_cuda_.seed()
-            self.__type_list__.append(
-                torch.tensor(1, dtype=torch.float32, device="cuda")
-            )
-            self.__type_list__.append(
-                torch.tensor(1, dtype=torch.float64, device="cuda")
-            )
-        else:
-            self.rng_cuda_ = torch.Generator("cpu")
+        self._type_list_cuda = None
+        self._rng_cuda = None
+        self._cuda_seed = None
 
         from torch.autograd import Function
         from torch.autograd.function import once_differentiable
@@ -2132,6 +2127,35 @@ class TorchBackend(Backend):
 
         self.ValFunction = ValFunction
         self.MatrixSqrtFunction = MatrixSqrtFunction
+
+    @property
+    def __type_list__(self):
+        if self._type_list_cuda is None:
+            if torch.cuda.is_available():
+                self._type_list_cuda = [
+                    torch.tensor(1, dtype=torch.float32, device="cuda"),
+                    torch.tensor(1, dtype=torch.float64, device="cuda"),
+                ]
+            else:
+                self._type_list_cuda = []
+        return self._type_list_cpu + self._type_list_cuda
+
+    @property
+    def rng_cuda_(self):
+        if self._rng_cuda is None:
+            if torch.cuda.is_available():
+                self._rng_cuda = torch.Generator("cuda")
+                if self._cuda_seed is None:
+                    self._rng_cuda.seed()
+                else:
+                    self._rng_cuda.manual_seed(self._cuda_seed)
+            else:
+                self._rng_cuda = torch.Generator("cpu")
+        return self._rng_cuda
+
+    @rng_cuda_.setter
+    def rng_cuda_(self, generator):
+        self._rng_cuda = generator
 
     def _to_numpy(self, a):
         if isinstance(a, float) or isinstance(a, int) or isinstance(a, np.ndarray):
@@ -2412,7 +2436,11 @@ class TorchBackend(Backend):
             pass
         elif isinstance(seed, int):
             self.rng_.manual_seed(seed)
-            self.rng_cuda_.manual_seed(seed)
+            # Remember the seed rather than forcing the CUDA generator into
+            # existence; it is applied when that generator is first needed.
+            self._cuda_seed = seed
+            if self._rng_cuda is not None:
+                self._rng_cuda.manual_seed(seed)
         elif isinstance(seed, torch.Generator):
             if self.device_type(seed) == "GPU":
                 self.rng_cuda_ = seed

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -942,3 +942,31 @@ def test_torch_optimizer_after_tensorflow_import():
         f"interpreter died with returncode {result.returncode}: "
         f"{result.stderr.decode(errors='replace')[-2000:]}"
     )
+
+
+@pytest.mark.skipif(
+    not torch or not torch.cuda.is_available(),
+    reason="Requires torch with CUDA available",
+)
+def test_no_cuda_context_for_cpu_only_work():
+    """Non-regression test for issue #612.
+
+    Building the torch backend used to create a CUDA generator and the CUDA
+    entries of the type list straight away. That initialises a CUDA context, so
+    device memory is claimed and the GPU wakes up for a computation that stays
+    entirely on the CPU. The check needs an interpreter that has not touched
+    CUDA yet, so it runs in a subprocess.
+    """
+    code = (
+        "import torch\n"
+        "import ot\n"
+        "x = torch.randn(64, 2)\n"
+        "ot.dist(x, x)\n"
+        "assert not torch.cuda.is_initialized(), 'a CUDA context was created'\n"
+        "assert torch.cuda.memory_allocated() == 0, 'device memory was claimed'\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True)
+    assert result.returncode == 0, (
+        f"interpreter exited with returncode {result.returncode}: "
+        f"{result.stderr.decode(errors='replace')[-2000:]}"
+    )


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context / Related issue

Closes #612.

`TorchBackend.__init__` builds a CUDA generator and the CUDA entries of
`__type_list__` as soon as the backend is instantiated. Both initialise a CUDA
context, so the first POT call on CPU-only torch tensors claims device memory
and wakes the GPU — which is what the issue reports as rising power draw with
CPU tensors.

On an RTX 4060 with POT 0.9.7.post1:

```python
import torch, ot
torch.cuda.is_initialized()        # False
x = torch.randn(2000, 2)           # CPU
ot.dist(x, x)
torch.cuda.is_initialized()        # True
torch.cuda.memory_allocated()      # 1024
```

The backend is instantiated lazily, which is why this happens at the first call
rather than at `import ot`.

## Description

The CUDA generator and the CUDA half of the type list are now built on first
access instead of in `__init__`:

* `__type_list__` becomes a property. The CPU entries are built eagerly as
  before; the CUDA entries are appended the first time the list is read, so
  anything that enumerates dtypes and devices (the tests, `_bench`) sees exactly
  what it saw before.
* `rng_cuda_` becomes a property with a setter, so `seed(torch.Generator)` keeps
  working.
* `seed(int)` records the seed instead of forcing the CUDA generator into
  existence, and applies it when that generator is first created. A seed set
  before any GPU work therefore still governs it.

After the change the same script leaves CUDA untouched, and a later GPU call
initialises it as usual.

## Reproducibility

Seeded GPU sampling is unchanged. With the same seed, before and after:

```python
nx.seed(42); nx.rand(3, type_as=torch.zeros(1, device="cuda"))
# [0.61296, 0.010059, 0.398414]   identical on both
```

`len(nx.__type_list__)` is still 4 when CUDA is available.

## How has this been tested

New `test_no_cuda_context_for_cpu_only_work` in `test/test_backend.py`, a
non-regression test for #612. It asserts that CPU-only work leaves
`torch.cuda.is_initialized()` false and `memory_allocated()` at zero. The check
needs an interpreter that has not touched CUDA yet, so it runs in a subprocess,
following `test_torch_optimizer_after_tensorflow_import` in the same file. It
fails on `master` and passes here, and is skipped without CUDA.

`test/test_backend.py` is 23 passed, 1 skipped (22 passed, 1 skipped before this
PR — the new test is the difference). `pre-commit run` on the changed files is
clean.

Ran on Windows with torch 2.9.1+cu126 and an RTX 4060 Laptop GPU.
