### PR TITLE
[MRG] Support RandomState instances in NumpyBackend.seed

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@
 
 #### Closed issues
 
+- Allow `NumpyBackend.seed` to adopt an existing `np.random.RandomState` instance and remove NumPy-specific random sampling paths in sliced utilities (Issue #848)
 - Preserve input dtype and device for expected sliced plans, avoid materializing dense distance matrices for sparse plans, and fix weighted sparse-distance ordering (PR #846, Issue #845)
 - Fix the sign issue in updates of the previous transport plan in `ot.batch.proximal_bregman_log_plan_batch` (Issue #842)
 - Load triton before TensorFlow in `ot.backend` so that building a torch optimizer no longer segfaults the interpreter, and remove the `torch<2.12` pin from the doctest and documentation requirements (PR #839, Issue #816)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,7 +8,7 @@
 
 #### Closed issues
 
-- Allow `NumpyBackend.seed` to adopt an existing `np.random.RandomState` instance and remove NumPy-specific random sampling paths in sliced utilities (Issue #848)
+- Allow `NumpyBackend.seed` to adopt an existing `np.random.RandomState` instance and remove NumPy-specific random sampling paths in sliced utilities (PR #849, Issue #848)
 - Preserve input dtype and device for expected sliced plans, avoid materializing dense distance matrices for sparse plans, and fix weighted sparse-distance ordering (PR #846, Issue #845)
 - Fix the sign issue in updates of the previous transport plan in `ot.batch.proximal_bregman_log_plan_batch` (Issue #842)
 - Load triton before TensorFlow in `ot.backend` so that building a torch optimizer no longer segfaults the interpreter, and remove the `torch<2.12` pin from the doctest and documentation requirements (PR #839, Issue #816)

--- a/ot/backend.py
+++ b/ot/backend.py
@@ -1430,7 +1430,9 @@ class NumpyBackend(Backend):
         return np.reshape(a, shape)
 
     def seed(self, seed=None):
-        if seed is not None:
+        if isinstance(seed, np.random.RandomState):
+            self.rng_ = seed
+        elif seed is not None:
             self.rng_.seed(seed)
 
     def rand(self, *size, type_as=None):

--- a/ot/sliced/_utils.py
+++ b/ot/sliced/_utils.py
@@ -54,12 +54,9 @@ def get_random_projections(d, n_projections, seed=None, backend=None, type_as=No
     else:
         nx = backend
 
-    if isinstance(seed, np.random.RandomState) and str(nx) == "numpy":
-        projections = seed.randn(d, n_projections)
-    else:
-        if seed is not None:
-            nx.seed(seed)
-        projections = nx.randn(d, n_projections, type_as=type_as)
+    if seed is not None:
+        nx.seed(seed)
+    projections = nx.randn(d, n_projections, type_as=type_as)
 
     projections = projections / nx.sqrt(nx.sum(projections**2, 0, keepdims=True))
     return projections
@@ -99,12 +96,9 @@ def get_projections_sphere(d, n_projections, seed=None, backend=None, type_as=No
     else:
         nx = backend
 
-    if isinstance(seed, np.random.RandomState) and str(nx) == "numpy":
-        Z = seed.randn(n_projections, d, 2)
-    else:
-        if seed is not None:
-            nx.seed(seed)
-        Z = nx.randn(n_projections, d, 2, type_as=type_as)
+    if seed is not None:
+        nx.seed(seed)
+    Z = nx.randn(n_projections, d, 2, type_as=type_as)
 
     projections, _ = nx.qr(Z)
     return projections
@@ -159,12 +153,9 @@ def get_random_rotations(d, n_rotations, seed=None, backend=None, type_as=None):
     else:
         nx = backend
 
-    if isinstance(seed, np.random.RandomState) and str(nx) == "numpy":
-        Z = seed.randn(n_rotations, d, d)
-    else:
-        if seed is not None:
-            nx.seed(seed)
-        Z = nx.randn(n_rotations, d, d, type_as=type_as)
+    if seed is not None:
+        nx.seed(seed)
+    Z = nx.randn(n_rotations, d, d, type_as=type_as)
 
     Q, R = nx.qr(Z)
     diagonal = nx.sum(R * nx.eye(d, type_as=R)[None, :, :], axis=-1)

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -840,6 +840,17 @@ def test_random_backends(nx):
         res = nx.randperm(size=[5, 12])
 
 
+def test_numpy_backend_seed_random_state():
+    nx = ot.backend.NumpyBackend()
+    rng = np.random.RandomState(42)
+    expected_rng = np.random.RandomState(42)
+
+    nx.seed(rng)
+
+    assert nx.rng_ is rng
+    np.testing.assert_array_equal(nx.randn(5, 2), expected_rng.randn(5, 2))
+
+
 def test_gradients_backends():
     rnd = np.random.RandomState(0)
     v = rnd.randn(10)


### PR DESCRIPTION
## Types of changes

- [x] Bug fix
- [x] Tests
- [x] Code cleanup
- [ ] New feature
- [ ] Documentation update

## Motivation and context / Related issue

Closes #848.

`NumpyBackend.seed()` currently forwards every non-`None` value to
`RandomState.seed()`. Passing an existing `np.random.RandomState`
instance therefore raises:

```text
TypeError: Cannot cast scalar from dtype('O') to dtype('int64')
according to the rule 'safe'
```

This forces callers that support both integer seeds and existing
`RandomState` instances to special-case the NumPy backend.

This change makes `NumpyBackend` adopt an externally supplied
`RandomState`, matching the generator-handling behavior of the other
backends. The NumPy-specific `RandomState` branches in the sliced
sampling utilities are removed accordingly.

The fourth occurrence mentioned in #848, in `get_projections_spiral`,
belongs to the still-open PR #838 and is not present on the current
`master` branch. That occurrence can use the unified backend path once
this fix is incorporated into #838.

## How has this been tested (if it applies)

The issue was reproduced on the unmodified `master` branch using:

```python
import numpy as np
from ot.backend import NumpyBackend

nx = NumpyBackend()
rng = np.random.RandomState(42)
nx.seed(rng)
```

The original code raises the reported `TypeError`.

The same code succeeds after the fix. Additional verification confirms
that:

- `NumpyBackend.rng_` is the exact supplied `RandomState` instance;
- subsequent `nx.randn(...)` calls use that generator's sequence;
- integer seeding retains its previous deterministic behavior.

A regression test was added in `test/test_backend.py`.

The following checks pass:

```text
pre-commit run --all-files
pytest --durations=20 -v test/ --doctest-modules
```

The full test run completed with 1456 passed, 96 skipped, and 4 xfailed.
The skipped tests require optional dependencies that are not installed in
the local test environment.

## PR checklist

- [x] I have read the [**CONTRIBUTING**](https://pythonot.github.io/contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (no public API documentation changes are required).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.md**](RELEASES.md) file.
